### PR TITLE
Add 2 hour limit to Insurgency gamemode

### DIFF
--- a/Content.Server/_CMU14/Threats/Rules/InsurgencyEndRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/InsurgencyEndRuleSystem.cs
@@ -8,6 +8,8 @@ public sealed class InsurgencyEndRuleSystem : GameRuleSystem<InsurgencyRuleCompo
 {
     [Dependency] private readonly GameTicker _gameTicker = default!;
 
+    private const string DefaultWinMsg = "Neutral outcome: The CLF have failed to gain a significant foothold in the colony during their time there. The cell and the military fall into a stalemate, both sides silently operating in the colony for days to come.";
+
     private static readonly TimeSpan RoundTimeLimit = TimeSpan.FromHours(2);
 
     public override void Update(float frameTime)
@@ -23,6 +25,6 @@ public sealed class InsurgencyEndRuleSystem : GameRuleSystem<InsurgencyRuleCompo
         if (_gameTicker.RoundDuration() < RoundTimeLimit)
             return;
 
-        _gameTicker.EndRound("The CLF have failed to gain a significant foothold in the colony during their time there. The cell and the military fall into a stalemate, both sides silently operating in the colony for days to come.");
+        _gameTicker.EndRound(DefaultWinMsg);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/InsurgencyEndRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/InsurgencyEndRuleSystem.cs
@@ -1,0 +1,28 @@
+﻿using Content.Server.GameTicking;
+using Content.Server.GameTicking.Rules;
+using Content.Shared._CMU14.Threats;
+
+namespace Content.Server._CMU14.Threats.Rules;
+
+public sealed class InsurgencyEndRuleSystem : GameRuleSystem<InsurgencyRuleComponent>
+{
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    private static readonly TimeSpan RoundTimeLimit = TimeSpan.FromHours(2);
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_gameTicker.RunLevel != GameRunLevel.InRound)
+            return;
+
+        if (!_gameTicker.IsGameRuleActive<InsurgencyRuleComponent>())
+            return;
+
+        if (_gameTicker.RoundDuration() < RoundTimeLimit)
+            return;
+
+        _gameTicker.EndRound("The CLF have failed to gain a significant foothold in the colony during their time there. The cell and the military fall into a stalemate, both sides silently operating in the colony for days to come.");
+    }
+}

--- a/Content.Server/_CMU14/Threats/Rules/InsurgencyEndRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/InsurgencyEndRuleSystem.cs
@@ -1,6 +1,7 @@
 ﻿using Content.Server.GameTicking;
 using Content.Server.GameTicking.Rules;
 using Content.Shared._CMU14.Threats;
+using Content.Shared.GameTicking.Components;
 
 namespace Content.Server._CMU14.Threats.Rules;
 
@@ -19,7 +20,10 @@ public sealed class InsurgencyEndRuleSystem : GameRuleSystem<InsurgencyRuleCompo
         if (_gameTicker.RunLevel != GameRunLevel.InRound)
             return;
 
-        if (!_gameTicker.IsGameRuleActive<InsurgencyRuleComponent>())
+        EntityQueryEnumerator<ActiveGameRuleComponent, InsurgencyRuleComponent, GameRuleComponent> query =
+            QueryActiveRules();
+
+        if (!query.MoveNext(out _, out _, out _))
             return;
 
         if (_gameTicker.RoundDuration() < RoundTimeLimit)


### PR DESCRIPTION
## About the PR
There was a round last night where CLF did nothing for so long that almost all of govfor just disconnected from boredom. Insurgency rounds should not be lasting 3+ hours with nothing happening. This aims to both force CLF to get their shit together and do something, and make people more willing to participate in the round knowing that something will happen before the 2 hours is up. 2 hours is also plenty of time to think of and carry out a plan.
In addition, some people are employed and do not have the time to wait 3 hours or more for the round to end. Me personally, I would rather not wait 3 hours just to play the gamemodes I like.

There is probably a better way of going about this but right now this solves the problem of any remaining CLF sitting around doing nothing.

## Technical details
TimeSpan is hardcoded but it shouldn't matter much.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Insurgency now ends with a neutral outcome at 2 hours.