### PR TITLE
Queen scream changes and new spit ability

### DIFF
--- a/Content.Client/_RMC14/Xenonids/Screech/ScreechBlindOverlay.cs
+++ b/Content.Client/_RMC14/Xenonids/Screech/ScreechBlindOverlay.cs
@@ -1,0 +1,52 @@
+using Content.Shared._RMC14.Xenonids.Screech;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+using Robust.Shared.Enums;
+using Robust.Shared.Prototypes;
+
+namespace Content.Client._RMC14.Xenonids.Screech;
+
+public sealed class ScreechBlindOverlay : Overlay
+{
+    private static readonly ProtoId<ShaderPrototype> ScreechBlindShader = "RMCScreechBlind";
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpace;
+    public override bool RequestScreenTexture => true;
+
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
+
+    private readonly ShaderInstance _shader;
+
+    public ScreechBlindOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+        _shader = _prototypeManager.Index(ScreechBlindShader).InstanceUnique();
+    }
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (!_entityManager.TryGetComponent(_playerManager.LocalEntity, out ScreechBlindComponent? blind))
+            return;
+
+        if (ScreenTexture == null || args.Viewport.Eye == null)
+            return;
+
+        var viewportSize = args.Viewport.Size;
+        var worldHeight = args.WorldBounds.Box.Height;
+        var pixelsPerTile = viewportSize.Y / worldHeight;
+
+        var innerRadius = blind.Radius * pixelsPerTile;
+        var outerRadius = (blind.Radius + 1f) * pixelsPerTile;
+
+        var handle = args.WorldHandle;
+        _shader.SetParameter("SCREEN_TEXTURE", ScreenTexture);
+        _shader.SetParameter("innerRadius", (float) innerRadius);
+        _shader.SetParameter("outerRadius", (float) outerRadius);
+
+        handle.UseShader(_shader);
+        handle.DrawRect(args.WorldBounds, Color.White);
+        handle.UseShader(null);
+    }
+}

--- a/Content.Client/_RMC14/Xenonids/Screech/ScreechBlindSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Screech/ScreechBlindSystem.cs
@@ -1,0 +1,31 @@
+using Content.Shared._RMC14.Xenonids.Screech;
+using Robust.Client.Graphics;
+using Robust.Client.Player;
+
+namespace Content.Client._RMC14.Xenonids.Screech;
+
+public sealed class ScreechBlindSystem : EntitySystem
+{
+    [Dependency] private readonly IOverlayManager _overlay = default!;
+    [Dependency] private readonly IPlayerManager _player = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ScreechBlindComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<ScreechBlindComponent, ComponentRemove>(OnRemove);
+    }
+
+    private void OnInit(Entity<ScreechBlindComponent> ent, ref ComponentInit args)
+    {
+        if (_player.LocalEntity == ent.Owner)
+            _overlay.AddOverlay(new ScreechBlindOverlay());
+    }
+
+    private void OnRemove(Entity<ScreechBlindComponent> ent, ref ComponentRemove args)
+    {
+        if (_player.LocalEntity == ent.Owner)
+            _overlay.RemoveOverlay<ScreechBlindOverlay>();
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Queen/XenoQueenSpitActionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Queen/XenoQueenSpitActionEvent.cs
@@ -1,0 +1,5 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._RMC14.Xenonids.Projectile.Spit.Queen;
+
+public sealed partial class XenoQueenSpitActionEvent : WorldTargetActionEvent;

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Queen/XenoQueenSpitComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/Queen/XenoQueenSpitComponent.cs
@@ -1,0 +1,32 @@
+using Content.Shared.FixedPoint;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.Projectile.Spit.Queen;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(XenoSpitSystem))]
+public sealed partial class XenoQueenSpitComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 PlasmaCost = 40;
+
+    [DataField, AutoNetworkedField]
+    public float Speed = 40;
+
+    [DataField, AutoNetworkedField]
+    public EntProtoId ProjectileId = "XenoQueenSpitProjectile";
+
+    [DataField, AutoNetworkedField]
+    public SoundSpecifier Sound = new SoundCollectionSpecifier("XenoSpitAcid", AudioParams.Default.WithVolume(-5f));
+
+    [DataField, AutoNetworkedField]
+    public int MaxProjectiles = 3;
+
+    [DataField, AutoNetworkedField]
+    public Angle MaxDeviation = Angle.FromDegrees(15);
+
+    [DataField, AutoNetworkedField]
+    public int ProjectileHitLimit = 1;
+}

