### PR TITLE
Adjust crusher's shield value

### DIFF
--- a/Content.Shared/_RMC14/Shields/CrusherShieldComponent.cs
+++ b/Content.Shared/_RMC14/Shields/CrusherShieldComponent.cs
@@ -20,7 +20,7 @@ public sealed partial class CrusherShieldComponent : Component
     public int ExplosionResistance = 1000;
 
     [DataField, AutoNetworkedField]
-    public int DamageReduction = 8;
+    public int DamageReduction = 10;
 
     [DataField, AutoNetworkedField]
     public TimeSpan ExplosionResistanceDuration = TimeSpan.FromSeconds(2.5);
@@ -32,13 +32,13 @@ public sealed partial class CrusherShieldComponent : Component
     public FixedPoint2 PlasmaCost = FixedPoint2.New(50);
 
     [DataField, AutoNetworkedField]
-    public FixedPoint2 Amount = FixedPoint2.New(100);
+    public FixedPoint2 Amount = FixedPoint2.New(200);
 
     [DataField, AutoNetworkedField]
     public EntProtoId Effect = "RMCEffectEmpowerBrown";
 
     [DataField, AutoNetworkedField]
-    public float ReflectChanceFront = 0.1f;
+    public float ReflectChanceFront = 0.2f;
 
     [DataField, AutoNetworkedField]
     public float ReflectChanceSide = 0f;


### PR DESCRIPTION
## About the PR
Adjusted crusher defensive shieldrestore shield HP to 200, flat damage reduction to 10, and increase frontal reflect chance to 20%.

## Why / Balance
The shield's 100 HP was too low for the reflect to do anything, the shield broke before it could reflect anything meaningful. Restoring the original 200 HP and 10 flat DR gives the shield enough durability for the 20% frontal reflect to actually come into play.

## Technical details
Changed three default values in CrusherShieldComponent.cs: Amount 100→200, DamageReduction 8→10, ReflectChanceFront 0.1→0.2.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Adjusted crusher defensive shield values: 200 HP, 10 flat DR, 20% frontal reflect.