### PR TITLE
Fix limb surgery and two-point sling throws

### DIFF
--- a/Content.Server/Medical/DefibrillatorSystem.cs
+++ b/Content.Server/Medical/DefibrillatorSystem.cs
@@ -265,6 +265,8 @@ public sealed partial class DefibrillatorSystem : EntitySystem
                 damageableComponent.TotalDamage < threshold)
             {
                 _mobState.ChangeMobState(target, MobState.Critical, mob, uid);
+                // RMC14 - A fully healed target makes TryChangeDamage no-op, so refresh the state explicitly.
+                _mobThreshold.VerifyThresholds(target, thresholds, mob, damageableComponent);
                 dead = false;
             }
 

--- a/Content.Server/_CMU14/Medical/Treatment/Surgery/CMUSurgeryFlowSystem.cs
+++ b/Content.Server/_CMU14/Medical/Treatment/Surgery/CMUSurgeryFlowSystem.cs
@@ -475,7 +475,10 @@ public sealed partial class CMUSurgeryFlowSystem : SharedCMUSurgeryFlowSystem
             return;
         if (!TryComp<BodyPartComponent>(part, out var partComp))
             return;
-        if (partComp.PartType is not (BodyPartType.Arm or BodyPartType.Leg))
+        if (partComp.PartType is not (BodyPartType.Arm
+            or BodyPartType.Hand
+            or BodyPartType.Leg
+            or BodyPartType.Foot))
             return;
         if (HasComp<FractureComponent>(part) || HasComp<CMUCastComponent>(part))
             return;

--- a/Content.Server/_CMU14/Medical/Treatment/Surgery/CMUSurgeryRulebookSystem.cs
+++ b/Content.Server/_CMU14/Medical/Treatment/Surgery/CMUSurgeryRulebookSystem.cs
@@ -256,7 +256,12 @@ public sealed partial class CMUSurgeryRulebookSystem : EntitySystem
 
     private static bool IsSurgicallySupportedPart(BodyPartType type)
     {
-        return type is BodyPartType.Head or BodyPartType.Torso or BodyPartType.Arm or BodyPartType.Leg;
+        return type is BodyPartType.Head
+            or BodyPartType.Torso
+            or BodyPartType.Arm
+            or BodyPartType.Hand
+            or BodyPartType.Leg
+            or BodyPartType.Foot;
     }
 
     private string BuildConditionSummary(EntityUid part, BodyPartType partType)

--- a/Content.Shared/_CMU14/Medical/Treatment/Surgery/SharedCMUSurgeryFlowSystem.cs
+++ b/Content.Shared/_CMU14/Medical/Treatment/Surgery/SharedCMUSurgeryFlowSystem.cs
@@ -1339,7 +1339,10 @@ public abstract partial class SharedCMUSurgeryFlowSystem : EntitySystem
 
     private static bool IsSelfSurgeryPart(BodyPartType partType)
     {
-        return partType is BodyPartType.Arm or BodyPartType.Leg;
+        return partType is BodyPartType.Arm
+            or BodyPartType.Hand
+            or BodyPartType.Leg
+            or BodyPartType.Foot;
     }
 
     public IEnumerable<CMUSurgeryStepMetadataPrototype> EnumerateMetadata()

--- a/Content.Shared/_RMC14/Armor/Magnetic/RMCMagneticItemComponent.cs
+++ b/Content.Shared/_RMC14/Armor/Magnetic/RMCMagneticItemComponent.cs
@@ -12,4 +12,7 @@ public sealed partial class RMCMagneticItemComponent : Component
 
     [DataField, AutoNetworkedField]
     public bool NeedsMagneticField;
+
+    [DataField, AutoNetworkedField]
+    public bool ReturnOnThrow = true;
 }

