### PR TITLE
Alcohol Mess Hall

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/Recipes/Reactions/drinks.yml
@@ -829,15 +829,15 @@
 - type: reaction
   id: Mead
   reactants:
-    RMCBlackGoo: # TODO RMC14 remove this later
-      amount: 0.5
     RMCSugar: #Changed for RMC
       amount: 1
       # TODO replace Sugar with Honey once added
     Enzyme:
       amount: 1
+    Water:
+      amount: 1
   products:
-    Mead: 2
+    Mead: 3
 
 - type: reaction
   id: Mojito

--- a/Resources/Prototypes/_CMU14/Entities/Objects/Kits/Universal/platoonofficer_kits.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Kits/Universal/platoonofficer_kits.yml
@@ -216,7 +216,7 @@
   - type: Storage
     maxItemSize: Ginormous
     grid:
-    - 0,0,5,6
+    - 0,0,5,10
   - type: StorageFill
     contents:
     - id: CMHeadBeretCMP
@@ -243,8 +243,8 @@
       amount: 1
     - id: RMCAttachmentRailFlashlight
       amount: 1
-    - id: RMCSpeedLoaderRsh9 # TODO: munition swap/fix
-      amount: 3
+    - id: RMCSpeedLoaderRsh9 # TODO: munition swap/fix UPDATE: Done?
+      amount: 6
     - id: RMCBeltBrowne
       amount: 1
     - id: AU14TeleBaton

--- a/Resources/Prototypes/_CMU14/Entities/Objects/Kits/Universal/platoonofficer_kits.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Kits/Universal/platoonofficer_kits.yml
@@ -243,7 +243,7 @@
       amount: 1
     - id: RMCAttachmentRailFlashlight
       amount: 1
-    - id: RMCSpeedLoaderRsh9 # TODO: munition swap/fix UPDATE: Done?
+    - id: RMCSpeedLoaderRsh9 # TODO: munition swap/fix
       amount: 3
     - id: RMCBeltBrowne
       amount: 1

--- a/Resources/Prototypes/_CMU14/Entities/Objects/Kits/Universal/platoonofficer_kits.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Kits/Universal/platoonofficer_kits.yml
@@ -216,7 +216,7 @@
   - type: Storage
     maxItemSize: Ginormous
     grid:
-    - 0,0,5,10
+    - 0,0,5,6
   - type: StorageFill
     contents:
     - id: CMHeadBeretCMP
@@ -244,7 +244,7 @@
     - id: RMCAttachmentRailFlashlight
       amount: 1
     - id: RMCSpeedLoaderRsh9 # TODO: munition swap/fix UPDATE: Done?
-      amount: 6
+      amount: 3
     - id: RMCBeltBrowne
       amount: 1
     - id: AU14TeleBaton

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -916,6 +916,10 @@
         amount: 18
       - id: FoodOnionRed
         amount: 14
+      - id: FoodGrape
+        amount: 14
+      - id: FoodBerries
+        amount: 14
       - id: FoodGarlic
         amount: 22
       - id: ReagentContainerRice

--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/ingredients.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/ingredients.yml
@@ -42,8 +42,6 @@
   reactants:
     Enzyme:
       amount: 1
-    RMCBlackGoo: # TODO RMC14 remove this later
-      amount: 0.5
     JuiceBerry:
       amount: 1
   products:
@@ -54,8 +52,6 @@
   reactants:
     Enzyme:
       amount: 1
-    RMCBlackGoo: # TODO RMC14 remove this later
-      amount: 0.5
     JuiceOrange:
       amount: 1
   products:
@@ -66,8 +62,6 @@
   reactants:
     Enzyme:
       amount: 1
-    RMCBlackGoo: # TODO RMC14 remove this later
-      amount: 0.5
     JuicePotato:
       amount: 1
   products:
@@ -78,8 +72,6 @@
   reactants:
     Enzyme:
       amount: 1
-    RMCBlackGoo: # TODO RMC14 remove this later
-      amount: 0.5
     Rice:
       amount: 1
   products:
@@ -90,22 +82,18 @@
   reactants:
     Enzyme:
       amount: 1
-    RMCBlackGoo: # TODO RMC14 remove this later
-      amount: 0.5
     Coffee:
       amount: 1
     Sugar:
       amount: 1
   products:
-    CoffeeLiqueur: 2
+    CoffeeLiqueur: 3
 
 - type: reaction
   id: MelonLiquor
   reactants:
     Enzyme:
       amount: 1
-    RMCBlackGoo: # TODO RMC14 remove this later
-      amount: 0.5
     JuiceWatermelon:
       amount: 1
   products:
