### PR TITLE
Announce Distress Signal survivors before round start

### DIFF
--- a/Content.IntegrationTests/_AU14/ThirdParty/DistressSignalSurvivorPrototypeTest.cs
+++ b/Content.IntegrationTests/_AU14/ThirdParty/DistressSignalSurvivorPrototypeTest.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using Content.Server._CMU14.Threats;
+using Content.Shared._CMU14.Threats;
+using Robust.Shared.Localization;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests._AU14.ThirdParty;
+
+[TestFixture]
+public sealed class DistressSignalSurvivorPrototypeTest
+{
+    private static readonly HashSet<string> ExpectedSurvivorParties = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "AU14IntelThirdPartyMarksmanGOVFOR",
+        "AU14IntelThirdPartySniperGOVFOR",
+        "CLFCellReinforcementsIntel",
+        "CLFCellReinforcementsIntelMachineGunner",
+        "CLFSurvsBig",
+        "CLFSurvsMedium",
+        "CLFSurvsSmall",
+        "FORECON",
+        "FORECONAlt",
+        "FORECONAlt2",
+        "FORECONFirstRecon",
+        "FORECONKillTeam",
+        "IPIE",
+        "IPIESynth",
+        "LACNSniperteam",
+        "LACNSniperteamIntel",
+        "NSPAInvestigationParty",
+        "NSPAInvestigationPartyAlt",
+        "NSPAInvestigationPartyArmored",
+        "PAPInvestigationParty",
+        "PAPInvestigationPartyAlt",
+        "UPPGROM",
+        "UPPGROMAlt",
+        "UPPGROMAlt2",
+        "UPPTDLostTeam",
+        "USArmy",
+        "USArmyAlt",
+        "USArmyAlt2",
+        "USArmyArmored",
+        "USArmyTank",
+        "VAIPO",
+        "VAISO",
+        "VAISP",
+        "WEYUSurvLarge",
+        "WEYUSurvMedium",
+        "WEYUSurvSmall",
+        "WYHT",
+        "WYPMCParty",
+        "WYPMCPartyAlt",
+    };
+
+    [Test]
+    public async Task SurvivorPartiesAndAnnouncementsAreValid()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var localization = server.ResolveDependency<ILocalizationManager>();
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
+            var survivorParties = prototypes
+                .EnumeratePrototypes<ThirdPartyPrototype>()
+                .Where(party => party.AnnounceAsSurvivors)
+                .ToDictionary(party => party.ID, StringComparer.OrdinalIgnoreCase);
+
+            Assert.That(survivorParties.Keys, Is.EquivalentTo(ExpectedSurvivorParties));
+            foreach (var (id, party) in survivorParties)
+            {
+                Assert.That(
+                    prototypes.TryIndex(party.PartySpawn, out PartySpawnPrototype spawn),
+                    Is.True,
+                    $"Survivor party '{id}' references missing party spawn '{party.PartySpawn}'.");
+                Assert.That(
+                    ThreatVoteSelection.CalculateBodyCount(spawn, 100).Total,
+                    Is.GreaterThan(0),
+                    $"Survivor party '{id}' must spawn at least one player body.");
+                if (party.RoundStart)
+                {
+                    Assert.That(
+                        spawn.Scaling,
+                        Is.Empty,
+                        $"Round-start survivor party '{id}' uses population scaling, which would invalidate its pre-round count.");
+                }
+            }
+
+            Assert.That(localization.HasString("cmu-distress-signal-survivors-spawning"), Is.True);
+            Assert.That(localization.HasString("cmu-distress-signal-no-survivors"), Is.True);
+            Assert.That(
+                localization.GetString("cmu-distress-signal-survivors-spawning", ("count", 1)),
+                Does.Contain("1 survivor"));
+            Assert.That(
+                localization.GetString("cmu-distress-signal-survivors-spawning", ("count", 2)),
+                Does.Contain("2 survivors"));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/AU14/Round/AuRoundSelectionState.cs
+++ b/Content.Server/AU14/Round/AuRoundSelectionState.cs
@@ -15,6 +15,9 @@ internal sealed class AuRoundSelectionState
     public string? SelectedGovforShip { get; set; }
     public string? SelectedOpforShip { get; set; }
     public List<ThirdPartyPrototype> SelectedThirdParties { get; } = new();
+    public bool DistressSignalThirdPartiesLocked { get; set; }
+    public bool DistressSignalThirdPartyFillCompleted { get; set; }
+    public int DistressSignalSurvivorCount { get; set; }
 
     public void Reset()
     {
@@ -25,6 +28,19 @@ internal sealed class AuRoundSelectionState
         SelectedGovforShip = null;
         SelectedOpforShip = null;
         SelectedThirdParties.Clear();
+        DistressSignalThirdPartiesLocked = false;
+        DistressSignalThirdPartyFillCompleted = false;
+        DistressSignalSurvivorCount = 0;
+    }
+
+    public void ResetDistressSignalThirdPartyLock()
+    {
+        if (DistressSignalThirdPartiesLocked)
+            SelectedThirdParties.Clear();
+
+        DistressSignalThirdPartiesLocked = false;
+        DistressSignalThirdPartyFillCompleted = false;
+        DistressSignalSurvivorCount = 0;
     }
 
     public void SetPlanet(string planetId, RMCPlanetMapPrototypeComponent planet)