--- a/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/Spit/XenoSpitSystem.cs
@@ -17,6 +17,7 @@ using Content.Shared._RMC14.Xenonids.Projectile.Spit.Shield;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Shotgun;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Slowing;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Stacks;
+using Content.Shared._RMC14.Xenonids.Projectile.Spit.Queen;
 using Content.Shared._RMC14.Xenonids.Projectile.Spit.Standard;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
@@ -85,6 +86,8 @@ public sealed partial class XenoSpitSystem : EntitySystem
 
         SubscribeLocalEvent<XenoAcidShotgunComponent, XenoAcidShotgunActionEvent>(OnXenoShotgunSpitAction);
         SubscribeLocalEvent<XenoAcidShotgunComponent, ProjectileHitEvent>(GainInsightOnHit, after: [typeof(CMClusterGrenadeSystem)]);
+
+        SubscribeLocalEvent<XenoQueenSpitComponent, XenoQueenSpitActionEvent>(OnXenoQueenSpitAction);
 
         SubscribeLocalEvent<XenoActiveChargingSpitComponent, ComponentStartup>(OnActiveChargingSpitAdded);
         SubscribeLocalEvent<XenoActiveChargingSpitComponent, ComponentRemove>(OnActiveChargingSpitRemove);
@@ -235,6 +238,29 @@ public sealed partial class XenoSpitSystem : EntitySystem
             xeno.Comp.MaxDeviation,
             xeno.Comp.Speed,
             target: args.Entity
+        );
+    }
+
+    private void OnXenoQueenSpitAction(Entity<XenoQueenSpitComponent> xeno, ref XenoQueenSpitActionEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        if (!_rmcActions.TryUseAction(args))
+            return;
+
+        args.Handled = _xenoProjectile.TryShoot(
+            xeno,
+            args.Target,
+            xeno.Comp.PlasmaCost,
+            xeno.Comp.ProjectileId,
+            xeno.Comp.Sound,
+            xeno.Comp.MaxProjectiles,
+            xeno.Comp.MaxDeviation,
+            xeno.Comp.Speed,
+            target: args.Entity,
+            projectileHitLimit: xeno.Comp.ProjectileHitLimit,
+            uniformSpread: true
         );
     }
 

--- a/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Projectile/XenoProjectileSystem.cs
@@ -228,7 +228,8 @@ public sealed partial class XenoProjectileSystem : EntitySystem
         float? stopAtDistance = null,
         EntityUid? target = null,
         bool predicted = true,
-        int? projectileHitLimit = null)
+        int? projectileHitLimit = null,
+        bool uniformSpread = false)
     {
         if (!predicted && _net.IsClient)
             return false;
@@ -267,10 +268,14 @@ public sealed partial class XenoProjectileSystem : EntitySystem
 
         for (var i = 0; i < shots; i++)
         {
-            // center projectile has no deviation; others are randomly offset within deviation
             var angleOffset = Angle.Zero;
-            if (i > 0 && deviation != Angle.Zero)
-                angleOffset = _rmcPseudoRandom.NextAngle(ref xoroshiro, -halfDeviation, halfDeviation);
+            if (deviation != Angle.Zero)
+            {
+                if (uniformSpread && shots > 1)
+                    angleOffset = -halfDeviation + deviation * ((double) i / (shots - 1));
+                else if (i > 0)
+                    angleOffset = _rmcPseudoRandom.NextAngle(ref xoroshiro, -halfDeviation, halfDeviation);
+            }
 
             var projTarget = new MapCoordinates(origin.Position + angleOffset.RotateVec(originalDiff), targetMap.MapId);
 

--- a/Content.Shared/_RMC14/Xenonids/Screech/ScreechBlindComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/ScreechBlindComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Screech;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ScreechBlindComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public TimeSpan? EndsAt;
+
+    /// <summary>
+    ///     Visible radius in tiles around the player.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float Radius = 2f;
+}

--- a/Content.Shared/_RMC14/Xenonids/Screech/ScreechScatterComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/ScreechScatterComponent.cs
@@ -1,0 +1,14 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Screech;
+
+/// <summary>
+///     Added to guns held by a marine affected by queen screech.
+///     Applies a scatter penalty while present.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ScreechScatterComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Angle AngleIncrease = Angle.FromDegrees(45);
+}

