### PR TITLE
Comms 2/12: COMSEC fill card system

### DIFF
--- a/Content.Server/_AU14/Radio/ANPRCCryptoSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCCryptoSystem.cs
@@ -1,0 +1,250 @@
+using System.Diagnostics.CodeAnalysis;
+using Content.Shared._AU14.Radio;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Examine;
+using Content.Shared.GameTicking;
+using Content.Shared.Popups;
+using Content.Shared.Radio;
+using Robust.Shared.Containers;
+
+namespace Content.Server._AU14.Radio;
+
+public sealed partial class ANPRCCryptoSystem : EntitySystem
+{
+    public const string FillSlotId = "fill_card";
+
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly ItemSlotsSystem _itemSlots = default!;
+
+    private readonly Dictionary<string, int> _generation = new();
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<ANPRCCryptoSlotComponent, ExaminedEvent>(OnExamine);
+        SubscribeLocalEvent<ANPRCCryptoSlotComponent, EntInsertedIntoContainerMessage>(OnFillInserted);
+        SubscribeLocalEvent<ANPRCCryptoSlotComponent, EntRemovedFromContainerMessage>(OnFillRemoved);
+        SubscribeLocalEvent<ANPRCFillCardComponent, MapInitEvent>(OnFillCardMapInit);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+
+        Subs.BuiEvents<ANPRCCryptoSlotComponent>(ANPRCRadioUI.Key, subs =>
+        {
+            subs.Event<ANPRCCryptoZeroizeMsg>(OnZeroize);
+            subs.Event<ANPRCCryptoDestroyMsg>(OnDestroy);
+            subs.Event<ANPRCCryptoRecryptoMsg>(OnRecrypto);
+        });
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent ev)
+    {
+        _generation.Clear();
+    }
+
+    private void OnFillCardMapInit(Entity<ANPRCFillCardComponent> ent, ref MapInitEvent args)
+    {
+        if (string.IsNullOrEmpty(ent.Comp.Faction))
+            return;
+
+        ent.Comp.Generation = GetGeneration(ent.Comp.Faction);
+        Dirty(ent);
+    }
+
+    private void OnFillInserted(EntityUid uid, ANPRCCryptoSlotComponent comp, EntInsertedIntoContainerMessage args)
+    {
+        if (args.Container.ID != FillSlotId)
+            return;
+
+        RaiseLocalEvent(uid, new ANPRCCryptoChangedEvent());
+    }
+
+    private void OnFillRemoved(EntityUid uid, ANPRCCryptoSlotComponent comp, EntRemovedFromContainerMessage args)
+    {
+        if (args.Container.ID != FillSlotId)
+            return;
+
+        RaiseLocalEvent(uid, new ANPRCCryptoChangedEvent());
+    }
+
+    private void OnZeroize(Entity<ANPRCCryptoSlotComponent> ent, ref ANPRCCryptoZeroizeMsg args)
+    {
+        if (!_itemSlots.TryGetSlot(ent.Owner, FillSlotId, out var slot) || !slot.HasItem)
+        {
+            _popup.PopupEntity(
+                Loc.GetString("anprc-crypto-no-card"),
+                args.Actor,
+                args.Actor,
+                PopupType.SmallCaution);
+
+            return;
+        }
+
+        var designation = GetFillDesignation(ent.Owner);
+        _itemSlots.TryEjectToHands(ent.Owner, slot, args.Actor);
+
+        _popup.PopupEntity(
+            Loc.GetString("anprc-crypto-zeroized", ("designation", designation)),
+            args.Actor,
+            args.Actor,
+            PopupType.Medium);
+    }
+
+    private void OnDestroy(Entity<ANPRCCryptoSlotComponent> ent, ref ANPRCCryptoDestroyMsg args)
+    {
+        if (!_itemSlots.TryGetSlot(ent.Owner, FillSlotId, out var slot) || slot.Item is not { } card)
+        {
+            _popup.PopupEntity(
+                Loc.GetString("anprc-crypto-no-card"),
+                args.Actor,
+                args.Actor,
+                PopupType.SmallCaution);
+
+            return;
+        }
+
+        var designation = GetFillDesignation(ent.Owner);
+        QueueDel(card);
+
+        _popup.PopupEntity(
+            Loc.GetString("anprc-crypto-destroyed", ("designation", designation)),
+            args.Actor,
+            args.Actor,
+            PopupType.LargeCaution);
+    }
+
+    private void OnRecrypto(Entity<ANPRCCryptoSlotComponent> ent, ref ANPRCCryptoRecryptoMsg args)
+    {
+        if (!TryGetFillCard(ent.Owner, out var card, out var cardUid) || string.IsNullOrEmpty(card.Faction))
+        {
+            _popup.PopupEntity(
+                Loc.GetString("anprc-recrypto-no-card"),
+                args.Actor,
+                args.Actor,
+                PopupType.SmallCaution);
+
+            return;
+        }
+
+        if (TryComp(ent.Owner, out ANPRCRadioComponent? radio) &&
+            !string.IsNullOrEmpty(radio.OperatorFaction) &&
+            !string.Equals(radio.OperatorFaction, card.Faction, StringComparison.OrdinalIgnoreCase))
+        {
+            _popup.PopupEntity(
+                Loc.GetString("anprc-recrypto-foreign-card"),
+                args.Actor,
+                args.Actor,
+                PopupType.SmallCaution);
+
+            return;
+        }
+
+        if (card.Generation != GetGeneration(card.Faction))
+        {
+            _popup.PopupEntity(
+                Loc.GetString("anprc-recrypto-stale-card"),
+                args.Actor,
+                args.Actor,
+                PopupType.SmallCaution);
+
+            return;
+        }
+
+        var faction = card.Faction;
+        var newGeneration = GetGeneration(faction) + 1;
+
+        _generation[faction] = newGeneration;
+        card.Generation = newGeneration;
+
+        Dirty(cardUid, card);
+        RaiseLocalEvent(ent.Owner, new ANPRCCryptoChangedEvent());
+
+        _popup.PopupEntity(
+            Loc.GetString("anprc-recrypto-ordered", ("faction", faction)),
+            args.Actor,
+            args.Actor,
+            PopupType.Large);
+    }
+
+    private void OnExamine(Entity<ANPRCCryptoSlotComponent> ent, ref ExaminedEvent args)
+    {
+        using (args.PushGroup(nameof(ANPRCCryptoSlotComponent)))
+        {
+            var faction = GetFillFaction(ent.Owner);
+
+            if (string.IsNullOrEmpty(faction))
+            {
+                args.PushMarkup(Loc.GetString("anprc-crypto-examine-empty"));
+                return;
+            }
+
+            var message = IsFillStale(ent.Owner)
+                ? "anprc-crypto-examine-stale"
+                : "anprc-crypto-examine-loaded";
+
+            args.PushMarkup(Loc.GetString(
+                message,
+                ("designation", GetFillDesignation(ent.Owner)),
+                ("faction", faction)));
+        }
+    }
+
+    public bool HasMatchingCrypto(EntityUid anprc, RadioChannelPrototype channel)
+    {
+        if (!TryGetFillCard(anprc, out var fill, out _))
+            return false;
+
+        if (string.IsNullOrEmpty(channel.Faction))
+            return true;
+
+        if (fill.Faction != channel.Faction)
+            return false;
+
+        return fill.Generation == GetGeneration(fill.Faction);
+    }
+
+    public string GetFillFaction(EntityUid anprc)
+    {
+        return TryGetFillCard(anprc, out var fill, out _)
+            ? fill.Faction
+            : string.Empty;
+    }
+
+    public string GetFillDesignation(EntityUid anprc)
+    {
+        return TryGetFillCard(anprc, out var fill, out _)
+            ? fill.Designation
+            : string.Empty;
+    }
+
+    public bool IsFillStale(EntityUid anprc)
+    {
+        return TryGetFillCard(anprc, out var fill, out _) &&
+               !string.IsNullOrEmpty(fill.Faction) &&
+               fill.Generation != GetGeneration(fill.Faction);
+    }
+
+    private int GetGeneration(string faction)
+    {
+        return _generation.TryGetValue(faction, out var generation)
+            ? generation
+            : 0;
+    }
+
+    private bool TryGetFillCard(
+        EntityUid anprc,
+        [NotNullWhen(true)] out ANPRCFillCardComponent? fill,
+        out EntityUid cardUid)
+    {
+        fill = null;
+        cardUid = default;
+
+        if (!HasComp<ANPRCCryptoSlotComponent>(anprc))
+            return false;
+
+        if (!_itemSlots.TryGetSlot(anprc, FillSlotId, out var slot) || slot.Item is not { } card)
+            return false;
+
+        cardUid = card;
+        return TryComp(card, out fill);
+    }
+}
+
+public record struct ANPRCCryptoChangedEvent;

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -45,4 +45,11 @@ public sealed partial class RadioChannelPrototype : IPrototype
 
     [DataField]
     public string Faction = string.Empty;
