### PR TITLE
Prevent water theft via shuttle

### DIFF
--- a/Resources/Prototypes/_RMC14/Tiles/Sheperd/sheperd_beach.yml
+++ b/Resources/Prototypes/_RMC14/Tiles/Sheperd/sheperd_beach.yml
@@ -50,6 +50,8 @@
     cover:
       tags:
       - Catwalk
+  - type: FTLSmashImmune
+  - type: NoFTL
 
 - type: entity
   parent: AUShepFloorWaterEntity
@@ -79,6 +81,8 @@
   components:
   - type: Sprite
     color: '#FFFFFF33'
+  - type: FTLSmashImmune
+  - type: NoFTL
 
 - type: entity
   id: CMUOverlayWater
@@ -145,3 +149,5 @@
         components:
         - Xeno
         - Synth
+  - type: FTLSmashImmune
+  - type: NoFTL


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The entities in sheperd_beach.yml now have FTLSmashImmune and NoFTL. The Smash immune may have been unnecessary, but the NoFTL prevents shuttles from picking up water.

## Why / Balance
Bug fix

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Sheperds': Prevent water theft via shuttle
