### PR TITLE
Wendigo global screech bug fix

### DIFF
--- a/Content.Shared/_CMU14/Wendigo/WendigoHeadbiteAudioSystem.cs
+++ b/Content.Shared/_CMU14/Wendigo/WendigoHeadbiteAudioSystem.cs
@@ -28,6 +28,8 @@ public sealed partial class WendigoHeadbiteAudioSystem : EntitySystem
         SubscribeLocalEvent<WendigoHeadbiteAudioComponent, XenoHeadbiteDoAfterEvent>(
             OnHeadbiteDoAfter,
             after: [typeof(XenoHeadbiteSystem)]);
+
+        SubscribeNetworkEvent<WendigoScreechEvent>(OnScreechEvent);
     }
 
     private void OnHeadbiteDoAfter(Entity<WendigoHeadbiteAudioComponent> ent, ref XenoHeadbiteDoAfterEvent args)
@@ -40,40 +42,29 @@ public sealed partial class WendigoHeadbiteAudioSystem : EntitySystem
 
         var globalReady = IsGlobalReady(ent);
 
-        // Play global directional screech if off cooldown; otherwise play close sound.
         if (globalReady && ent.Comp.GlobalSound != null)
         {
-            var wendigoCoords = _transform.GetMoverCoordinates(ent);
+            var coords = _transform.GetMoverCoordinates(ent);
+            var netCoords = GetNetCoordinates(coords);
 
             var outdoorParams = AudioParams.Default
-                .WithMaxDistance(float.MaxValue)
+                .WithMaxDistance(5000f)
                 .WithRolloffFactor(0)
                 .WithVolume(ent.Comp.GlobalVolume);
 
             var indoorParams = AudioParams.Default
-                .WithMaxDistance(float.MaxValue)
+                .WithMaxDistance(5000f)
                 .WithRolloffFactor(0)
                 .WithVolume(ent.Comp.GlobalIndoorVolume);
-
-            var outdoorFilter = Filter.Empty();
-            var indoorFilter = Filter.Empty();
 
             foreach (var session in Filter.Broadcast().Recipients)
             {
                 if (session.AttachedEntity is not { } player)
                     continue;
 
-                if (IsEntityRoofed(player))
-                    indoorFilter.AddPlayer(session);
-                else
-                    outdoorFilter.AddPlayer(session);
+                var audioParams = IsEntityRoofed(player) ? indoorParams : outdoorParams;
+                RaiseNetworkEvent(new WendigoScreechEvent(ent.Comp.GlobalSound, audioParams, netCoords), session);
             }
-
-            if (outdoorFilter.Count > 0)
-                _audio.PlayStatic(ent.Comp.GlobalSound, outdoorFilter, wendigoCoords, true, outdoorParams);
-
-            if (indoorFilter.Count > 0)
-                _audio.PlayStatic(ent.Comp.GlobalSound, indoorFilter, wendigoCoords, true, indoorParams);
 
             ent.Comp.LastGlobalPlayed = _timing.CurTime;
             ent.Comp.ScreechReady = false;
@@ -83,6 +74,14 @@ public sealed partial class WendigoHeadbiteAudioSystem : EntitySystem
         {
             _audio.PlayPvs(ent.Comp.CloseSound, ent);
         }
+    }
+
+    private void OnScreechEvent(WendigoScreechEvent ev)
+    {
+        if (_net.IsServer)
+            return;
+
+        _audio.PlayStatic(ev.Sound, Filter.Local(), GetCoordinates(ev.Coordinates), true, ev.AudioParams);
     }
 
     private bool IsGlobalReady(Entity<WendigoHeadbiteAudioComponent> ent)

--- a/Content.Shared/_CMU14/Wendigo/WendigoScreechEvent.cs
+++ b/Content.Shared/_CMU14/Wendigo/WendigoScreechEvent.cs
@@ -1,0 +1,13 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CMU14.Wendigo;
+
+[Serializable, NetSerializable]
+public sealed class WendigoScreechEvent(SoundSpecifier sound, AudioParams audioParams, NetCoordinates coordinates) : EntityEventArgs
+{
+    public readonly SoundSpecifier Sound = sound;
+    public readonly AudioParams AudioParams = audioParams;
+    public readonly NetCoordinates Coordinates = coordinates;
+}


### PR DESCRIPTION
## About the PR
Fixes the Wendigo headbite global screech not playing map-wide. The sound was only audible to nearby players instead of the entire map.

## Why / Balance
This restores the intended behavior from PR #1000 that broke after an engine update.

## Technical details
The RobustToolbox PVS override system was changed to respect visibility masks, which caused the audio entity created by `PlayStatic` to be filtered out for distant players. Replaced the server-side audio entity approach with a network event (`WendigoScreechEvent`) sent directly to each player session. Each client plays the sound locally via `PlayStatic` at the Wendigo's coordinates, preserving directionality while bypassing PVS entirely. Also replaced `float.MaxValue` for `MaxDistance` with `5000f` to avoid an OpenAL invalid value error.

## Media
N/A - audio fix, no visual changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed Wendigo headbite screech not playing globally for all players.