+
+    /// <summary>
+    /// AU14: combat nets require ANPRC relay coverage on the speaker's and listener's map. Ungated channels
+    /// keep stock radio behavior
+    /// </summary>
+    [DataField]
+    public bool AnchorGated;
 }

--- a/Content.Shared/_AU14/CCVar/AU14CCVars.cs
+++ b/Content.Shared/_AU14/CCVar/AU14CCVars.cs
@@ -14,4 +14,11 @@ public sealed partial class AU14CCVars : CVars
 
     public static readonly CVarDef<bool> SellCargoRewards =
         CVarDef.Create("au14.sell_cargo_rewards", true, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Master switch for the AU14 comms overhaul. When off, radio reverts to
+    /// stock behavior
+    /// </summary>
+    public static readonly CVarDef<bool> NewCommsSystem =
+        CVarDef.Create("au14.new_comms_system", true, CVar.SERVERONLY);
 }

--- a/Content.Shared/_AU14/Callsigns/AU14CallsignComponent.cs
+++ b/Content.Shared/_AU14/Callsigns/AU14CallsignComponent.cs
@@ -1,0 +1,32 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Timing;
+
+namespace Content.Shared._AU14.Callsigns;
+
+/// <summary>
+/// A faction member's assigned radio callsign, e.g. "ALPHA 6" or "HAVOC ROMEO".
+/// Assigned automatically at spawn from job and squad
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class AU14CallsignComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public string Faction = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public string Callsign = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public string Suffix = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public string JobTitle = string.Empty;
+
+    [DataField]
+    public EntityUid? Squad;
+
+    [DataField]
+    public bool RoleSuffix;
+
+    public GameTick RadioMaskTick;
+}