--- a/Content.Server/AU14/Round/AuRoundSystem.cs
+++ b/Content.Server/AU14/Round/AuRoundSystem.cs
@@ -31,6 +31,8 @@ namespace Content.Server.AU14.Round
     /// </summary>
     public sealed partial class AuRoundSystem : EntitySystem
     {
+        private const string DistressSignalPresetId = "DistressSignal";
+
         private static readonly HashSet<string> NoThreatPresets = new(StringComparer.OrdinalIgnoreCase)
         {
             "ForceOnForce",
@@ -214,6 +216,7 @@ namespace Content.Server.AU14.Round
             _selectedPlanet = null;
             _selectedPlanetId = null;
             _state.SelectedThreat = null;
+            _state.ResetDistressSignalThirdPartyLock();
             _selectedThirdParties.Clear();
             var sequenceId = _voteSequenceId;
             var presetVote = StartPresetVote(sequenceId, presetId =>
@@ -376,6 +379,17 @@ namespace Content.Server.AU14.Round
 
         private void PreselectThirdParties()
         {
+            if (_state.DistressSignalThirdPartiesLocked &&
+                _selectedPreset?.ID.Equals(DistressSignalPresetId, StringComparison.OrdinalIgnoreCase) == true)
+            {
+                FillLockedDistressSignalThirdPartiesForSelectedThreat();
+                _sawmill.Debug(
+                    $"[AuRoundSystem] Keeping pre-round Distress Signal third-party selection: selected={
+                        _selectedThirdParties.Count}, survivors={_state.DistressSignalSurvivorCount}, fillCompleted={
+                            _state.DistressSignalThirdPartyFillCompleted}.");
+                return;
+            }
+
             _selectedThirdParties.Clear();
             Logger.GetSawmill("content").Debug(
                 $"[AuRoundSystem] PreselectThirdParties start: preset={_selectedPreset?.ID ?? "null"}, planet={_selectedPlanet?.MapId ?? "null"}, threat={SelectedThreat?.ID ?? "null"}.");
@@ -429,11 +443,7 @@ namespace Content.Server.AU14.Round
                 GetThirdPartyBodyCount,
                 out var selectedBodyCount);
 
-            var roundStartParties = selected.Where(party => party.RoundStart).ToList();
-            var delayedParties = selected.Where(party => !party.RoundStart).ToList();
-
-            _selectedThirdParties.AddRange(roundStartParties);
-            _selectedThirdParties.AddRange(delayedParties);
+            SetSelectedThirdPartiesInSpawnOrder(selected);
             if (_sawmill.Level <= Robust.Shared.Log.LogLevel.Debug)
             {
                 _sawmill.Debug(
@@ -479,7 +489,9 @@ namespace Content.Server.AU14.Round
             if (maxThirdParties <= 0 || bodyBudget <= 0 || candidates.Count == 0)
                 return selected;
 
-            var remaining = candidates.ToList();
+            var remaining = candidates
+                .DistinctBy(candidate => candidate.ID, StringComparer.OrdinalIgnoreCase)
+                .ToList();
             while (selected.Count < maxThirdParties &&
                    selectedBodyCount < bodyBudget &&
                    remaining.Count > 0)
@@ -558,6 +570,230 @@ namespace Content.Server.AU14.Round
         public void PreselectThirdPartiesForSelectedThreat()
         {
             PreselectThirdParties();
+        }
+
+        private void FillLockedDistressSignalThirdPartiesForSelectedThreat()
+        {
+            var selectedThreat = SelectedThreat;
+            var selectedPlanet = _selectedPlanet;
+            if (_state.DistressSignalThirdPartyFillCompleted ||
+                selectedThreat == null ||
+                selectedPlanet == null)
+            {
+                return;
+            }
+
+            var playerCount = _playerManager.PlayerCount;
+            var bodyBudget = CalculateThirdPartyBodyBudget(playerCount, selectedThreat.ThirdPartyRatio);
+            if (TryCalculateThreatBodyCount(selectedThreat, playerCount, out var threatBodyCount))
+                bodyBudget = Math.Min(bodyBudget, threatBodyCount.Total);
+            var maxThirdParties = Math.Max(0, selectedThreat.MaxThirdParties);
+
+            var candidates = new List<ThirdPartyPrototype>();
+            foreach (var partyId in selectedPlanet.ThirdParties)
+            {
+                if (!_prototypeManager.TryIndex(partyId, out ThirdPartyPrototype? party))
+                {
+                    _sawmill.Warning($"[AuRoundSystem] Could not find ThirdPartyPrototype for ID: {partyId}");
+                    continue;
+                }
+
+                if (IsThirdPartyAllowedForCurrentContext(party))
+                    candidates.Add(party);
+            }
+
+            List<ThirdPartyPrototype> additional = SelectAdditionalDistressSignalThirdParties(
+                candidates,
+                _selectedThirdParties,
+                maxThirdParties,
+                bodyBudget,
+                PickWeightedThirdParty,
+                GetThirdPartyBodyCount,
+                out var lockedBodyCount,
+                out var additionalBodyCount);
+
+            var lockedPartyCount = _selectedThirdParties.Count;
+            if (lockedPartyCount > maxThirdParties || lockedBodyCount > bodyBudget)
+            {
+                _sawmill.Warning(
+                    $"[AuRoundSystem] Locked Distress Signal third parties exceed the final threat capacity after the player count changed: selected={
+                        lockedPartyCount}/{maxThirdParties}, bodies={lockedBodyCount}/{bodyBudget}. Keeping the announced roster.");
+            }
+
+            if (additional.Count > 0)
+                SetSelectedThirdPartiesInSpawnOrder(_selectedThirdParties.Concat(additional));
+
+            _state.DistressSignalThirdPartyFillCompleted = true;
+            _sawmill.Info(
+                $"[AuRoundSystem] Completed Distress Signal third-party selection for threat {selectedThreat.ID}: locked={
+                    lockedPartyCount}, added={additional.Count}, bodies={lockedBodyCount + additionalBodyCount}/{
+                        bodyBudget}, survivors={_state.DistressSignalSurvivorCount}.");
+
+            int GetThirdPartyBodyCount(ThirdPartyPrototype party)
+                => TryCalculateThirdPartyBodyCount(party, playerCount, out var bodyCount)
+                    ? bodyCount
+                    : 0;
+        }
+
+        internal static List<ThirdPartyPrototype> SelectAdditionalDistressSignalThirdParties(
+            IReadOnlyList<ThirdPartyPrototype> candidates,
+            IReadOnlyCollection<ThirdPartyPrototype> lockedParties,
+            int maxThirdParties,
+            int bodyBudget,
+            Func<IReadOnlyList<ThirdPartyPrototype>, ThirdPartyPrototype?> pickThirdParty,
+            Func<ThirdPartyPrototype, int> getBodyCount,
+            out int lockedBodyCount,
+            out int additionalBodyCount)
+        {
+            lockedBodyCount = lockedParties.Sum(party => Math.Max(0, getBodyCount(party)));
+            var lockedIds = lockedParties
+                .Select(party => party.ID)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var fillCandidates = candidates
+                .Where(party =>
+                    !lockedIds.Contains(party.ID) &&
+                    !(party.RoundStart && party.AnnounceAsSurvivors))
+                .ToList();
+
+            return SelectThirdPartiesWithinBodyBudget(
+                fillCandidates,
+                Math.Max(0, maxThirdParties - lockedParties.Count),
+                Math.Max(0, bodyBudget - lockedBodyCount),
+                pickThirdParty,
+                getBodyCount,
+                out additionalBodyCount);
+        }
+
+        private void SetSelectedThirdPartiesInSpawnOrder(IEnumerable<ThirdPartyPrototype> selected)
+        {
+            var parties = selected.ToList();
+            _selectedThirdParties.Clear();
+            _selectedThirdParties.AddRange(parties.Where(party => party.RoundStart));
+            _selectedThirdParties.AddRange(parties.Where(party => !party.RoundStart));
+        }
+
+        /// <summary>
+        ///     Locks a safe Distress Signal third-party roster before the post-roundstart threat vote.
+        ///     The winning threat can fill any remaining capacity without changing the announced survivor count.
+        /// </summary>
+        public bool TryLockDistressSignalThirdParties(out int survivorCount)
+        {
+            survivorCount = _state.DistressSignalSurvivorCount;
+            if (_state.DistressSignalThirdPartiesLocked)
+                return true;
+
+            if (_selectedPreset?.ID.Equals(DistressSignalPresetId, StringComparison.OrdinalIgnoreCase) != true ||
+                _selectedPlanet == null)
+            {
+                return false;
+            }
+
+            var playerCount = _playerManager.PlayerCount;
+            var platoonSpawnRule = _entityManager.EntitySysManager.GetEntitySystem<PlatoonSpawnRuleSystem>();
+            var govforId = platoonSpawnRule.SelectedGovforPlatoon?.ID;
+            var opforId = platoonSpawnRule.SelectedOpforPlatoon?.ID;
+            var threatLimits = new List<(int MaxThirdParties, int BodyBudget)>();
+            var eligibleThreatIds = new List<string>();
+
+            foreach (var threatId in _selectedPlanet.AllowedThreats)
+            {
+                if (!_prototypeManager.TryIndex(threatId, out ThreatPrototype? threat) ||
+                    !ThreatVoteSelection.IsThreatAllowed(
+                        threat,
+                        DistressSignalPresetId,
+                        govforId,
+                        opforId,
+                        playerCount) ||
+                    !TryCalculateThreatBodyCount(threat, playerCount, out var threatBodyCount) ||
+                    threatBodyCount.Total <= 0)
+                {
+                    continue;
+                }
+
+                eligibleThreatIds.Add(threat.ID);
+                threatLimits.Add((
+                    Math.Max(0, threat.MaxThirdParties),
+                    CalculateThirdPartyBodyBudget(playerCount, threat.ThirdPartyRatio, threatBodyCount)));
+            }
+
+            var (maxThirdParties, bodyBudget) = GetConservativeThirdPartyLimits(threatLimits);
+            var candidates = new List<ThirdPartyPrototype>();
+            foreach (var partyId in _selectedPlanet.ThirdParties)
+            {
+                if (!_prototypeManager.TryIndex(partyId, out ThirdPartyPrototype? party))
+                {
+                    _sawmill.Warning($"[AuRoundSystem] Could not find ThirdPartyPrototype for ID: {partyId}");
+                    continue;
+                }
+
+                var allowedForEveryThreat = eligibleThreatIds.Count > 0 && eligibleThreatIds.All(threatId =>
+                    IsThirdPartyAllowed(
+                        party,
+                        DistressSignalPresetId,
+                        threatId,
+                        govforId,
+                        opforId,
+                        playerCount));
+                if (allowedForEveryThreat)
+                    candidates.Add(party);
+            }
+
+            var bodyCounts = new Dictionary<ThirdPartyPrototype, int>();
+            foreach (var party in candidates)
+            {
+                bodyCounts[party] = TryCalculateThirdPartyBodyCount(party, playerCount, out var count)
+                    ? count
+                    : 0;
+            }
+
+            List<ThirdPartyPrototype> selected = SelectThirdPartiesWithinBodyBudget(
+                candidates,
+                maxThirdParties,
+                bodyBudget,
+                PickWeightedThirdParty,
+                party => bodyCounts[party],
+                out var selectedBodyCount);
+
+            SetSelectedThirdPartiesInSpawnOrder(selected);
+            survivorCount = CalculateAnnouncedSurvivorCount(selected, party => bodyCounts[party]);
+            _state.DistressSignalSurvivorCount = survivorCount;
+            _state.DistressSignalThirdPartiesLocked = true;
+            _state.DistressSignalThirdPartyFillCompleted = false;
+
+            _sawmill.Info(
+                $"[AuRoundSystem] Locked Distress Signal third parties before round start: selected={
+                    selected.Count}, bodies={selectedBodyCount}/{bodyBudget}, survivors={survivorCount}, eligibleThreats=[{
+                        string.Join(", ", eligibleThreatIds)}].");
+
+            return true;
+        }
+
+        internal static (int MaxThirdParties, int BodyBudget) GetConservativeThirdPartyLimits(
+            IReadOnlyCollection<(int MaxThirdParties, int BodyBudget)> threatLimits)
+        {
+            if (threatLimits.Count == 0)
+                return default;
+
+            return (
+                threatLimits.Min(limit => Math.Max(0, limit.MaxThirdParties)),
+                threatLimits.Min(limit => Math.Max(0, limit.BodyBudget)));
+        }
+
+        internal static int CalculateAnnouncedSurvivorCount(
+            IEnumerable<ThirdPartyPrototype> selected,
+            Func<ThirdPartyPrototype, int> getBodyCount)
+        {
+            return selected
+                .Where(party => party.RoundStart && party.AnnounceAsSurvivors)
+                .Sum(getBodyCount);
+        }
+
+        /// <summary>
+        ///     Clears the committed pre-round roster without disturbing ordinary third-party preselection.
+        /// </summary>
+        public void ResetLockedDistressSignalThirdParties()
+        {
+            _state.ResetDistressSignalThirdPartyLock();
         }
 
         private void StartPlatoonVotes(int sequenceId)

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -245,6 +245,7 @@ namespace Content.Server.GameTicking
                     return;
 
                 _roundStartCountdownHasNotStartedYetDueToNoPlayers = true;
+                ResetDistressSignalSurvivorAnnouncement();
                 _roundStartTime = TimeSpan.Zero;
             }
             else
@@ -253,6 +254,7 @@ namespace Content.Server.GameTicking
                     return;
 
                 _roundStartCountdownHasNotStartedYetDueToNoPlayers = false;
+                ResetDistressSignalSurvivorAnnouncement();
                 _roundStartTime = _gameTiming.CurTime + LobbyDuration;
             }
 

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -447,6 +447,8 @@ namespace Content.Server.GameTicking
                 return;
             }
 
+            EnsureDistressSignalSurvivorAnnouncement();
+
             if (RoundId == 0)
                 IncrementRoundNumber();
             ReplayStartRound();
@@ -1123,6 +1125,8 @@ namespace Content.Server.GameTicking
         /// </summary>
         private void ResettingCleanup()
         {
+            ResetDistressSignalSurvivorAnnouncement();
+
             // Move everybody currently in the server to lobby.
             foreach (var player in _playerManager.Sessions)
             {
@@ -1167,6 +1171,9 @@ namespace Content.Server.GameTicking
 
             _roundStartTime += time;
 
+            if (_roundStartTime - _gameTiming.CurTime > DistressSignalSurvivorAnnouncementLeadTime)
+                ResetDistressSignalSurvivorAnnouncement();
+
             RaiseNetworkEvent(new TickerLobbyCountdownEvent(_roundStartTime, Paused));
 
             _chatManager.DispatchServerAnnouncement(Loc.GetString("game-ticker-delay-start", ("seconds", time.TotalSeconds)));
@@ -1194,6 +1201,8 @@ namespace Content.Server.GameTicking
                 UpdateLobbyCountdownForPlayerCount();
                 return;
             }
+
+            TryAnnounceDistressSignalSurvivors();
 
             if (_roundStartTime == TimeSpan.Zero ||
                 RunLevel != GameRunLevel.PreRoundLobby ||

--- a/Content.Server/_CMU14/GameTicking/GameTicker.DistressSignalSurvivors.cs
+++ b/Content.Server/_CMU14/GameTicking/GameTicker.DistressSignalSurvivors.cs
@@ -1,0 +1,74 @@
+using Content.Shared.GameTicking;
+
+namespace Content.Server.GameTicking;
+
+public sealed partial class GameTicker
+{
+    internal static readonly TimeSpan DistressSignalSurvivorAnnouncementLeadTime = TimeSpan.FromMinutes(1);
+
+    private bool _distressSignalSurvivorAnnouncementSent;
+
+    private void TryAnnounceDistressSignalSurvivors()
+    {
+        if (!IsDistressSignalSurvivorAnnouncementDue(
+                LobbyEnabled,
+                RunLevel,
+                Paused,
+                _distressSignalSurvivorAnnouncementSent,
+                _roundStartTime,
+                _gameTiming.CurTime))
+        {
+            return;
+        }
+
+        TryLockAndAnnounceDistressSignalSurvivors();
+    }
+
+    private void EnsureDistressSignalSurvivorAnnouncement()
+    {
+        if (_distressSignalSurvivorAnnouncementSent)
+            return;
+
+        TryLockAndAnnounceDistressSignalSurvivors();
+    }
+
+    private bool TryLockAndAnnounceDistressSignalSurvivors()
+    {
+        if (!_auRoundSystem.TryLockDistressSignalThirdParties(out var survivorCount))
+            return false;
+
+        _distressSignalSurvivorAnnouncementSent = true;
+        var message = survivorCount > 0
+            ? Loc.GetString("cmu-distress-signal-survivors-spawning", ("count", survivorCount))
+            : Loc.GetString("cmu-distress-signal-no-survivors");
+        _chatManager.DispatchServerAnnouncement(message);
+        return true;
+    }
+
+    private void ResetDistressSignalSurvivorAnnouncement()
+    {
+        _distressSignalSurvivorAnnouncementSent = false;
+        _auRoundSystem.ResetLockedDistressSignalThirdParties();
+    }
+
+    internal static bool IsDistressSignalSurvivorAnnouncementDue(
+        bool lobbyEnabled,
+        GameRunLevel runLevel,
+        bool paused,
+        bool announcementSent,
+        TimeSpan roundStartTime,
+        TimeSpan currentTime)
+    {
+        if (!lobbyEnabled ||
+            runLevel != GameRunLevel.PreRoundLobby ||
+            paused ||
+            announcementSent ||
+            roundStartTime == TimeSpan.Zero)
+        {
+            return false;
+        }
+
+        var timeLeft = roundStartTime - currentTime;
+        return timeLeft > TimeSpan.Zero && timeLeft <= DistressSignalSurvivorAnnouncementLeadTime;
+    }
+}

--- a/Content.Shared/_CMU14/Ops/ThirdParty/ThirdPartyPrototype.cs
+++ b/Content.Shared/_CMU14/Ops/ThirdParty/ThirdPartyPrototype.cs
@@ -59,6 +59,12 @@ public sealed partial class ThirdPartyPrototype : IPrototype
     [DataField("roundstart", required: false)]
     public bool RoundStart { get; private set; }
 
+    /// <summary>
+    ///     Whether this party belongs to a faction included in the Distress Signal survivor announcement.
+    /// </summary>
+    [DataField]
+    public bool AnnounceAsSurvivors { get; private set; }
+
     [DataField("partyspawn", required: true)]
     public ProtoId<PartySpawnPrototype> PartySpawn { get; private set; }
 

--- a/Content.Tests/Server/AU14/Round/AuJobSelectionTest.cs
+++ b/Content.Tests/Server/AU14/Round/AuJobSelectionTest.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Content.Server._CMU14.Threats;
 using Content.Server.AU14.Round;
+using Content.Server.GameTicking;
 using Content.Shared._RMC14.Rules;
 using Content.Shared._CMU14.Threats;
 using Content.Shared.Preferences;
@@ -148,9 +149,9 @@ public sealed class AuJobSelectionTest
     [Test]
     public void ThirdPartySelectionSkipsPartiesThatDoNotFitRemainingBodyBudget()
     {
-        var large = CreateThirdPartyPrototype();
-        var medium = CreateThirdPartyPrototype();
-        var small = CreateThirdPartyPrototype();
+        var large = CreateThirdPartyPrototype("Large");
+        var medium = CreateThirdPartyPrototype("Medium");
+        var small = CreateThirdPartyPrototype("Small");
         var bodyCounts = new Dictionary<ThirdPartyPrototype, int>
         {
             [large] = 8,
@@ -172,6 +173,223 @@ public sealed class AuJobSelectionTest
 
         static ThirdPartyPrototype PickFirst(IReadOnlyList<ThirdPartyPrototype> candidates)
             => candidates[0];
+    }
+
+    [Test]
+    public void ThirdPartySelectionDoesNotSelectDuplicatePrototypeIds()
+    {
+        var duplicate = CreateThirdPartyPrototype("Duplicate");
+        var duplicateWithDifferentCase = CreateThirdPartyPrototype("duplicate");
+        var other = CreateThirdPartyPrototype("Other");
+
+        var selected = AuRoundSystem.SelectThirdPartiesWithinBodyBudget(
+            [duplicate, duplicateWithDifferentCase, other],
+            maxThirdParties: 3,
+            bodyBudget: 3,
+            PickFirst,
+            _ => 1,
+            out var selectedBodies);
+
+        Assert.That(selected, Is.EqualTo(new[] { duplicate, other }));
+        Assert.That(selectedBodies, Is.EqualTo(2));
+        return;
+
+        static ThirdPartyPrototype PickFirst(IReadOnlyList<ThirdPartyPrototype> candidates)
+            => candidates[0];
+    }
+
+    [Test]
+    public void DistressSignalThirdPartyFillUsesRemainingThreatCapacity()
+    {
+        var lockedLarge = CreateThirdPartyPrototype("LockedLarge");
+        var lockedSmall = CreateThirdPartyPrototype("LockedSmall");
+        var tooLarge = CreateThirdPartyPrototype("TooLarge");
+        var fits = CreateThirdPartyPrototype("Fits");
+        var tiny = CreateThirdPartyPrototype("Tiny");
+        var bodyCounts = new Dictionary<ThirdPartyPrototype, int>
+        {
+            [lockedLarge] = 4,
+            [lockedSmall] = 2,
+            [tooLarge] = 4,
+            [fits] = 2,
+            [tiny] = 1,
+        };
+
+        var additional = AuRoundSystem.SelectAdditionalDistressSignalThirdParties(
+            [lockedLarge, lockedSmall, tooLarge, fits, tiny],
+            [lockedLarge, lockedSmall],
+            maxThirdParties: 3,
+            bodyBudget: 9,
+            PickFirst,
+            party => bodyCounts[party],
+            out var lockedBodies,
+            out var additionalBodies);
+
+        Assert.That(additional, Is.EqualTo(new[] { fits }));
+        Assert.That(lockedBodies, Is.EqualTo(6));
+        Assert.That(additionalBodies, Is.EqualTo(2));
+        return;
+
+        static ThirdPartyPrototype PickFirst(IReadOnlyList<ThirdPartyPrototype> candidates)
+            => candidates[0];
+    }
+
+    [Test]
+    public void DistressSignalThirdPartyFillPreservesAnnouncedSurvivorCount()
+    {
+        var lockedSurvivor = CreateThirdPartyPrototype(
+            "LockedSurvivor",
+            roundStart: true,
+            announceAsSurvivors: true);
+        var duplicateLockedParty = CreateThirdPartyPrototype("LockedSurvivor");
+        var additionalSurvivor = CreateThirdPartyPrototype(
+            "AdditionalSurvivor",
+            roundStart: true,
+            announceAsSurvivors: true);
+        var delayedSurvivor = CreateThirdPartyPrototype(
+            "DelayedSurvivor",
+            announceAsSurvivors: true);
+        var unrelatedRoundStart = CreateThirdPartyPrototype("UnrelatedRoundStart", roundStart: true);
+        var bodyCounts = new Dictionary<ThirdPartyPrototype, int>
+        {
+            [lockedSurvivor] = 3,
+            [duplicateLockedParty] = 3,
+            [additionalSurvivor] = 2,
+            [delayedSurvivor] = 2,
+            [unrelatedRoundStart] = 1,
+        };
+
+        var additional = AuRoundSystem.SelectAdditionalDistressSignalThirdParties(
+            [duplicateLockedParty, additionalSurvivor, delayedSurvivor, unrelatedRoundStart],
+            [lockedSurvivor],
+            maxThirdParties: 3,
+            bodyBudget: 10,
+            PickFirst,
+            party => bodyCounts[party],
+            out var lockedBodies,
+            out var additionalBodies);
+
+        Assert.That(additional, Is.EqualTo(new[] { delayedSurvivor, unrelatedRoundStart }));
+        Assert.That(lockedBodies, Is.EqualTo(3));
+        Assert.That(additionalBodies, Is.EqualTo(3));
+        Assert.That(
+            AuRoundSystem.CalculateAnnouncedSurvivorCount(
+                new[] { lockedSurvivor }.Concat(additional),
+                party => bodyCounts[party]),
+            Is.EqualTo(3));
+        return;
+
+        static ThirdPartyPrototype PickFirst(IReadOnlyList<ThirdPartyPrototype> candidates)
+            => candidates[0];
+    }
+
+    [Test]
+    public void DistressSignalThirdPartyLimitsUseMostRestrictiveThreat()
+    {
+        var limits = AuRoundSystem.GetConservativeThirdPartyLimits(
+        [
+            (MaxThirdParties: 7, BodyBudget: 8),
+            (MaxThirdParties: 3, BodyBudget: 10),
+            (MaxThirdParties: 5, BodyBudget: 4),
+        ]);
+
+        Assert.That(limits.MaxThirdParties, Is.EqualTo(3));
+        Assert.That(limits.BodyBudget, Is.EqualTo(4));
+        Assert.That(AuRoundSystem.GetConservativeThirdPartyLimits([]), Is.EqualTo(default((int, int))));
+    }
+
+    [Test]
+    public void SurvivorCountIncludesOnlyApprovedPartyFamilies()
+    {
+        var approvedRoundStart = CreateThirdPartyPrototype(roundStart: true, announceAsSurvivors: true);
+        var approvedDelayed = CreateThirdPartyPrototype(announceAsSurvivors: true);
+        var unrelated = CreateThirdPartyPrototype(roundStart: true);
+        var bodyCounts = new Dictionary<ThirdPartyPrototype, int>
+        {
+            [approvedRoundStart] = 3,
+            [approvedDelayed] = 2,
+            [unrelated] = 8,
+        };
+
+        var count = AuRoundSystem.CalculateAnnouncedSurvivorCount(
+            [approvedRoundStart, approvedDelayed, unrelated],
+            party => bodyCounts[party]);
+
+        Assert.That(count, Is.EqualTo(3));
+    }
+
+    [Test]
+    public void ResettingDistressSignalLockPreservesOrdinaryThirdPartySelection()
+    {
+        var state = new AuRoundSelectionState();
+        var ordinaryParty = CreateThirdPartyPrototype();
+        state.SelectedThirdParties.Add(ordinaryParty);
+
+        state.ResetDistressSignalThirdPartyLock();
+
+        Assert.That(state.SelectedThirdParties, Is.EqualTo(new[] { ordinaryParty }));
+
+        state.DistressSignalThirdPartiesLocked = true;
+        state.DistressSignalThirdPartyFillCompleted = true;
+        state.DistressSignalSurvivorCount = 3;
+        state.ResetDistressSignalThirdPartyLock();
+
+        Assert.That(state.SelectedThirdParties, Is.Empty);
+        Assert.That(state.DistressSignalThirdPartiesLocked, Is.False);
+        Assert.That(state.DistressSignalThirdPartyFillCompleted, Is.False);
+        Assert.That(state.DistressSignalSurvivorCount, Is.Zero);
+    }
+
+    [Test]
+    public void DistressSignalSurvivorAnnouncementTriggersOnceAtOneMinute()
+    {
+        var roundStart = TimeSpan.FromMinutes(10);
+
+        Assert.That(
+            GameTicker.IsDistressSignalSurvivorAnnouncementDue(
+                true,
+                GameRunLevel.PreRoundLobby,
+                false,
+                false,
+                roundStart,
+                roundStart - TimeSpan.FromSeconds(61)),
+            Is.False);
+        Assert.That(
+            GameTicker.IsDistressSignalSurvivorAnnouncementDue(
+                true,
+                GameRunLevel.PreRoundLobby,
+                false,
+                false,
+                roundStart,
+                roundStart - TimeSpan.FromSeconds(60)),
+            Is.True);
+        Assert.That(
+            GameTicker.IsDistressSignalSurvivorAnnouncementDue(
+                true,
+                GameRunLevel.PreRoundLobby,
+                false,
+                false,
+                roundStart,
+                roundStart - TimeSpan.FromSeconds(59.5)),
+            Is.True);
+        Assert.That(
+            GameTicker.IsDistressSignalSurvivorAnnouncementDue(
+                true,
+                GameRunLevel.PreRoundLobby,
+                false,
+                true,
+                roundStart,
+                roundStart - TimeSpan.FromSeconds(30)),
+            Is.False);
+        Assert.That(
+            GameTicker.IsDistressSignalSurvivorAnnouncementDue(
+                true,
+                GameRunLevel.PreRoundLobby,
+                true,
+                false,
+                roundStart,
+                roundStart - TimeSpan.FromSeconds(30)),
+            Is.False);
     }
 
     [Test]
@@ -202,6 +420,24 @@ public sealed class AuJobSelectionTest
         return planet;
     }
 
-    private static ThirdPartyPrototype CreateThirdPartyPrototype()
-        => (ThirdPartyPrototype) RuntimeHelpers.GetUninitializedObject(typeof(ThirdPartyPrototype));
+    private static ThirdPartyPrototype CreateThirdPartyPrototype(
+        string id = "TestThirdParty",
+        bool roundStart = false,
+        bool announceAsSurvivors = false)
+    {
+        var party = (ThirdPartyPrototype) RuntimeHelpers.GetUninitializedObject(typeof(ThirdPartyPrototype));
+        typeof(ThirdPartyPrototype)
+            .GetField($"<{nameof(ThirdPartyPrototype.ID)}>k__BackingField",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(party, id);
+        typeof(ThirdPartyPrototype)
+            .GetField($"<{nameof(ThirdPartyPrototype.RoundStart)}>k__BackingField",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(party, roundStart);
+        typeof(ThirdPartyPrototype)
+            .GetField($"<{nameof(ThirdPartyPrototype.AnnounceAsSurvivors)}>k__BackingField",
+                BindingFlags.Instance | BindingFlags.NonPublic)!
+            .SetValue(party, announceAsSurvivors);
+        return party;
+    }
 }

--- a/Resources/Locale/en-US/_CMU14/game-presets/distress-signal-survivors.ftl
+++ b/Resources/Locale/en-US/_CMU14/game-presets/distress-signal-survivors.ftl
@@ -1,0 +1,7 @@
+cmu-distress-signal-survivors-spawning =
+    {$count ->
+        [one] {$count} survivor is scheduled to spawn at round start.
+       *[other] {$count} survivors are scheduled to spawn at round start.
+    }
+
+cmu-distress-signal-no-survivors = No survivors are scheduled to spawn at round start.

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/VAIPO/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/VAIPO/third_party.yml
@@ -13,6 +13,7 @@
 
 - type: thirdParty
   id: VAIPO
+  announceAsSurvivors: true
   partyspawn: VAIPOSpawn
   entrymethod: shuttle
   weight: 20

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/VAISO/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/VAISO/third_party.yml
@@ -13,6 +13,7 @@
 
 - type: thirdParty
   id: VAISO
+  announceAsSurvivors: true
   partyspawn: VAISOSpawn
   blacklistedgamemodes:
     - insurgency

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/VAISP/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/VAISP/third_party.yml
@@ -10,6 +10,7 @@
 
 - type: thirdParty
   id: VAISP
+  announceAsSurvivors: true
   partyspawn: VAISPSpawn
   entrymethod: shuttle
   weight: 20

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/WeYu/HazardTransport/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/WeYu/HazardTransport/third_party.yml
@@ -11,6 +11,7 @@
 
 - type: thirdParty
   id: WYHT
+  announceAsSurvivors: true
   partyspawn: WYHTSpawn
   whitelistedgamemodes:
     - insurgency

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/WeYu/IPIE/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/WeYu/IPIE/third_party.yml
@@ -9,6 +9,7 @@
 
 - type: thirdParty
   id: IPIE
+  announceAsSurvivors: true
   partyspawn: IPIESpawn
   whitelistedgamemodes:
     - insurgency
@@ -32,6 +33,7 @@
 
 - type: thirdParty
   id: IPIESynth
+  announceAsSurvivors: true
   partyspawn: IPIESynthSpawn
   whitelistedgamemodes:
     - insurgency

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/WeYu/PMCParty/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/WeYu/PMCParty/third_party.yml
@@ -15,6 +15,7 @@
 
 - type: thirdParty
   id: WYPMCParty
+  announceAsSurvivors: true
   partyspawn: WYPMCPartySpawn
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_pmc_shuttle.yml
@@ -39,6 +40,7 @@
 
 - type: thirdParty
   id: WYPMCPartyAlt
+  announceAsSurvivors: true
   partyspawn: WYPMCPartySpawnAlt
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_pmc_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/WeYu/Survivors/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/WeYu/Survivors/third_party.yml
@@ -13,6 +13,7 @@
 
 - type: thirdParty
   id: WEYUSurvLarge
+  announceAsSurvivors: true
   displayName: Weyland-Yutani Survivors
   partyspawn: WEYUSurvSpawnLarge
   blacklistedgamemodes:
@@ -40,6 +41,7 @@
 
 - type: thirdParty
   id: WEYUSurvMedium
+  announceAsSurvivors: true
   displayName: Weyland-Yutani Survivors
   partyspawn: WEYUSurvSpawnMedium
   blacklistedgamemodes:
@@ -66,6 +68,7 @@
 
 - type: thirdParty
   id: WEYUSurvSmall
+  announceAsSurvivors: true
   displayName: Weyland-Yutani Survivors
   partyspawn: WEYUSurvSpawnSmall
   blacklistedgamemodes:
@@ -78,4 +81,3 @@
   maxplayers: 50
   GhostsNeeded: 0
   roundstart: true
-

--- a/Resources/Prototypes/_CMU14/ThirdParties/Insurgents/CLF/Reinforcements/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Insurgents/CLF/Reinforcements/third_party.yml
@@ -9,6 +9,7 @@
 
 - type: thirdParty
   id: CLFCellReinforcementsIntel
+  announceAsSurvivors: true
   partyspawn: CLFReinforcementsSpawnIntel
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_clf_shuttle.yml
@@ -29,6 +30,7 @@
 
 - type: thirdParty
   id: CLFCellReinforcementsIntelMachineGunner
+  announceAsSurvivors: true
   partyspawn: CLFReinforcementsSpawnIntelMachineGunner
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_clf_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Insurgents/CLF/Survivors/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Insurgents/CLF/Survivors/third_party.yml
@@ -10,6 +10,7 @@
 
 - type: thirdParty
   id: CLFSurvsBig
+  announceAsSurvivors: true
   partyspawn: CLFSurvsSpawnBig
   blacklistedgamemodes:
     - insurgency
@@ -34,7 +35,8 @@
 
 - type: thirdParty
   id: CLFSurvsMedium
-  partyspawn: CLFSurvsSpawnBig
+  announceAsSurvivors: true
+  partyspawn: CLFSurvsSpawnMedium
   blacklistedgamemodes:
     - insurgency
     - forceonforce
@@ -58,7 +60,8 @@
 
 - type: thirdParty
   id: CLFSurvsSmall
-  partyspawn: CLFSurvsSpawnBig
+  announceAsSurvivors: true
+  partyspawn: CLFSurvsSpawnSmall
   blacklistedgamemodes:
     - insurgency
     - forceonforce

--- a/Resources/Prototypes/_CMU14/ThirdParties/LawEnforcement/NSPA/Investigation/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/LawEnforcement/NSPA/Investigation/third_party.yml
@@ -11,6 +11,7 @@
 
 - type: thirdParty
   id: NSPAInvestigationParty
+  announceAsSurvivors: true
   partyspawn: NSPAInvestigationPartySpawn
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_tsepa_shuttle.yml
@@ -31,6 +32,7 @@
 
 - type: thirdParty
   id: NSPAInvestigationPartyArmored
+  announceAsSurvivors: true
   partyspawn: NSPAInvestigationPartySpawnArmored
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_tsepa_shuttle.yml
@@ -53,6 +55,7 @@
 
 - type: thirdParty
   id: NSPAInvestigationPartyAlt
+  announceAsSurvivors: true
   partyspawn: NSPAInvestigationPartySpawnAlt
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_tsepa_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/LawEnforcement/PaP/Investigation/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/LawEnforcement/PaP/Investigation/third_party.yml
@@ -21,6 +21,7 @@
 
 - type: thirdParty
   id: PAPInvestigationPartyAlt
+  announceAsSurvivors: true
   partyspawn: PAPInvestigationPartySpawnAlt
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_tsepa_shuttle.yml
@@ -32,6 +33,7 @@
 
 - type: thirdParty
   id: PAPInvestigationParty
+  announceAsSurvivors: true
   partyspawn: PAPInvestigationPartySpawn
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_tsepa_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Detachment/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Detachment/third_party.yml
@@ -9,6 +9,7 @@
 
 - type: thirdParty
   id: AU14IntelThirdPartyMarksmanGOVFOR
+  announceAsSurvivors: true
   partyspawn: AU14IntelThirdPartyMarksmanFORECONGOVFORSpawner
   entrymethod: shuttle #todo au14 entrymethod intel spawn/shipside
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_response_shuttle.yml
@@ -29,6 +30,7 @@
 
 - type: thirdParty
   id: AU14IntelThirdPartySniperGOVFOR
+  announceAsSurvivors: true
   partyspawn: AU14IntelThirdPartySniperFORECONGOVFORSpawner
   entrymethod: shuttle #todo au14 entrymethod intel spawn/shipside
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_response_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/FirstRecon/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/FirstRecon/third_party.yml
@@ -11,6 +11,7 @@
 
 - type: thirdParty
   id: FORECONFirstRecon
+  announceAsSurvivors: true
   partyspawn: AU14FORECONFirstReconSpawner
   entrymethod: shuttle 
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_response_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/KillTeam/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/KillTeam/third_party.yml
@@ -9,6 +9,7 @@
 
 - type: thirdParty
   id: FORECONKillTeam
+  announceAsSurvivors: true
   partyspawn: AU14FORECONKillTeamSpawner
   entrymethod: shuttle 
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_response_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Survivors/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Survivors/third_party.yml
@@ -14,6 +14,7 @@
 
 - type: thirdParty
   id: FORECON
+  announceAsSurvivors: true
   partyspawn: FORECONSpawn
   blacklistedgamemodes:
     - insurgency
@@ -42,6 +43,7 @@
 
 - type: thirdParty
   id: FORECONAlt
+  announceAsSurvivors: true
   partyspawn: FORECONSpawnAlt
   blacklistedgamemodes:
     - insurgency
@@ -70,6 +72,7 @@
 
 - type: thirdParty
   id: FORECONAlt2
+  announceAsSurvivors: true
   partyspawn: FORECONSpawnAlt2
   blacklistedgamemodes:
     - insurgency

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/LACN/SniperTeam/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/LACN/SniperTeam/third_party.yml
@@ -9,6 +9,7 @@
 
 - type: thirdParty
   id: LACNSniperteam
+  announceAsSurvivors: true
   partyspawn: LACNSniperteamSpawn
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_response_shuttle.yml
@@ -20,6 +21,7 @@
 
 - type: thirdParty
   id: LACNSniperteamIntel
+  announceAsSurvivors: true
   partyspawn: LACNSniperteamSpawn
   entrymethod: shuttle #todo au14 entrymethod intel spawn/shipside
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_response_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/GROM/Team/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/GROM/Team/third_party.yml
@@ -14,6 +14,7 @@
 
 - type: thirdParty
   id: UPPGROM
+  announceAsSurvivors: true
   partyspawn: UPPGROMSpawn
   blacklistedgamemodes:
     - insurgency
@@ -43,6 +44,7 @@
 
 - type: thirdParty
   id: UPPGROMAlt
+  announceAsSurvivors: true
   partyspawn: UPPGROMSpawnAlt
   blacklistedgamemodes:
     - insurgency
@@ -72,6 +74,7 @@
 
 - type: thirdParty
   id: UPPGROMAlt2
+  announceAsSurvivors: true
   partyspawn: UPPGROMSpawnAlt2
   blacklistedgamemodes:
     - insurgency

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/TerritorialDefense/LostTeam/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/TerritorialDefense/LostTeam/third_party.yml
@@ -10,6 +10,7 @@
 
 - type: thirdParty
   id: UPPTDLostTeam
+  announceAsSurvivors: true
   partyspawn: UPPTDLostTeamSpawn
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_spp_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/ArmoredResponse/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/ArmoredResponse/third_party.yml
@@ -15,6 +15,7 @@
 
 - type: thirdParty
   id: USArmyArmored
+  announceAsSurvivors: true
   partyspawn: USArmyArmoredSpawn
   entrymethod: shuttle
   dropshippath: /Maps/_AU14/ShuttlesDropships/rmc_ert_response_shuttle.yml

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/LostTankers/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/LostTankers/third_party.yml
@@ -11,6 +11,7 @@
 
 - type: thirdParty
   id: USArmyTank
+  announceAsSurvivors: true
   partyspawn: USArmyTankSpawn
   entrymethod: ground
   weight: 20

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/Survivors/third_party.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/Survivors/third_party.yml
@@ -15,6 +15,7 @@
 
 - type: thirdParty
   id: USArmy
+  announceAsSurvivors: true
   displayName: US Army Infantry (Full Squad)
   partyspawn: USArmySpawn
   blacklistedgamemodes:
@@ -41,6 +42,7 @@
 
 - type: thirdParty
   id: USArmyAlt
+  announceAsSurvivors: true
   displayName: US Army Infantry (Small Team)
   partyspawn: USArmySpawnAlt
   blacklistedgamemodes:
@@ -69,6 +71,7 @@
 
 - type: thirdParty
   id: USArmyAlt2
+  announceAsSurvivors: true
   displayName: US Army Infantry (Medium Team)
   partyspawn: USArmySpawnAlt2
   blacklistedgamemodes:


### PR DESCRIPTION
:cl:
- add: Distress Signal now announces one minute before round start whether any round-start survivors are scheduled to spawn and how many.