### PR TITLE
Examine rank loc

### DIFF
--- a/Content.Shared/_RMC14/Marines/Roles/Ranks/SharedRankSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Roles/Ranks/SharedRankSystem.cs
@@ -111,7 +111,7 @@ public abstract partial class SharedRankSystem : EntitySystem
         if (hasPaygrade && rank.Paygrade != null)
             return $"({Loc.GetString(rank.Paygrade)}) {Loc.GetString(rank.Name)}";
 
-        return rank.Name;
+        return Loc.TryGetString($"rank-{rank.ID}", out var localizedName) ? localizedName : rank.Name;
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds localization support for rank names displayed in the examine text. Previously, GetRankString returned rank.Name as a raw string when no paygrade was present. Now it first attempts to look up a localization key rank-{rank.ID} via Loc.TryGetString, falling back to rank.Name if no key is found.

## Why / Balance
We need this for russian loc(RussianCM fork)

## Technical details
Content.Shared/_RMC14/Marines/Roles/Ranks/SharedRankSystem.cs
before
return rank.Name;  
after
return Loc.TryGetString($"rank-{rank.ID}", out var localizedName) ? localizedName : rank.Name;

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- code:  Added localization key lookup (rank-{ID}) for rank names in examine text