--- a/Content.Shared/_AU14/Callsigns/AU14CallsignConsoleComponent.cs
+++ b/Content.Shared/_AU14/Callsigns/AU14CallsignConsoleComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared._AU14.Callsigns;
+
+[RegisterComponent]
+public sealed partial class AU14CallsignConsoleComponent : Component
+{
+    [DataField(required: true)]
+    public string Faction = string.Empty;
+}

--- a/Content.Shared/_AU14/Callsigns/AU14CallsignConsoleUI.cs
+++ b/Content.Shared/_AU14/Callsigns/AU14CallsignConsoleUI.cs
@@ -1,0 +1,58 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._AU14.Callsigns;
+
+[Serializable, NetSerializable]
+public enum AU14CallsignConsoleUI
+{
+    Key,
+}
+
+[Serializable, NetSerializable]
+public sealed class AU14CallsignConsoleRow(NetEntity member, string callsign, string name, string job)
+{
+    public readonly NetEntity Member = member;
+    public readonly string Callsign = callsign;
+    public readonly string Name = name;
+    public readonly string Job = job;
+}
+
+[Serializable, NetSerializable]
+public sealed class AU14CallsignConsoleElement(NetEntity? squad, string label, string word, List<AU14CallsignConsoleRow> rows)
+{
+    public readonly NetEntity? Squad = squad;
+
+    public readonly string Label = label;
+
+    public readonly string Word = word;
+
+    public readonly List<AU14CallsignConsoleRow> Rows = rows;
+}
+
+[Serializable, NetSerializable]
+public sealed class AU14CallsignConsoleState(string faction, List<AU14CallsignConsoleElement> elements)
+    : BoundUserInterfaceState
+{
+    public readonly string Faction = faction;
+    public readonly List<AU14CallsignConsoleElement> Elements = elements;
+}
+
+[Serializable, NetSerializable]
+public sealed class AU14CallsignRenameElementMsg(NetEntity? squad, string word) : BoundUserInterfaceMessage
+{
+    public readonly NetEntity? Squad = squad;
+    public readonly string Word = word;
+}
+
+[Serializable, NetSerializable]
+public sealed class AU14CallsignSetSuffixMsg(NetEntity member, string suffix) : BoundUserInterfaceMessage
+{
+    public readonly NetEntity Member = member;
+    public readonly string Suffix = suffix;
+}
+
+public static class AU14Callsigns
+{
+    public const int MaxWordLength = 10;
+    public const int MaxSuffixLength = 8;
+}

--- a/Content.Shared/_AU14/Callsigns/AU14CallsignRoleComponent.cs
+++ b/Content.Shared/_AU14/Callsigns/AU14CallsignRoleComponent.cs
@@ -1,0 +1,15 @@
+namespace Content.Shared._AU14.Callsigns;
+
+/// <summary>
+/// Added to a mob via its job's roundComponents to claim a fixed callsign
+/// suffix (6 = leader, 5 = 2IC, 7 = senior NCO, ROMEO = RTO, OPS = staff)
+/// </summary>
+[RegisterComponent]
+public sealed partial class AU14CallsignRoleComponent : Component
+{
+    [DataField(required: true)]
+    public string Suffix = string.Empty;
+
+    [DataField]
+    public bool CommandElement;
+}