--- a/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/SharedXenoScreechSystem.cs
@@ -2,18 +2,21 @@ using Content.Shared._RMC14.Deafness;
 using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.CameraShake;
 using Content.Shared._RMC14.Slow;
-using Content.Shared._RMC14.Xenonids.Doom;
-using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared.Containers;
 using Content.Shared.Coordinates;
+using Content.Shared.Jittering;
 using Content.Shared.Examine;
+using Content.Shared.Hands.Components;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
-using Content.Shared.Stunnable;
+using Content.Shared.Weapons.Ranged.Components;
+using Content.Shared.Weapons.Ranged.Events;
+using Content.Shared.Weapons.Ranged.Systems;
 using Robust.Shared.Audio.Systems;
+using Robust.Shared.Containers;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
-using System.Linq;
 
 namespace Content.Shared._RMC14.Xenonids.Screech;
 
@@ -24,23 +27,26 @@ public sealed partial class XenoScreechSystem : EntitySystem
     [Dependency] private EntityLookupSystem _entityLookup = default!;
     [Dependency] private ExamineSystemShared _examineSystem = default!;
     [Dependency] private INetManager _net = default!;
-    [Dependency] private SharedStunSystem _stun = default!;
     [Dependency] private SharedDeafnessSystem _deaf = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private XenoSystem _xeno = default!;
     [Dependency] private RMCCameraShakeSystem _cameraShake = default!;
     [Dependency] private RMCSlowSystem _slow = default!;
+    [Dependency] private SharedGunSystem _gun = default!;
+    [Dependency] private SharedContainerSystem _container = default!;
+    [Dependency] private SharedJitteringSystem _jitter = default!;
     [Dependency] private IGameTiming _timing = default!;
 
     private readonly HashSet<Entity<MobStateComponent>> _mobs = new();
-    private readonly HashSet<Entity<MobStateComponent>> _closeMobs = new();
-    private readonly HashSet<Entity<XenoParasiteComponent>> _parasites = new();
 
     public override void Initialize()
     {
         base.Initialize();
 
         SubscribeLocalEvent<XenoScreechComponent, XenoScreechActionEvent>(OnXenoScreechAction);
+        SubscribeLocalEvent<ScreechScatterComponent, GunRefreshModifiersEvent>(OnScreechScatterRefresh);
+        SubscribeLocalEvent<ScreechBlindComponent, ComponentStartup>(OnScreechBlindStartup);
+        SubscribeLocalEvent<ScreechBlindComponent, ComponentShutdown>(OnScreechBlindShutdown);
     }
 
     private void OnXenoScreechAction(Entity<XenoScreechComponent> xeno, ref XenoScreechActionEvent args)
@@ -65,45 +71,19 @@ public sealed partial class XenoScreechSystem : EntitySystem
         if (_net.IsServer)
             _audio.PlayPvs(xeno.Comp.Sound, xeno);
 
-        _closeMobs.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParalyzeRange, _closeMobs);
-
-        foreach (var receiver in _closeMobs)
-        {
-            if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
-                continue;
-
-            if (!ApplyScreechEffects(xeno, receiver, xeno.Comp.SlowTime, xeno.Comp.BlindTime))
-                continue;
-
-            _cameraShake.ShakeCamera(receiver, xeno.Comp.CloseScreenShakeShakes, xeno.Comp.CloseScreenShakeStrength);
-            Deafen(xeno, receiver, xeno.Comp.CloseDeafTime);
-        }
-
         _mobs.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.StunRange, _mobs);
+        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.Range, _mobs);
 
         foreach (var receiver in _mobs)
         {
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
                 continue;
 
-            if (_closeMobs.Contains(receiver))
-                continue;
-
             if (!ApplyScreechEffects(xeno, receiver, xeno.Comp.SlowTime, xeno.Comp.BlindTime))
                 continue;
 
-            _cameraShake.ShakeCamera(receiver, xeno.Comp.FarScreenShakeShakes, xeno.Comp.FarScreenShakeStrength);
-            Deafen(xeno, receiver, xeno.Comp.FarDeafTime);
-        }
-
-        _parasites.Clear();
-        _entityLookup.GetEntitiesInRange(xform.Coordinates, xeno.Comp.ParasiteStunRange, _parasites);
-
-        foreach (var receiver in _parasites)
-        {
-            Stun(xeno, receiver, xeno.Comp.ParasiteStunTime, true, false);
+            _cameraShake.ShakeCamera(receiver, xeno.Comp.ScreenShakeShakes, xeno.Comp.ScreenShakeStrength);
+            Deafen(xeno, receiver, xeno.Comp.DeafTime);
         }
 
         if (_net.IsServer)
