### PR TITLE
give weyu sec construction 2

### DIFF
--- a/Resources/Prototypes/_CMU14/Roles/WeYu/WYGuard.yml
+++ b/Resources/Prototypes/_CMU14/Roles/WeYu/WYGuard.yml
@@ -21,6 +21,7 @@
       RMCSkillCqc: 2
       RMCSkillEndurance: 2
       RMCSkillFireman: 2
+      RMCSkillConstruction: 2
       RMCSkillEngineer: 1
       RMCSkillIntel: 1
       RMCSkillVehicles: 1


### PR DESCRIPTION

## About the PR
1 line yaml to let wysec build stuff by giving them construction 2

## Why / Balance
gives more room for wysec to prevent breakouts by building cades. 

## Technical details
RMCSkillConstruction: 2

## Media
none

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- add: Added construction 2 to WeYu Security Guards