--- a/Content.Shared/_AU14/Radio/ANPRCAntennaComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCAntennaComponent.cs
@@ -1,0 +1,22 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ANPRCAntennaComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public string Label = "WHIP";
+
+    [DataField, AutoNetworkedField]
+    public float FullRange = 30f;
+
+    [DataField, AutoNetworkedField]
+    public float PartialRange = 45f;
+
+    [DataField, AutoNetworkedField]
+    public bool RequiresStationary;
+
+    [DataField, AutoNetworkedField]
+    public float MovingRangeMultiplier = 1f;
+}

--- a/Content.Shared/_AU14/Radio/ANPRCCryptoSlotComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCCryptoSlotComponent.cs
@@ -1,0 +1,4 @@
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent]
+public sealed partial class ANPRCCryptoSlotComponent : Component;

--- a/Content.Shared/_AU14/Radio/ANPRCFillCardComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCFillCardComponent.cs
@@ -1,0 +1,16 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ANPRCFillCardComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public string Faction = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public string Designation = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public int Generation = 0;
+}

--- a/Content.Shared/_AU14/Radio/ANPRCHandsetUserComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCHandsetUserComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent]
+public sealed partial class ANPRCHandsetUserComponent : Component
+{
+    [DataField]
+    public EntityUid Radio;
+
+    public bool PendingTransmit;
+}

--- a/Content.Shared/_AU14/Radio/ANPRCInRangeComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCInRangeComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent]
+public sealed partial class ANPRCInRangeComponent : Component
+{
+    [DataField]
+    public bool IsPartial = false;
+}

--- a/Content.Shared/_AU14/Radio/ANPRCRadioComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCRadioComponent.cs
@@ -1,0 +1,112 @@
+using System.Numerics;
+using Content.Shared.Radio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class ANPRCRadioComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public Dictionary<int, string> SlotLabels = new();
+
+    [DataField, AutoNetworkedField]
+    public Dictionary<int, ProtoId<RadioChannelPrototype>> Presets = new();
+
+    [DataField, AutoNetworkedField]
+    public Dictionary<int, int> FrequencyOverrides = new();
+
+    public const int MaxSlots = 4;
+
+    [DataField, AutoNetworkedField]
+    public int ActiveSlot = -1;
+
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
+
+    [DataField]
+    public string RequiredSlot = "back";
+
+    [DataField, AutoNetworkedField]
+    public bool IsEquipped = false;
+
+    [DataField, AutoNetworkedField]
+    public bool MonitorEnabled = false;
+
+    [DataField, AutoNetworkedField]
+    public RadioMode Mode = RadioMode.FrequencyHopping;
+
+    [DataField, AutoNetworkedField]
+    public bool ScanEnabled = false;
+
+    [DataField, AutoNetworkedField]
+    public RadioTxPower TxPower = RadioTxPower.Medium;
+
+    [DataField, AutoNetworkedField]
+    public bool Planted = false;
+
+    [DataField, AutoNetworkedField]
+    public int SquelchLevel = 3;
+
+    public const int MaxSquelchLevel = 4;
+
+    [DataField, AutoNetworkedField]
+    public string Callsign = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public List<string> CallsignPresets = new();
+
+    public const int MaxCallsignLength = 16;
+
+    public EntityUid? HandsetUser;
+
+    public bool NameMaskActive;
+
+    public const int MaxLabelLength = 8;
+
+    [DataField, AutoNetworkedField]
+    public string OperatorFaction = string.Empty;
+
+    [DataField("transmitChargeCost")]
+    public float TransmitChargeCost = 8f;
+
+    [DataField("dfReportFactions")]
+    public List<string> DFReportFactions = new();
+
+    [DataField("dfPingDuration")]
+    public TimeSpan DFPingDuration = TimeSpan.FromSeconds(20);
+
+    [DataField("dfChancePlainText")]
+    public float DFChancePlainText = 0.08f;
+
+    [DataField("dfChanceUnsecured")]
+    public float DFChanceUnsecured = 0.05f;
+
+    [DataField("dfChanceSecuredFH")]
+    public float DFChanceSecuredFH = 0.03f;
+
+    [DataField("dfChanceJamBonus")]
+    public float DFChanceJamBonus = 0.12f;
+
+    [DataField("dfAccumBonus")]
+    public float DFAccumBonus = 0.04f;
+
+    [DataField("dfAccumDecay")]
+    public TimeSpan DFAccumDecay = TimeSpan.FromSeconds(60);
+
+    [DataField("dfAccumResetDistance")]
+    public float DFAccumResetDistance = 10f;
+
+    public float DFAccumulation;
+
+    public TimeSpan DFLastTransmitTime;
+
+    public Vector2 DFLastTransmitPos;
+
+    public Queue<ANPRCNetLogEntry> NetLog = new();
+
+    public const int MaxNetLogEntries = 50;
+
+    public HashSet<string> GrantedChannels = new();
+}