--- a/Content.Shared/_RMC14/Armor/Magnetic/RMCMagneticSystem.cs
+++ b/Content.Shared/_RMC14/Armor/Magnetic/RMCMagneticSystem.cs
@@ -52,6 +52,9 @@ public sealed partial class RMCMagneticSystem : EntitySystem
 
     private void OnMagneticItemThrown(Entity<RMCMagneticItemComponent> ent, ref ThrownEvent args)
     {
+        if (!ent.Comp.ReturnOnThrow)
+            return;
+
         if (args.User is not { } user)
             return;
 
@@ -147,6 +150,12 @@ public sealed partial class RMCMagneticSystem : EntitySystem
     public void SetMagnetizeToSlots(Entity<RMCMagneticItemComponent> ent, SlotFlags slots)
     {
         ent.Comp.MagnetizeToSlots = slots;
+        Dirty(ent);
+    }
+
+    public void SetReturnOnThrow(Entity<RMCMagneticItemComponent> ent, bool returnOnThrow)
+    {
+        ent.Comp.ReturnOnThrow = returnOnThrow;
         Dirty(ent);
     }
 

--- a/Content.Shared/_RMC14/Attachable/Components/AttachableMagneticComponent.cs
+++ b/Content.Shared/_RMC14/Attachable/Components/AttachableMagneticComponent.cs
@@ -10,4 +10,7 @@ public sealed partial class AttachableMagneticComponent : Component
 {
     [DataField, AutoNetworkedField]
     public SlotFlags MagnetizeToSlots = SlotFlags.SUITSTORAGE;
+
+    [DataField, AutoNetworkedField]
+    public bool ReturnOnThrow = true;
 }

--- a/Content.Shared/_RMC14/Attachable/Systems/AttachableMagneticSystem.cs
+++ b/Content.Shared/_RMC14/Attachable/Systems/AttachableMagneticSystem.cs
@@ -25,6 +25,7 @@ public sealed partial class AttachableMagneticSystem : EntitySystem
             case AttachableAlteredType.Attached:
                 var comp = EnsureComp<RMCMagneticItemComponent>(args.Holder);
                 _magneticSystem.SetMagnetizeToSlots((args.Holder, comp), attachable.Comp.MagnetizeToSlots);
+                _magneticSystem.SetReturnOnThrow((args.Holder, comp), attachable.Comp.ReturnOnThrow);
                 break;
 
             case AttachableAlteredType.Detached:

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Attachments/universal.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Attachments/universal.yml
@@ -8,6 +8,7 @@
     sprite: _RMC14/Objects/Weapons/Guns/Attachments/rifle_sling/classic-desert-jungle.rsi
     state: pve-sling
   - type: AttachableMagnetic
+    returnOnThrow: false
   - type: AttachableVisuals
   - type: AttachableWeaponRangedMods
     modifiers:

--- a/Resources/Prototypes/_CMU14/Medical/Treatment/Surgery/surgery_step_metadata.yml
+++ b/Resources/Prototypes/_CMU14/Medical/Treatment/Surgery/surgery_step_metadata.yml
@@ -4,9 +4,9 @@
   id: CMUSurgeryStepMetaSetSimpleFracture
   surgery: CMUSurgerySetSimpleFracture
   displayName: Set Fracture
-  validParts: [Arm, Leg]
+  validParts: [Arm, Hand, Leg, Foot]
   allowSelfSurgery: true
-  selfSurgeryValidParts: [Arm, Leg]
+  selfSurgeryValidParts: [Arm, Hand, Leg, Foot]
   category: fracture
 
 - type: cmuSurgeryStepMetadata
@@ -20,9 +20,9 @@
   id: CMUSurgeryStepMetaSetCompoundFracture
   surgery: CMUSurgerySetCompoundFracture
   displayName: Set Fracture
-  validParts: [Arm, Leg]
+  validParts: [Arm, Hand, Leg, Foot]
   allowSelfSurgery: true
-  selfSurgeryValidParts: [Arm, Leg]
+  selfSurgeryValidParts: [Arm, Hand, Leg, Foot]
   category: fracture
 
 - type: cmuSurgeryStepMetadata
@@ -36,9 +36,9 @@
   id: CMUSurgeryStepMetaSetShatteredFracture
   surgery: CMUSurgerySetShatteredFracture
   displayName: Set Fracture
-  validParts: [Arm, Leg]
+  validParts: [Arm, Hand, Leg, Foot]
   allowSelfSurgery: true
-  selfSurgeryValidParts: [Arm, Leg]
+  selfSurgeryValidParts: [Arm, Hand, Leg, Foot]
   category: fracture
 
 - type: cmuSurgeryStepMetadata
@@ -54,9 +54,9 @@
   id: CMUSurgeryStepMetaCauterizeInternalBleeding
   surgery: CMUSurgeryCauterizeInternalBleeding
   displayName: Stop Internal Bleeding
-  validParts: [Head, Torso, Arm, Leg]
+  validParts: [Head, Torso, Arm, Hand, Leg, Foot]
   allowSelfSurgery: true
-  selfSurgeryValidParts: [Arm, Leg]
+  selfSurgeryValidParts: [Arm, Hand, Leg, Foot]
   category: bleed
 
 # ---- Organ removal (torso only) -------------------------------------
@@ -254,9 +254,9 @@
   id: CMUSurgeryStepMetaDebrideEschar
   surgery: CMUSurgeryDebrideEschar
   displayName: Debride Eschar
-  validParts: [Head, Torso, Arm, Leg]
+  validParts: [Head, Torso, Arm, Hand, Leg, Foot]
   allowSelfSurgery: true
-  selfSurgeryValidParts: [Arm, Leg]
+  selfSurgeryValidParts: [Arm, Hand, Leg, Foot]
   category: burn
   steps:
   - stepId: CMUSurgeryStepDebrideEschar

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Attachments/rail_attachments.yml
@@ -117,6 +117,7 @@
     sprite: _RMC14/Objects/Weapons/Guns/Attachments/rifle_sling/classic-desert-jungle.rsi
     state: pve-sling
   - type: AttachableMagnetic
+    returnOnThrow: false
   - type: AttachableVisuals
   - type: AttachableWeaponRangedMods
     modifiers:


### PR DESCRIPTION
:cl:
- fix: Hands and feet can now be selected for fracture, internal bleeding, and eschar surgeries.
- fix: Weapons with two-point slings now use normal throwing physics.
- fix: Fully repaired synthetics now return to an alive state after defibrillation instead of remaining critical.