### PR TITLE
Sharp mines can now be blown up with bullets or xeno spit

### DIFF
--- a/Content.Server/_RMC14/Explosion/RMCLandmineSystem.cs
+++ b/Content.Server/_RMC14/Explosion/RMCLandmineSystem.cs
@@ -1,6 +1,5 @@
 using Content.Server.Explosion.EntitySystems;
 using Content.Shared._RMC14.Explosion;
-using Content.Shared._RMC14.Xenonids.Projectile;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.StepTrigger.Systems;
 using Robust.Shared.Physics.Events;
@@ -50,7 +49,7 @@ public sealed partial class RMCLandmineSystem : SharedRMCLandmineSystem
 
     private void OnStartCollide(Entity<RMCLandmineComponent> ent, ref StartCollideEvent args)
     {
-        if (!ent.Comp.Armed || !HasComp<XenoProjectileComponent>(args.OtherEntity))
+        if (!ent.Comp.Armed || !CanProjectileTrigger(ent, args.OtherEntity))
             return;
 
         ent.Comp.ShotStacks++;

--- a/Content.Shared/_RMC14/Explosion/RMCLandmineComponent.cs
+++ b/Content.Shared/_RMC14/Explosion/RMCLandmineComponent.cs
@@ -41,6 +41,12 @@ public sealed partial class RMCLandmineComponent : Component
     public HashSet<EntProtoId<IFFFactionComponent>> Factions = new();
 
     /// <summary>
+    ///     Whether all projectiles can trigger the landmine, instead of only xeno projectiles.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool TriggerOnAnyProjectile;
+
+    /// <summary>
     ///     The amount of times the claymore has been shot.
     /// </summary>
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Explosion/SharedRMCLandmineSystem.cs
+++ b/Content.Shared/_RMC14/Explosion/SharedRMCLandmineSystem.cs
@@ -142,8 +142,16 @@ public abstract partial class SharedRMCLandmineSystem : EntitySystem
 
     private void OnPreventCollide(Entity<RMCLandmineComponent> ent, ref PreventCollideEvent args)
     {
-        if (ent.Comp.Armed && !HasComp<XenoProjectileComponent>(args.OtherEntity) && !HasComp<MobStateComponent>(args.OtherEntity))
+        if (ent.Comp.Armed &&
+            !CanProjectileTrigger(ent, args.OtherEntity) &&
+            !HasComp<MobStateComponent>(args.OtherEntity))
             args.Cancelled = true;
+    }
+
+    protected bool CanProjectileTrigger(Entity<RMCLandmineComponent> ent, EntityUid projectile)
+    {
+        return HasComp<XenoProjectileComponent>(projectile) ||
+               ent.Comp.TriggerOnAnyProjectile && HasComp<ProjectileComponent>(projectile);
     }
 
     private void OnBeforeDamageChanged(Entity<RMCLandmineComponent> ent, ref BeforeDamageChangedEvent args)

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/sharp_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/sharp_rifle.yml
@@ -18,7 +18,6 @@
   - type: SharpGun
   - type: GunRequiresWield
   - type: GunIFF
-    intrinsic: true
     enabled: true
   - type: ShootAtFixedPoint
     maxFixedRange: 7
@@ -435,6 +434,7 @@
           bounds: "-0.25,-0.25,0.25,0.25"
         hard: false
         layer:
+        - BulletImpassable
         - XenoProjectileImpassable
       fix1:
         shape:
@@ -469,6 +469,7 @@
     placementDelay: 3
     disarmDelay: 3
     shotStackLimit: 1
+    triggerOnAnyProjectile: true
     deploySound:
       path: /Audio/_RMC14/Weapons/Guns/Gunshots/gun_sharp_explode.ogg
   - type: SharpMine


### PR DESCRIPTION
:cl:
fix: Allow armed SHARP mines to collide with and detonate from bullets or xeno spit.
fix: Make SHARP darts inherit the operator's IFF so they pass through friendlies.

