### PR TITLE
Remove auto-unhide when parasite leaps

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Parasite/SharedXenoParasiteSystem.cs
@@ -280,18 +280,9 @@ public abstract partial class SharedXenoParasiteSystem : EntitySystem
         _tagSystem.AddTag(ent, ParasiteIsPreparingLeapProtoID);
         _rmcSprite.UpdateDrawDepth(ent);
 
-        if (TryComp<XenoHideComponent>(ent, out var xenoHideComp) &&
-            xenoHideComp.Hiding)
+        foreach (var action in _rmcActions.GetActionsWithEvent<XenoHideActionEvent>(ent))
         {
-            var ev = new XenoHideActionEvent();
-            ev.Performer = ent;
-            ev.Toggle = false;
-            RaiseLocalEvent(ent, ev);
-
-            foreach (var action in _rmcActions.GetActionsWithEvent<XenoHideActionEvent>(ent))
-            {
-                _action.SetEnabled(action.AsNullable(), false);
-            }
+            _action.SetEnabled(action.AsNullable(), false);
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
 Parasites no longer automatically unhide when leaping.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, parasites are forced out of hide when they initiate a leap, which makes the hide ability less useful. This change allows parasites to stay hidden during leap wind-up doafter, making ambush play more viable.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed the auto-unhide logic in OnParasiteLeap in SharedXenoParasiteSystem.cs

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in RMC14 progress reports with credit. -->
 N/A - small behavior change with no visual changes.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Make sure to read the guidelines.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Parasites no longer automatically unhide when leaping.