@@ -119,24 +99,11 @@ public sealed partial class XenoScreechSystem : EntitySystem
             return false;
 
         _slow.TrySuperSlowdown(receiver, slowTime, ignoreDurationModifier: true);
-        var doom = EnsureComp<MobDoomedComponent>(receiver);
-        doom.EndsAt = _timing.CurTime + blindTime;
-        Dirty(receiver, doom);
+        _jitter.DoJitter(receiver, slowTime, true, 3f, 8f);
+        var blind = EnsureComp<ScreechBlindComponent>(receiver);
+        blind.EndsAt = _timing.CurTime + blindTime;
+        Dirty(receiver, blind);
         return true;
-    }
-
-    private bool Stun(EntityUid xeno, EntityUid receiver, TimeSpan time, bool stun, bool occlusionCheck = true)
-    {
-        if (_mobState.IsDead(receiver))
-            return false;
-
-        if (occlusionCheck && !_examineSystem.InRangeUnOccluded(xeno, receiver))
-            return false;
-
-        if (stun)
-            return _stun.TryStun(receiver, time, false);
-
-        return _stun.TryParalyze(receiver, time, false);
     }
 
     private void Deafen(EntityUid xeno, EntityUid receiver, TimeSpan time)
@@ -148,5 +115,79 @@ public sealed partial class XenoScreechSystem : EntitySystem
             return;
 
         _deaf.TryDeafen(receiver, time, false);
