### PR TITLE
Centralized AU14SilenceOrderComponent application inside AU14SilenceO…

### DIFF
--- a/Content.Server/_AU14/Marines/Orders/AU14CallToAttentionSystem.cs
+++ b/Content.Server/_AU14/Marines/Orders/AU14CallToAttentionSystem.cs
@@ -26,7 +26,7 @@ public sealed partial class AU14CallToAttentionSystem : EntitySystem
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private RotateToFaceSystem _rotateToFace = default!;
-    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private AU14SilenceOrderSystem _silence = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
 
     private readonly HashSet<Entity<HumanoidAppearanceComponent>> _receivers = new();
@@ -72,11 +72,13 @@ public sealed partial class AU14CallToAttentionSystem : EntitySystem
         var noticeMsg = Loc.GetString("au14-call-to-attention-notice");
         var emote = ent.Comp.Emote;
         var maxDelay = ent.Comp.ResponseStagger;
-        var whisperExpiresAt = _timing.CurTime + ent.Comp.WhisperDuration;
 
         _visibleTargets.Clear();
         foreach (var receiver in _receivers)
         {
+            if (receiver.Owner == ent.Owner)
+                continue;
+
             if (_mobState.IsDead(receiver))
                 continue;
 
@@ -90,7 +92,7 @@ public sealed partial class AU14CallToAttentionSystem : EntitySystem
         var attentionFocus = GetAttentionFocus(ent.Owner, _visibleTargets);
         foreach (var target in _visibleTargets)
         {
-            ApplyWhisperEffect(target, whisperExpiresAt);
+            ApplyWhisperEffect(target, ent.Comp.WhisperDuration);
 
             var delay = maxDelay <= TimeSpan.Zero
                 ? TimeSpan.Zero
@@ -118,14 +120,12 @@ public sealed partial class AU14CallToAttentionSystem : EntitySystem
         }
     }
 
-    private void ApplyWhisperEffect(EntityUid target, TimeSpan expiresAt)
+    private void ApplyWhisperEffect(EntityUid target, TimeSpan duration)
     {
         if (HasComp<AU14CallToAttentionWhisperImmuneComponent>(target))
             return;
 
-        var silence = EnsureComp<AU14SilenceOrderComponent>(target);
-        if (silence.ExpiresAt < expiresAt)
-            silence.ExpiresAt = expiresAt;
+        _silence.ApplySilenceFor(target, duration);
     }
 
     private void SnapToAttention(EntityUid target, EntityUid attentionFocus, ProtoId<EmotePrototype> emote, string noticeMsg)

--- a/Content.Server/_AU14/Marines/Orders/AU14SilenceOrderSystem.cs
+++ b/Content.Server/_AU14/Marines/Orders/AU14SilenceOrderSystem.cs
@@ -87,12 +87,26 @@ public sealed partial class AU14SilenceOrderSystem : EntitySystem
             if (_mobState.IsDead(receiver))
                 continue;
 
-            var silence = EnsureComp<AU14SilenceOrderComponent>(receiver);
-            silence.ExpiresAt = expiresAt;
+            ApplySilenceUntil(receiver, expiresAt);
 
             _popup.PopupEntity(noticeMsg, receiver, receiver, PopupType.Small);
             _cmChat.ChatMessageToOne(noticeMsg, receiver, ChatChannel.Local, colorOverride: new Color(0.75f, 0.75f, 1f, 1f));
         }
+    }
+
+    public void ApplySilenceFor(EntityUid target, TimeSpan duration)
+    {
+        ApplySilenceUntil(target, _timing.CurTime + duration);
+    }
+
+    public void ApplySilenceUntil(EntityUid target, TimeSpan expiresAt)
+    {
+        var silence = EnsureComp<AU14SilenceOrderComponent>(target);
+        if (silence.ExpiresAt >= expiresAt)
+            return;
+
+        silence.ExpiresAt = expiresAt;
+        Dirty(target, silence);
     }
 
     private void SendSilenceCallout(Entity<AU14SilenceOrderAbilityComponent> ent)


### PR DESCRIPTION
…rderSystem

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Centralized AU14SilenceOrderComponent application inside AU14SilenceOrderSystem.
- Updated Call to Attention to reuse the Silence Order system for applying whisper-only duration.
- Prevented Call to Attention from affecting the person who used the ability.
- ## Why / Balance

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->