### PR TITLE
Lowers chance of xenos and aboms spawning as research crates

### DIFF
--- a/Resources/Prototypes/_CMU14/Maps/Markers/crates.yml
+++ b/Resources/Prototypes/_CMU14/Maps/Markers/crates.yml
@@ -11,10 +11,17 @@
   - type: RandomSpawner
     chance: 1.0
     prototypes:
-      - AU14CrateSecureWeYuXenoEggs
+      - AU14CrateSecureWeYuXenoEggs # x1
+      - AU14CrateSecureWeYuMMI # x2
       - AU14CrateSecureWeYuMMI
-      - AU14CrateSecureWeYuMindBreaker # x2
+      - AU14CrateSecureWeYuMindBreaker # x5
       - AU14CrateSecureWeYuMindBreaker
-      - AU14CrateSecureWeYuDrug # x2
+      - AU14CrateSecureWeYuMindBreaker
+      - AU14CrateSecureWeYuMindBreaker
+      - AU14CrateSecureWeYuMindBreaker
+      - AU14CrateSecureWeYuDrug # x5
+      - AU14CrateSecureWeYuDrug
+      - AU14CrateSecureWeYuDrug
+      - AU14CrateSecureWeYuDrug
       - AU14CrateSecureWeYuDrug
       - AU14CrateSecureWeYuClottedSyringes # x1 abom toxin sucks


### PR DESCRIPTION
## About the PR
Changes the WeYu experimental supply spawner so xeno egg crates and abomination syringe crates are rarer outcomes.

## Why / Balance
Xeno eggs and abomination venom syringes are high-impact crate results. This reduces each from a 1/7 chance to a 1/14 chance, making the more dangerous experimental outcomes less common while keeping them possible.

## Technical details
Expanded the `AU14SpawnerRandomWeYuSupply` random prototype list from 7 entries to 14 entries. The xeno egg and clotted syringe crates now appear once each in the weighted list.

## Media
N/A, probability-only balance change with no visual changes.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Reduced the chance for WeYu experimental supply crates to spawn xeno eggs or abomination syringes.