+    }
+
+    private void OnScreechScatterRefresh(Entity<ScreechScatterComponent> ent, ref GunRefreshModifiersEvent args)
+    {
+        args.MinAngle += ent.Comp.AngleIncrease;
+        args.MaxAngle += ent.Comp.AngleIncrease;
+    }
+
+    private void OnScreechBlindStartup(Entity<ScreechBlindComponent> ent, ref ComponentStartup args)
+    {
+        AddScatterToHeldGuns(ent);
+    }
+
+    private void OnScreechBlindShutdown(Entity<ScreechBlindComponent> ent, ref ComponentShutdown args)
+    {
+        RemoveScatterFromHeldGuns(ent);
+    }
+
+    private void AddScatterToHeldGuns(EntityUid user)
+    {
+        if (!TryComp<HandsComponent>(user, out var hands))
+            return;
+
+        foreach (var name in hands.Hands.Keys)
+        {
+            if (!_container.TryGetContainer(user, name, out var container))
+                continue;
+
+            foreach (var held in container.ContainedEntities)
+            {
+                if (!HasComp<GunComponent>(held))
+                    continue;
+
+                EnsureComp<ScreechScatterComponent>(held);
+                _gun.RefreshModifiers(held);
+            }
+        }
+    }
+
+    private void RemoveScatterFromHeldGuns(EntityUid user)
+    {
+        if (!TryComp<HandsComponent>(user, out var hands))
+            return;
+
+        foreach (var name in hands.Hands.Keys)
+        {
+            if (!_container.TryGetContainer(user, name, out var container))
+                continue;
+
+            foreach (var held in container.ContainedEntities)
+            {
+                if (!RemComp<ScreechScatterComponent>(held))
+                    continue;
+
+                _gun.RefreshModifiers(held);
+            }
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_net.IsClient)
+            return;
+
+        var time = _timing.CurTime;
+        var query = EntityQueryEnumerator<ScreechBlindComponent>();
+
+        while (query.MoveNext(out var uid, out var blind))
+        {
+            if (blind.EndsAt != null && time < blind.EndsAt)
+                continue;
+
+            RemCompDeferred<ScreechBlindComponent>(uid);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Screech/XenoScreechComponent.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.FixedPoint;
+using Content.Shared.FixedPoint;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
@@ -13,51 +13,27 @@ public sealed partial class XenoScreechComponent : Component
     public FixedPoint2 PlasmaCost = 250;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan StunTime = TimeSpan.FromSeconds(6);
+    public float Range = 7;
 
     [DataField, AutoNetworkedField]
-    public TimeSpan ParalyzeTime = TimeSpan.FromSeconds(8);
+    public TimeSpan SlowTime = TimeSpan.FromSeconds(8);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan CloseDeafTime = TimeSpan.FromSeconds(7);
+    public TimeSpan BlindTime = TimeSpan.FromSeconds(8);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan FarDeafTime = TimeSpan.FromSeconds(4);
-
-    // TODO RMC14 stun less within 4 tiles
-    [DataField, AutoNetworkedField]
-    public float StunRange = 7;
+    public TimeSpan DeafTime = TimeSpan.FromSeconds(8);
 
     [DataField, AutoNetworkedField]
-    public float ParalyzeRange = 4;
+    public int ScreenShakeShakes = 12;
 
     [DataField, AutoNetworkedField]
-    public float ParasiteStunRange = 11.2838f;
+    public int ScreenShakeStrength = 6;
 
-    [DataField, AutoNetworkedField]
-    public TimeSpan ParasiteStunTime = TimeSpan.FromSeconds(8);
-
-    [DataField, AutoNetworkedField]
-    public int CloseScreenShakeShakes = 12;
-
-    [DataField, AutoNetworkedField]
-    public int CloseScreenShakeStrength = 6;
-
-    [DataField, AutoNetworkedField]
-    public int FarScreenShakeShakes = 8;
-
-    [DataField, AutoNetworkedField]
-    public int FarScreenShakeStrength = 4;
 
     [DataField, AutoNetworkedField]
     public EntProtoId Effect = "CMEffectScreech";
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier Sound = new SoundPathSpecifier("/Audio/_RMC14/Xeno/alien_queen_screech.ogg", AudioParams.Default.WithVolume(-7));
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan SlowTime = TimeSpan.FromSeconds(8);
-
-    [DataField, AutoNetworkedField]
-    public TimeSpan BlindTime = TimeSpan.FromSeconds(2);
 }

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -675,7 +675,7 @@
   id: ActionXenoScreech
   parent: ActionXenoBase
   name: Screech (250)
-  description: A wide area of effect stun, screeches upon activation. [color=red]This will also stun parasites, and is blocked by solid walls, smoke, and boiler gas, but not windows![/color]
+  description: An ear-splitting screech that debilitates nearby enemies within 7 tiles. [color=red]Severely slows, deafens, restricts vision, and disrupts aim for 8 seconds. Blocked by solid walls, but not windows.[/color]
   components:
   - type: Action
     itemIconStyle: NoItem
@@ -1099,7 +1099,7 @@
 - type: entity
   id: ActionXenoQueenSpit
   parent: ActionXenoBase
-  name: Acid Volley (50)
+  name: Acid Volley (40)
   description: Launches three acid projectiles in a narrow cone. Each target can only be hit once.
   components:
   - type: Action
@@ -1118,7 +1118,7 @@
     event: !type:XenoQueenSpitActionEvent
   - type: ActionBlockIfResting
   - type: XenoActionPlasma
-    cost: 50
+    cost: 40
 
 - type: entity
   parent: ActionXenoBase

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -1097,6 +1097,30 @@
   description: Launches a projectile that will either paralyze the first enemy it hits or damage them and cover them in acid.
 
 - type: entity
+  id: ActionXenoQueenSpit
+  parent: ActionXenoBase
+  name: Acid Volley (50)
+  description: Launches three acid projectiles in a narrow cone. Each target can only be hit once.
+  components:
+  - type: Action
+    itemIconStyle: NoItem
+    icon:
+      sprite: _RMC14/Actions/xeno_actions.rsi
+      state: xeno_spit
+    useDelay: 5
+  - type: TargetAction
+    repeat: true
+    range: 30
+    checkCanAccess: false
+  - type: EntityTargetAction
+    targetCheckCanInteract: false
+  - type: WorldTargetAction
+    event: !type:XenoQueenSpitActionEvent
+  - type: ActionBlockIfResting
+  - type: XenoActionPlasma
+    cost: 50
+
+- type: entity
   parent: ActionXenoBase
   id: ActionXenoToggleSpitType
   name: Toggle Spit Type

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -205,8 +205,10 @@
     deadThreshold: 1100
     addComponents:
     - type: XenoScreech
+    - type: XenoQueenSpit
     addActions:
     - ActionXenoScreech
+    - ActionXenoQueenSpit
   - type: RMCSize
     size: Immobile
   - type: RMCXenoDamageVisuals

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Xeno/xeno_projectiles.yml
@@ -92,6 +92,14 @@
     max: 5
 
 - type: entity
+  parent: XenoChargedSpitProjectile
+  id: XenoQueenSpitProjectile
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: ProjectileMaxRange
+    max: 10
+
+- type: entity
   id: XenoSlowingSpitProjectile
   parent: XenoBaseProjectile
   name: slowing spit

--- a/Resources/Prototypes/_RMC14/Shaders/shaders.yml
+++ b/Resources/Prototypes/_RMC14/Shaders/shaders.yml
@@ -29,6 +29,11 @@
     nv_color: 0.5, 0.5, 0.5
 
 - type: shader
+  id: RMCScreechBlind
+  kind: source
+  path: "/Textures/_RMC14/Shaders/screech_blind.swsl"
+
+- type: shader
   id: RMCBlurryVisionX
   kind: source
   path: "/Textures/_RMC14/Shaders/blurryx.swsl"

--- a/Resources/Textures/_RMC14/Shaders/screech_blind.swsl
+++ b/Resources/Textures/_RMC14/Shaders/screech_blind.swsl
@@ -1,0 +1,22 @@
+uniform sampler2D SCREEN_TEXTURE;
+uniform highp float innerRadius;
+uniform highp float outerRadius;
+
+void fragment() {
+    highp vec2 pixelSize = vec2(1.0 / SCREEN_PIXEL_SIZE.x, 1.0 / SCREEN_PIXEL_SIZE.y);
+    highp vec2 pixelCenter = pixelSize * 0.5;
+    highp float distance = length(FRAGCOORD.xy - pixelCenter);
+
+    highp vec4 color = zTextureSpec(SCREEN_TEXTURE, UV);
+
+    if (distance > outerRadius) {
+        COLOR = vec4(0.0, 0.0, 0.0, 1.0);
+    }
+    else if (distance < innerRadius) {
+        COLOR = color;
+    }
+    else {
+        highp float ratio = (distance - innerRadius) / (outerRadius - innerRadius);
+        COLOR = mix(color, vec4(0.0, 0.0, 0.0, 1.0), ratio);
+    }
+}


### PR DESCRIPTION
## About the PR

**Acid Volley (maturity ability):**
- Fires 3 charged acid spit projectiles in a uniform 15° cone
- 40 plasma cost, 5s cooldown, 10 tile projectile range
- Each target can only be hit by one projectile per volley

**Screech Rework:**
- Removed parasite stun
- Replaced doom overlay with a new "screech blind" effect: vision restricted to a 2-tile radius with gradient fade to black
- Added weapon scatter debuff for the duration

## Why / Balance

The queen's new spit fires a triple acid volley which gives her ranged pressure without hard CC. The hit-limit-per-target mechanic ammends the issue of it being the same as trapper boiler's acid shotgun.

The screech rework replaces the full-screen doom tint with a more interesting restricted-vision effect that still allows some counterplay, while the scatter debuff makes marines dangerous to shoot during the effect without completely removing their ability to fight.

## Technical details

- Added `uniformSpread` parameter to `XenoProjectileSystem.TryShoot` (defaults false, no impact on existing callers)
- New `ScreechBlindComponent` + client overlay with custom `screech_blind.swsl` shader (radius-based circle mask)
- New `ScreechScatterComponent` marker added to held guns during screech; subscribes to `GunRefreshModifiersEvent`
- Cleaned up dead fields from `XenoScreechComponent` (StunTime, ParalyzeTime, ParalyzeRange, far-range fields)

## Media

N/A

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- add: Queen gains Acid Volley on maturity: fires 3 acid projectiles in a narrow cone (each target hit once max)
- tweak: Queen screech now restricts vision to 2 tiles, adds weapon scatter
- tweak: Queen screech effects unified to 7-tile range, all debuffs last 8 seconds
- remove: Removed parasite stun from queen screech
- remove: Removed close/far range distinction from queen screech