@@ -116,12 +104,150 @@
   reactants:
     Enzyme:
       amount: 1
-    RMCBlackGoo: # TODO RMC14 remove this later
-      amount: 0.5
     JuiceGrape:
       amount: 1
   products:
     Wine: 2
+
+- type: reaction
+  id: DeadRum
+  reactants:
+    Enzyme:
+      amount: 1
+    TableSalt:
+      amount: 1
+    Water:
+      amount: 1
+  products:
+    DeadRum: 3
+
+- type: reaction  
+  id: Rum
+  reactants:
+    Enzyme:
+      amount: 1
+    CoconutWater:
+      amount: 1
+  products:
+    Rum: 2
+
+- type: reaction  
+  id: Tequila
+  requiredMixerCategories:
+  - Stir
+  reactants:
+    Enzyme:
+      amount: 1
+    Wine:
+      amount: 1
+    Vodka:
+      amount: 1
+  products:
+    Tequila: 3
+
+- type: reaction  
+  id: Gin
+  requiredMixerCategories:
+  - Stir
+  reactants:
+    Vodka:
+      amount: 1
+    JuiceBerry:
+      amount: 1
+    JuiceOrange:
+      amount: 1
+  products:
+    Gin: 3
+
+- type: reaction  
+  id: Champagne
+  requiredMixerCategories:
+  - Stir
+  reactants:
+    Wine:
+      amount: 1
+    SodaWater:
+      amount: 1
+  products:
+    Champagne: 2
+
+- type: reaction  
+  id: Cognac
+  requiredMixerCategories:
+  - Stir
+  reactants:
+    Wine:
+      amount: 2
+    Vodka:
+      amount: 1
+    RMCSugar:
+      amount: 1
+  products:
+    Cognac: 4
+
+- type: reaction  
+  id: Beer
+  reactants:
+    Water:
+      amount: 1
+    Enzyme:
+      amount: 1
+    Flour:
+      amount: 1
+  products:
+    Beer: 3
+
+- type: reaction  
+  id: Ale
+  reactants:
+    Water:
+      amount: 1
+    Enzyme:
+      amount: 1
+    Cornmeal:
+      amount: 1
+  products:
+    Ale: 3
+
+- type: reaction  
+  id: Vermouth
+  requiredMixerCategories:
+  - Stir
+  reactants:
+    Cognac:
+      amount: 1
+    Gin:
+      amount: 1
+    Wine:
+      amount: 1
+  products:
+    Vermouth: 3
+
+- type: reaction  
+  id: Absinthe
+  requiredMixerCategories:
+  - Stir
+  reactants:
+    Vodka:
+      amount: 1
+    Gin:
+      amount: 1
+    BlueCuracao:
+      amount: 1
+  products:
+    Absinthe: 3
+
+- type: reaction  
+  id: Whiskey
+  reactants:
+    Enzyme:
+      amount: 1
+    RMCCornoil:
+      amount: 1
+    Flour:
+      amount: 1
+  products:
+    Whiskey: 3
 
 - type: reaction
   id: RMCMilkshake


### PR DESCRIPTION
unblackgoofied:
wine - 1 grape j. 1 enzyme
mead - 1 sugar 1 enzyme
sake - 1 rice 1 enzyme
coffee liqueur - 1 coffee 1 sugar 1 enzyme
melon liquor - 1 melon j. 1 enzyme
vodka - 1 potato j. 1 enzyme
blue curacao - 1 orange j. 1 enzyme
grenadine - 1 berry j. 1 enzyme

so on top of what was blackgooed it's also now possible to make:
rum - 1 coconutwater 1 enzyme
deadrum - 1 water 1 salt 1 enzyme
tequila - 1 vodka 1 wine 1 enzyme (stir)
gin - 1 vodka 1 orange j. 1 berry j. (stir)
cognac - 2 wine 1 vodka 1 sugar (stir)
beer - 1 water 1 flour 1 enzyme
ale - 1 water 1 cornmeal 1 enzyme
vermouth - 1 cognac 1 gin 1 wine (stir)
whiskey - 1 flour 1 cornoil 1 enzyme
champagne - 1 soda water 1 wine (stir)
absinthe - 1 vodka 1 gin 1 blue curacao (stir)

**Changelog**
:cl:
- add: Simple alcohol brewing expansion for the low price of suspense of disbelief.
- remove: Removed the black goo requirement in several alcohol recipes.
- add: Ingredients Vendor (a.k.a Galley Auxilliary) now includes 14 grapes and 14 berries.