--- a/Content.Shared/_AU14/Radio/ANPRCRadioUI.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCRadioUI.cs
@@ -1,0 +1,226 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Radio;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._AU14.Radio;
+
+[Serializable, NetSerializable]
+public enum ANPRCRadioUI
+{
+    Key,
+}
+
+[Serializable, NetSerializable]
+public enum RadioMode : byte
+{
+    FrequencyHopping,
+    SingleChannel,
+    CipherText,
+    PlainText,
+}
+
+public static class RadioModeExtensions
+{
+    public static float ChargeMultiplier(this RadioMode mode) => mode switch
+    {
+        RadioMode.FrequencyHopping => 1.5f,
+        RadioMode.SingleChannel    => 0.75f,
+        RadioMode.PlainText        => 0.5f,
+        _                          => 1f,
+    };
+}
+
+[Serializable, NetSerializable]
+public enum RadioTxPower : byte
+{
+    Low,
+    Medium,
+    High,
+}
+
+public static class RadioTxPowerExtensions
+{
+    public static float RangeMultiplier(this RadioTxPower power) => power switch
+    {
+        RadioTxPower.Low  => 0.6f,
+        RadioTxPower.High => 1.5f,
+        _                 => 1f,
+    };
+
+    public static float ChargeMultiplier(this RadioTxPower power) => power switch
+    {
+        RadioTxPower.Low  => 0.5f,
+        RadioTxPower.High => 2f,
+        _                 => 1f,
+    };
+
+    public static float DFMultiplier(this RadioTxPower power) => power switch
+    {
+        RadioTxPower.Low  => 0.5f,
+        RadioTxPower.High => 2f,
+        _                 => 1f,
+    };
+
+    public static string Short(this RadioTxPower power) => power switch
+    {
+        RadioTxPower.Low  => "LO",
+        RadioTxPower.High => "HI",
+        _                 => "MED",
+    };
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCNetLogEntry(float timestamp, string senderName, string channelDisplay, string message)
+{
+    public readonly float Timestamp = timestamp;
+    public readonly string SenderName = senderName;
+    public readonly string ChannelDisplay = channelDisplay;
+    public readonly string Message = message;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCSelectSlotMsg(int slot) : BoundUserInterfaceMessage
+{
+    public readonly int Slot = slot;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCTogglePowerMsg : BoundUserInterfaceMessage;
+
+[Serializable, NetSerializable]
+public sealed class ANPRCToggleMonitorMsg : BoundUserInterfaceMessage;
+
+[Serializable, NetSerializable]
+public sealed class ANPRCSetModeMsg(RadioMode mode) : BoundUserInterfaceMessage
+{
+    public readonly RadioMode Mode = mode;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCSetScanMsg(bool enabled) : BoundUserInterfaceMessage
+{
+    public readonly bool Enabled = enabled;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCSetTxPowerMsg(RadioTxPower power) : BoundUserInterfaceMessage
+{
+    public readonly RadioTxPower Power = power;
+}
+
+[Serializable, NetSerializable]
+public sealed partial class ANPRCPlantDoAfterEvent : SimpleDoAfterEvent;
+
+[Serializable, NetSerializable]
+public sealed partial class ANPRCPackUpDoAfterEvent : SimpleDoAfterEvent;
+
+[Serializable, NetSerializable]
+public sealed class ANPRCSetSquelchMsg(int level) : BoundUserInterfaceMessage
+{
+    public readonly int Level = level;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCSetCallsignMsg(string callsign) : BoundUserInterfaceMessage
+{
+    public readonly string Callsign = callsign;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCAddSlotMsg(string label) : BoundUserInterfaceMessage
+{
+    public readonly string Label = label;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCDeleteSlotMsg(int slot) : BoundUserInterfaceMessage
+{
+    public readonly int Slot = slot;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCSetSlotChannelMsg(int slot, ProtoId<RadioChannelPrototype> channel) : BoundUserInterfaceMessage
+{
+    public readonly int                            Slot    = slot;
+    public readonly ProtoId<RadioChannelPrototype> Channel = channel;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCClearSlotMsg(int slot) : BoundUserInterfaceMessage
+{
+    public readonly int Slot = slot;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCCryptoZeroizeMsg : BoundUserInterfaceMessage;
+
+[Serializable, NetSerializable]
+public sealed class ANPRCCryptoDestroyMsg : BoundUserInterfaceMessage;
+
+[Serializable, NetSerializable]
+public sealed class ANPRCCryptoRecryptoMsg : BoundUserInterfaceMessage;
+
+[Serializable, NetSerializable]
+public sealed class ANPRCRadioCheckMsg : BoundUserInterfaceMessage;
+
+[Serializable, NetSerializable]
+public sealed class ANPRCManualFrequencyMsg(int slot, string frequencyText) : BoundUserInterfaceMessage
+{
+    public readonly int Slot = slot;
+    public readonly string FrequencyText = frequencyText;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCRadioState(
+    Dictionary<int, ProtoId<RadioChannelPrototype>> presets,
+    Dictionary<int, int> frequencyOverrides,
+    Dictionary<int, string> slotLabels,
+    int activeSlot,
+    bool enabled,
+    bool isEquipped,
+    bool monitorEnabled,
+    RadioMode mode,
+    bool scanEnabled,
+    int squelchLevel,
+    RadioTxPower txPower,
+    bool planted,
+    string callsign,
+    string wearerCallsign,
+    List<string> callsignPresets,
+    string cryptoDesignation,
+    string cryptoFaction,
+    bool cryptoStale,
+    string operatorFaction,
+    List<ANPRCNetLogEntry> netLog,
+    float batteryFraction,
+    bool hasBattery,
+    string antennaLabel)
+    : BoundUserInterfaceState
+{
+    public readonly Dictionary<int, ProtoId<RadioChannelPrototype>> Presets = presets;
+    public readonly Dictionary<int, int> FrequencyOverrides = frequencyOverrides;
+    public readonly Dictionary<int, string> SlotLabels = slotLabels;
+    public readonly int ActiveSlot = activeSlot;
+    public readonly bool Enabled = enabled;
+    public readonly bool IsEquipped = isEquipped;
+    public readonly bool MonitorEnabled = monitorEnabled;
+    public readonly RadioMode Mode = mode;
+    public readonly bool ScanEnabled = scanEnabled;
+    public readonly int SquelchLevel = squelchLevel;
+    public readonly RadioTxPower TxPower = txPower;
+    public readonly bool Planted = planted;
+    public readonly string Callsign = callsign;
+
+    public readonly string WearerCallsign = wearerCallsign;
+
+    public readonly List<string> CallsignPresets = callsignPresets;
+    public readonly string CryptoDesignation = cryptoDesignation;
+    public readonly string CryptoFaction = cryptoFaction;
+    public readonly bool CryptoStale = cryptoStale;
+    public readonly string OperatorFaction = operatorFaction;
+    public readonly List<ANPRCNetLogEntry> NetLog = netLog;
+    public readonly float BatteryFraction = batteryFraction;
+    public readonly bool HasBattery = hasBattery;
+    public readonly string AntennaLabel = antennaLabel;
+}

--- a/Content.Shared/_AU14/Radio/ANPRCRadioUserComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCRadioUserComponent.cs
@@ -1,0 +1,6 @@
+﻿using Robust.Shared.GameStates;
+
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class ANPRCRadioUserComponent : Component;

--- a/Content.Shared/_AU14/Radio/ANPRCRelayAnchorComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCRelayAnchorComponent.cs
@@ -1,0 +1,30 @@
+﻿using Content.Shared.Radio;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent]
+public sealed partial class ANPRCRelayAnchorComponent : Component
+{
+    [DataField]
+    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new();
+
+    [DataField]
+    public float FullRange = 30f;
+
+    [DataField]
+    public float PartialRange = 45f;
+
+    [DataField]
+    public bool RequiresStationary;
+
+    [DataField]
+    public float RangeMultiplier = 1f;
+
+    [DataField]
+    public float MovingRangeMultiplier = 1f;
+
+    [DataField]
+    public bool Planted;
+}

--- a/Content.Shared/_AU14/Radio/RTORelayComponent.cs
+++ b/Content.Shared/_AU14/Radio/RTORelayComponent.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Radio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class RTORelayComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public HashSet<ProtoId<RadioChannelPrototype>> BridgedChannels = new()
+    {
+        "radioGovforAlpha",
+        "radioGovforBravo",
+        "radioGovforCharlie",
+    };
+
+    [DataField, AutoNetworkedField]
+    public bool Active = false;
+}

--- a/Content.Shared/_AU14/Radio/RadioJamIntensity.cs
+++ b/Content.Shared/_AU14/Radio/RadioJamIntensity.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._AU14.Radio;
+
+[Serializable, NetSerializable]
+public enum RadioJamIntensity : byte
+{
+    None = 0,
+    Light = 1,
+    Medium = 2,
+    Heavy = 3,
+}

--- a/Content.Shared/_AU14/Radio/TunableFrequencyUI.cs
+++ b/Content.Shared/_AU14/Radio/TunableFrequencyUI.cs
@@ -1,0 +1,33 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._AU14.Radio;
+
+[Serializable, NetSerializable]
+public enum TunableFrequencyUI
+{
+    Key,
+}
+
+[Serializable, NetSerializable]
+public sealed class TunableFrequencySetMsg(string frequencyText) : BoundUserInterfaceMessage
+{
+    public readonly string FrequencyText = frequencyText;
+}
+
+[Serializable, NetSerializable]
+public sealed class TunableFrequencyState(
+    int tunedFrequency,
+    int minFrequency,
+    int maxFrequency)
+    : BoundUserInterfaceState
+{
+    public readonly int TunedFrequency = tunedFrequency;
+    public readonly int MinFrequency   = minFrequency;
+    public readonly int MaxFrequency   = maxFrequency;
+}
+
+public static class TunableFrequencyHelpers
+{
+    public static string FormatFreq(int raw)
+        => raw >= 1000 ? $"{raw / 1000}.{raw % 1000:D3}" : $"00.{raw:D3}";
+}

--- a/Content.Shared/_AU14/Radio/TunableHeadsetComponent.cs
+++ b/Content.Shared/_AU14/Radio/TunableHeadsetComponent.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Inventory;
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization.Manager.Attributes;
+
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class TunableHeadsetComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public int TunedFrequency = 0;
+
+    [DataField]
+    public SlotFlags RequiredSlots = SlotFlags.EARS;
+
+    [DataField]
+    public int DefaultFrequency = 0;
+
+    [DataField]
+    public int MinFrequency = 30000;
+
+    [DataField]
+    public int MaxFrequency = 87999;
+}

--- a/Content.Shared/_AU14/Radio/TunedFrequencyComponent.cs
+++ b/Content.Shared/_AU14/Radio/TunedFrequencyComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent]
+public sealed partial class TunedFrequencyComponent : Component
+{
+    public int Frequency = 0;
+
+    public EntityUid Source = EntityUid.Invalid;
+}

--- a/Content.Shared/_AU14/Radio/WearingANPRCComponent.cs
+++ b/Content.Shared/_AU14/Radio/WearingANPRCComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._AU14.Radio;
+
+[RegisterComponent]
+public sealed partial class WearingANPRCComponent : Component
+{
+    [DataField]
+    public EntityUid Radio;
+
+    [DataField]
+    public bool PendingANPRCTransmit;
+}

--- a/Resources/Locale/en-US/_AU14/au14-radio-channels.ftl
+++ b/Resources/Locale/en-US/_AU14/au14-radio-channels.ftl
@@ -1,0 +1,4 @@
+# Names for the AU14 sentinel radio channels. These ship with the channel
+# prototypes; the systems that use them come in later parts of the comms stack.
+chat-radio-anprc-sentinel = ANPRC
+chat-radio-tunable-sentinel = Direct Freq

--- a/Resources/Prototypes/_CMU14/Entities/Objects/anprc_fill_cards.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/anprc_fill_cards.yml
@@ -1,0 +1,49 @@
+- type: entity
+  abstract: true
+  id: ANPRCFillCard
+  name: COMSEC fill card
+  description: A hardened cryptographic fill card for the AN/PRC-117G radio. Worth more than the radio it slots into.
+  parent: BaseItem
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Devices/synth_reset_key.rsi
+    state: reset_key
+  - type: Item
+    size: Tiny
+  - type: ANPRCFillCard
+
+- type: entity
+  parent: ANPRCFillCard
+  id: ANPRCFillCardGOVFOR
+  name: GOVFOR COMSEC fill card
+  description: >-
+    A GOVFOR KY-99A cryptographic fill card. Signal section property —
+    loss must be reported immediately, and nobody enjoys what happens next.
+  components:
+  - type: ANPRCFillCard
+    faction: govfor
+    designation: KY-99A
+
+- type: entity
+  parent: ANPRCFillCard
+  id: ANPRCFillCardOPFOR
+  name: OPFOR COMSEC fill card
+  description: >-
+    An OPFOR KY-58 cryptographic fill card. The serial number has been
+    stamped over three times.
+  components:
+  - type: ANPRCFillCard
+    faction: opfor
+    designation: KY-58
+
+- type: entity
+  parent: ANPRCFillCard
+  id: ANPRCFillCardCLF
+  name: CLF COMSEC fill card
+  description: >-
+    A CLF KY-38 cryptographic fill card, scuffed and lovingly maintained.
+    Harder to replace than the radio, and everyone knows it.
+  components:
+  - type: ANPRCFillCard
+    faction: clf
+    designation: KY-38

--- a/Resources/Prototypes/_CMU14/Roles/radio_channels.yml
+++ b/Resources/Prototypes/_CMU14/Roles/radio_channels.yml
@@ -8,6 +8,7 @@
   longRange: true
   tower: true
   faction: "govfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioGovforBravo
@@ -18,6 +19,7 @@
   longRange: true
   tower: true
   faction: "govfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioGovforCharlie
@@ -28,6 +30,7 @@
   longRange: true
   tower: true
   faction: "govfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioGovforCommand
@@ -38,6 +41,7 @@
   longRange: true
   tower: true
   faction: "govfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioGovforIntel
@@ -48,6 +52,7 @@
   longRange: true
   tower: true
   faction: "govfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioGovforJTAC
@@ -58,6 +63,7 @@
   longRange: true
   tower: true
   faction: "govfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioGovforMILP
@@ -79,6 +85,7 @@
   longRange: true
   tower: true
   faction: "opfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioOpforBravo
@@ -89,6 +96,7 @@
   longRange: true
   tower: true
   faction: "opfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioOpforCharlie
@@ -99,6 +107,7 @@
   longRange: true
   tower: true
   faction: "opfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioOpforCommand
@@ -109,6 +118,7 @@
   longRange: true
   tower: true
   faction: "opfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioOpforIntel
@@ -119,6 +129,7 @@
   longRange: true
   tower: true
   faction: "opfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioOpforJTAC
@@ -129,6 +140,7 @@
   longRange: true
   tower: true
   faction: "opfor"
+  anchorGated: true
 
 - type: radioChannel
   id: radioOpforMILP
@@ -283,3 +295,19 @@
   color: "#92969A"
   longRange: true
   tower: true
+
+- type: radioChannel
+  id: ANPRCActiveChannel
+  name: chat-radio-anprc-sentinel
+  keycode: "r"
+  frequency: 0
+  color: "#3fcf8e"
+  longRange: true
+
+- type: radioChannel
+  id: TunableFrequencyChannel
+  name: chat-radio-tunable-sentinel
+  keycode: "x"
+  frequency: 0
+  color: "#5B9BD5"
+  longRange: false


### PR DESCRIPTION
## About the PR

This is part 2 of 12 for the AN/PRC-117G communications system and replaces the corresponding portion of #1306.

Previous PR: #1568 

This PR adds the COMSEC fill card system used to secure faction radio traffic

Each radio has a dedicated slot for a physical fill card. The system supports:

* loading and ejecting fill cards
* `ZEROIZE`, which ejects the currently loaded card
* `DESTROY`, which permanently deletes the card
* `RECRYPTO`, which advances a faction's active fill generation

When a faction performs `RECRYPTO`, every older card issued to that faction becomes stale, including captured copies. Stale cards remain identifiable, but no longer provide access to secured traffic

Newly spawned cards are stamped with the faction's current generation. This means cards obtained through the normal supply chain remain valid after a recrypto without requiring any special resupply handling

The system is gated behind `au14.new_comms_system`. The radio entity and fill slot are introduced in a later PR, so none of this functionality is currently reachable in-game

## Why / Balance

The fill card loop provides the main counterplay around secured radio traffic

Capturing an enemy fill card allows hostile traffic to be decoded. `RECRYPTO` gives the affected faction a way to invalidate that captured card and restore secure communications

Balance discussion for the overall capture and recrypto loop remains on #1306 

## Technical details

### `ANPRCCryptoSystem`

Adds:

* fill card slot handling
* faction generation tracking
* card validity and staleness checks
* `HasMatchingCrypto` checks used by the garble and transmit systems in later PRs
* faction validation for `RECRYPTO`

`RECRYPTO` requires the operator's faction to match the card's faction. A captured enemy fill card therefore cannot be used to invalidate that faction's active cards

### Fill card prototypes

`anprc_fill_cards.yml` adds the GOVFOR, OPFOR, and CLF fill card prototypes

## Media

Not really needed as the fill cards are not obtainable until the vendor and loadout integration is added later in the series

## Requirements

* [x] I have read and am following the [[Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
* [x] I have added media to this PR or it does not require an in-game showcase.
* [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
* [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

* code: Added the COMSEC fill card and recrypto systems for the upcoming AN/PRC communications overhaul. These changes remain unavailable until the rest of the system is integrated and enabled.