### PR TITLE
Enable bad blood yautjas again

### DIFF
--- a/Resources/Prototypes/_AU14/Maps/planets.yml
+++ b/Resources/Prototypes/_AU14/Maps/planets.yml
@@ -148,6 +148,7 @@
     - wendigoThreat
     - abominationsThreat
     - abominationsThreatDistress
+    - badBloodClanThreat
     # Shepherds' Pride exposes CWPS Ranger as its map-specific LEO role.
     joboverrides:
       AU14JobLEOLeaderBase: AU14JobCivilianCWPSRanger
@@ -464,7 +465,7 @@
     - XenoThreatCF
     - wendigoThreat
     - abominationsThreatDistress
-#    - badBloodClanThreat
+    - badBloodClanThreat
 
     thirdparties:
     - WEYUSurvLarge
@@ -529,7 +530,7 @@
     - cultistThreat
     - XenoThreat
     - XenoThreatCF
-#    - badBloodClanThreat
+    - badBloodClanThreat
 
     thirdparties:
     - WEYUSurvLarge
@@ -671,7 +672,7 @@
     - wendigoThreat
  #   - TribalsThreat
     - abominationsThreatDistress
-#    - badBloodClanThreat
+    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
@@ -732,7 +733,7 @@
     threats:
     - XenoThreat
     #- TribalsThreat
-#    - badBloodClanThreat
+    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
@@ -790,7 +791,7 @@
     threats:
     - XenoThreat
  #   - TribalsThreat
-#    - badBloodClanThreat
+    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
@@ -848,7 +849,7 @@
     threats:
     - XenoThreat
 #    - TribalsThreat
-#    - badBloodClanThreat
+    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
@@ -907,7 +908,7 @@
     threats:
     - abominationsThreatDistress
     - XenoThreat
- #   -  badBloodClanThreat
+    - badBloodClanThreat
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale
 
@@ -963,7 +964,7 @@
     threats:
     - abominationsThreatDistress
     - XenoThreat
-#    - badBloodClanThreat
+    - badBloodClanThreat
 
     jobScalingFof: DefaultGovforOpforScale
     jobScalingIns: DefaultInsurgencyScale


### PR DESCRIPTION
## About the PR
Enable badBloodClanThreat on all active Distress Signal maps.

## Why / Balance
Bad Blood Yautja threat was commented out on every map. This adds them to the threat pool for all Distress Signal maps after the threat changes. 
## Technical details
Uncommented badBloodClanThreat in planets.yml for 8 maps and added it to Shepherds' Pride which lacked the entry entirely.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Bad Blood Yautja threat enabled on all Distress Signal maps.