### PR TITLE
General gameplay, xeno, z-level, and role fixes

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/ChatMarkupParser.cs
+++ b/Content.Client/UserInterface/Systems/Chat/ChatMarkupParser.cs
@@ -1,0 +1,15 @@
+using Robust.Shared.Utility;
+
+namespace Content.Client.UserInterface.Systems.Chat;
+
+internal static class ChatMarkupParser
+{
+    public static string? AddMarkup(FormattedMessage message, string markup)
+    {
+        if (message.TryAddMarkup(markup, out var error))
+            return null;
+
+        message.AddMarkupPermissive(markup);
+        return error;
+    }
+}

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -37,6 +37,7 @@ public partial class ChatBox : UIWidget
     private readonly ChatUIController _controller;
     private readonly Dictionary<string, ChatTabButton> _tabButtons = new();
     private readonly Dictionary<string, int> _tabUnread = new();
+    private readonly HashSet<string> _reportedInvalidMarkup = new();
     private readonly List<ChatTabSettings> _overflowTabs = new();
     private List<ChatTabSettings> _tabs = new();
     private List<ChatStyleSettings> _styles = new();
@@ -1173,7 +1174,7 @@ public partial class ChatBox : UIWidget
         if (_colorWholeMessage)
             formatted.PushColor(color);
 
-        formatted.AddMarkupOrThrow(markup);
+        AddChatMarkup(formatted, markup, message.Channel);
 
         if (_colorWholeMessage)
             formatted.Pop();
@@ -1222,13 +1223,24 @@ public partial class ChatBox : UIWidget
 
         // RMC14
         if (!string.IsNullOrWhiteSpace(message.LanguageIcon))
-            formatted.AddMarkupOrThrow($"[langicon language=\"{FormattedMessage.EscapeText(message.LanguageIcon)}\"][/langicon]");
+            AddChatMarkup(formatted, $"[langicon language=\"{FormattedMessage.EscapeStringParameter(message.LanguageIcon)}\"][/langicon]", message.Channel);
         // RMC14
-        formatted.AddMarkupOrThrow(message.WrappedMessage);
+        AddChatMarkup(formatted, message.WrappedMessage, message.Channel);
 
         formatted.Pop();
 
         return FilterProblematicTags(formatted, allowCommandLinks: true);
+    }
+
+    private void AddChatMarkup(FormattedMessage formatted, string markup, ChatChannel channel)
+    {
+        if (ChatMarkupParser.AddMarkup(formatted, markup) is not { } error ||
+            !_reportedInvalidMarkup.Add(markup))
+        {
+            return;
+        }
+
+        _sawmill.Warning($"Invalid markup in {channel} chat message; using permissive fallback: {error}");
     }
 
     private static string StripDuplicateChannelPrefix(string markup, ChatMessage message)

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.cs
@@ -339,10 +339,7 @@ public sealed partial class GunSystem : SharedGunSystem
             AddComp(ent, light);
         }
 
-        Lights.SetEnabled(ent, true, light);
-        Lights.SetRadius(ent, 2f, light);
-        Lights.SetColor(ent, Color.FromHex("#cc8e2b"), light);
-        Lights.SetEnergy(ent, 5f, light);
+        ConfigureMuzzleFlashLight(ent, light, Lights); // CMU14
 
         var animTwo = new Animation()
         {

--- a/Content.Client/_CMU14/Medical/Presentation/HUD/BodyZoneTargetWidgetController.cs
+++ b/Content.Client/_CMU14/Medical/Presentation/HUD/BodyZoneTargetWidgetController.cs
@@ -1,4 +1,5 @@
 using Content.Client.Gameplay;
+using Content.Client.UserInterface.Systems.Gameplay;
 using Content.Shared._CMU14.Input;
 using Content.Shared._CMU14.Medical.Core;
 using Content.Shared._CMU14.Medical.Anatomy.BodyParts;
@@ -65,6 +66,10 @@ public sealed partial class BodyZoneTargetWidgetController :
             InputCmdHandler.FromDelegate(_ => SelectZoneGroup(TargetBodyZone.LeftLeg, TargetBodyZone.LeftFoot), handle: true));
         _input.SetInputCommand(CMUKeyFunctions.CMUTargetBodyZoneRightLeg,
             InputCmdHandler.FromDelegate(_ => SelectZoneGroup(TargetBodyZone.RightLeg, TargetBodyZone.RightFoot), handle: true));
+
+        var gameplayStateLoad = UIManager.GetUIController<GameplayStateLoadController>();
+        gameplayStateLoad.OnScreenLoad += OnScreenLoad;
+        gameplayStateLoad.OnScreenUnload += OnScreenUnload;
     }
 
     public void OnStateEntered(GameplayState state)
@@ -84,6 +89,20 @@ public sealed partial class BodyZoneTargetWidgetController :
         _cfg.OnValueChanged(CMUMedicalCCVars.HitLocationEnabled, OnGateCvarChanged);
 
         RefreshVisibility();
+    }
+
+    private void OnScreenLoad()
+    {
+        if (_widget == null)
+            return;
+
+        AttachToHud(_widget);
+        RefreshVisibility();
+    }
+
+    private void OnScreenUnload()
+    {
+        _widget?.Orphan();
     }
 
     public void OnStateExited(GameplayState state)

--- a/Content.Client/_CMU14/Weapons/Ranged/GunSystem.MuzzleFlashLight.cs
+++ b/Content.Client/_CMU14/Weapons/Ranged/GunSystem.MuzzleFlashLight.cs
@@ -1,0 +1,21 @@
+using Robust.Shared.GameObjects;
+
+namespace Content.Client.Weapons.Ranged.Systems;
+
+public sealed partial class GunSystem
+{
+    // Brief presentation effects must not evict persistent lights when the shadow-light budget is full.
+    internal const bool MuzzleFlashCastsShadows = false;
+
+    internal static void ConfigureMuzzleFlashLight(
+        EntityUid uid,
+        SharedPointLightComponent light,
+        SharedPointLightSystem lights)
+    {
+        lights.SetCastShadows(uid, MuzzleFlashCastsShadows, light);
+        lights.SetEnabled(uid, true, light);
+        lights.SetRadius(uid, 2f, light);
+        lights.SetColor(uid, Color.FromHex("#cc8e2b"), light);
+        lights.SetEnergy(uid, 5f, light);
+    }
+}

--- a/Content.Client/_RMC14/Cassette/CassetteSystem.cs
+++ b/Content.Client/_RMC14/Cassette/CassetteSystem.cs
@@ -98,7 +98,7 @@ public sealed partial class CassetteSystem : SharedCassetteSystem
             return null;
 
         var audioParams = player.Comp.AudioParams.WithVolume(SharedAudioSystem.GainToVolume(_gain));
-        return _audio.PlayGlobal(stream, new ResolvedPathSpecifier(name), audioParams)?.Entity;
+        return _audio.PlayEntity(stream, player, new ResolvedPathSpecifier(name), audioParams)?.Entity;
     }
 
     protected override async void ChooseCustomTrack(Entity<CassetteTapeComponent> tape)

--- a/Content.Client/_RMC14/Xenonids/Egg/XenoEggStorageVisualizerSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Egg/XenoEggStorageVisualizerSystem.cs
@@ -18,18 +18,36 @@ public sealed partial class XenoEggStorageVisualizerSystem : VisualizerSystem<Xe
         if (!_sprite.LayerMapTryGet((uid, sprite), XenoEggStorageVisualLayers.Base, out var layer, false))
             return;
 
-        string layerState = "eggsac_";
-
-        int level = Math.Clamp((int)Math.Ceiling(((double)eggs / component.MaxEggs) * component.FullStates), 0, component.FullStates);
-        layerState += level;
+        var level = Math.Clamp((int)Math.Ceiling(((double)eggs / component.MaxEggs) * component.FullStates), 0, component.FullStates);
+        var stateSuffix = string.Empty;
 
         if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Downed, out bool downed) && downed)
-            layerState += "_downed";
+            stateSuffix += "_downed";
         else if (AppearanceSystem.TryGetData(uid, RMCXenoStateVisuals.Resting, out bool resting) && resting)
-            layerState += "_rest";
+            stateSuffix += "_rest";
 
         if (AppearanceSystem.TryGetData(uid, XenoEggStorageVisuals.Active, out bool active) && active)
-            layerState += "_active";
+            stateSuffix += "_active";
+
+        var rsi = sprite[layer].ActualRsi;
+        if (rsi == null)
+            return;
+
+        // Some sprite sets do not have every egg level for every posture.
+        // Fall back to the nearest lower level instead of displaying the error sprite.
+        string? layerState = null;
+        for (; level >= 0; level--)
+        {
+            var candidate = $"eggsac_{level}{stateSuffix}";
+            if (!rsi.TryGetState(candidate, out _))
+                continue;
+
+            layerState = candidate;
+            break;
+        }
+
+        if (layerState == null)
+            return;
 
         _sprite.LayerSetRsiState((uid, sprite), layer, layerState);
 

--- a/Content.Client/_RMC14/Xenonids/Invisibility/XenoInvisibilityVisualsSystem.cs
+++ b/Content.Client/_RMC14/Xenonids/Invisibility/XenoInvisibilityVisualsSystem.cs
@@ -1,37 +1,17 @@
 ﻿using Content.Shared._RMC14.Xenonids.Invisibility;
 using Robust.Client.GameObjects;
-using Robust.Client.Graphics;
-using Robust.Shared.Prototypes;
 
 namespace Content.Client._RMC14.Xenonids.Invisibility;
 
 public sealed partial class XenoInvisibilityVisualsSystem : EntitySystem
 {
-    private static readonly ProtoId<ShaderPrototype> InvisibilityShader = "RMCInvisible";
+    [Dependency] private SpriteSystem _sprite = default!;
 
-    [Dependency] private IPrototypeManager _prototypes = default!;
-
-    private readonly Dictionary<EntityUid, ShaderInstance> _shaders = new();
     private EntityQuery<XenoActiveInvisibleComponent> _activeInvisibleQuery;
 
     public override void Initialize()
     {
         _activeInvisibleQuery = GetEntityQuery<XenoActiveInvisibleComponent>();
-
-        SubscribeLocalEvent<XenoTurnInvisibleComponent, ComponentShutdown>(OnShutdown);
-    }
-
-    private void OnShutdown(Entity<XenoTurnInvisibleComponent> ent, ref ComponentShutdown args)
-    {
-        if (!_shaders.Remove(ent, out var shader) ||
-            TerminatingOrDeleted(ent))
-            return;
-
-        if (TryComp(ent, out SpriteComponent? sprite) &&
-            ReferenceEquals(sprite.PostShader, shader))
-        {
-            sprite.PostShader = null;
-        }
     }
 
     public override void Update(float frameTime)
@@ -40,20 +20,7 @@ public sealed partial class XenoInvisibilityVisualsSystem : EntitySystem
         while (invisible.MoveNext(out var uid, out var comp, out var sprite))
         {
             var opacity = _activeInvisibleQuery.HasComp(uid) ? comp.Opacity : 1;
-
-            if (opacity < 1)
-            {
-                if (!_shaders.TryGetValue(uid, out var shader))
-                    _shaders[uid] = shader = _prototypes.Index(InvisibilityShader).InstanceUnique();
-
-                sprite.PostShader = shader;
-                shader.SetParameter("visibility", opacity);
-            }
-            else if (_shaders.Remove(uid, out var shader) &&
-                     ReferenceEquals(sprite.PostShader, shader))
-            {
-                sprite.PostShader = null;
-            }
+            _sprite.SetColor((uid, sprite), Color.Transparent.WithAlpha(opacity));
         }
     }
 }

--- a/Content.IntegrationTests/Tests/Commands/JoinGameCommandTest.cs
+++ b/Content.IntegrationTests/Tests/Commands/JoinGameCommandTest.cs
@@ -1,0 +1,117 @@
+using System.Linq;
+using Content.IntegrationTests.Pair;
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Commands;
+using Content.Server.Mind;
+using Content.Server.Station.Systems;
+using Content.Shared._RMC14.CCVar;
+using Content.Shared.CCVar;
+using Content.Shared.GameTicking;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using Content.Shared.Roles.Jobs;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Commands;
+
+[TestFixture]
+[TestOf(typeof(JoinGameCommand))]
+public sealed class JoinGameCommandTest
+{
+    private const string TestMap = "JoinGameCommandTestMap";
+    private static readonly ProtoId<JobPrototype> SelectedJob = "JoinGameCommandSelectedJob";
+    private static readonly ProtoId<JobPrototype> FallbackJob = "JoinGameCommandFallbackJob";
+
+    [TestPrototypes]
+    private static readonly string Prototypes = $@"
+- type: playTimeTracker
+  id: PlayTimeJoinGameCommandSelectedJob
+
+- type: playTimeTracker
+  id: PlayTimeJoinGameCommandFallbackJob
+
+- type: job
+  id: {SelectedJob}
+  playTimeTracker: PlayTimeJoinGameCommandSelectedJob
+
+- type: job
+  id: {FallbackJob}
+  playTimeTracker: PlayTimeJoinGameCommandFallbackJob
+
+- type: gameMap
+  id: {TestMap}
+  mapName: {TestMap}
+  mapPath: /Maps/Test/empty.yml
+  minPlayers: 0
+  stations:
+    Empty:
+      stationProto: StandardNanotrasenStation
+      components:
+      - type: StationNameSetup
+        mapNameTemplate: ""Join Game Command Test Station""
+      - type: StationJobs
+        availableJobs:
+          {SelectedJob}: [1, 1]
+          {FallbackJob}: [-1, -1]
+";
+
+    [Test]
+    public async Task SelectedJobIsPreservedDuringDelayedRoundEnd()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            Dirty = true,
+            DummyTicker = false,
+            InLobby = true,
+        });
+
+        var server = pair.Server;
+        var config = server.ResolveDependency<IConfigurationManager>();
+        var console = server.ResolveDependency<IConsoleHost>();
+        var entityManager = server.ResolveDependency<IEntityManager>();
+        var jobs = entityManager.System<SharedJobSystem>();
+        var minds = entityManager.System<MindSystem>();
+        var stationJobs = entityManager.System<StationJobsSystem>();
+        var stations = entityManager.System<StationSystem>();
+        var ticker = entityManager.System<GameTicker>();
+
+        config.SetCVar(CCVars.GameMap, TestMap);
+        config.SetCVar(RMCCVars.RMCDelayRoundEnd, true);
+        await pair.SetJobPriorities((FallbackJob, JobPriority.High));
+
+        await server.WaitPost(() => ticker.StartRound());
+        await pair.RunTicksSync(10);
+
+        var station = EntityUid.Invalid;
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.InRound));
+            station = stations.GetStations().Single(uid =>
+                stationJobs.TryGetJobSlot(uid, SelectedJob, out _));
+
+            ticker.EndRound();
+            Assert.That(ticker.RunLevel, Is.EqualTo(GameRunLevel.PostRound));
+        });
+
+        var session = server.PlayerMan.Sessions.Single();
+        var stationId = entityManager.GetNetEntity(station).Id;
+        await server.WaitPost(() =>
+            console.GetSessionShell(session).ExecuteCommand($"joingame {SelectedJob} {stationId}"));
+        await pair.RunTicksSync(10);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(session.AttachedEntity, Is.Not.Null);
+            var mind = minds.GetMind(session.AttachedEntity!.Value);
+            Assert.That(entityManager.EntityExists(mind));
+            Assert.That(jobs.MindTryGetJobId(mind, out var actualJob));
+            Assert.That(actualJob, Is.EqualTo(SelectedJob));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/_RMC14/Cassette/CassetteAudioTest.cs
+++ b/Content.IntegrationTests/Tests/_RMC14/Cassette/CassetteAudioTest.cs
@@ -1,0 +1,102 @@
+using System.Linq;
+using Content.Shared._RMC14.Cassette;
+using Robust.Shared.Audio.Components;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests._RMC14.Cassette;
+
+[TestFixture]
+[TestOf(typeof(CassettePlayerComponent))]
+public sealed class CassetteAudioTest
+{
+    [Test]
+    public async Task PlaybackFollowsCassettePlayerAndRestartLeavesOneTrack()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+        });
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+        var session = server.PlayerMan.Sessions.Single();
+        EntityUid actor = default;
+        EntityUid cassettePlayer = default;
+
+        await server.WaitPost(() =>
+        {
+            actor = server.EntMan.SpawnEntity(null, testMap.GridCoords);
+            server.PlayerMan.SetAttachedEntity(session, actor);
+        });
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            cassettePlayer = entMan.SpawnEntity("RMCCassettePlayer", server.Transform(actor).Coordinates);
+            var tape = entMan.SpawnEntity("RMCCassetteTapeWigWoo1", server.Transform(actor).Coordinates);
+            var playerComp = entMan.GetComponent<CassettePlayerComponent>(cassettePlayer);
+            var containers = entMan.System<SharedContainerSystem>();
+            var container = containers.EnsureContainer<ContainerSlot>(cassettePlayer, playerComp.ContainerId);
+            Assert.That(containers.Insert(tape, container), Is.True);
+
+            var restart = new CassetteRestartActionEvent { Performer = actor };
+            entMan.EventBus.RaiseLocalEvent(cassettePlayer, restart);
+
+            Assert.That(playerComp.AudioStream, Is.Not.Null);
+            var audio = playerComp.AudioStream!.Value;
+            Assert.Multiple(() =>
+            {
+                Assert.That(entMan.HasComponent<AudioComponent>(audio), Is.True);
+                Assert.That(server.Transform(audio).ParentUid, Is.EqualTo(cassettePlayer));
+            });
+        });
+
+        for (var i = 1; i < 10; i++)
+        {
+            await server.WaitPost(() =>
+            {
+                var restart = new CassetteRestartActionEvent { Performer = actor };
+                server.EntMan.EventBus.RaiseLocalEvent(cassettePlayer, restart);
+            });
+            await pair.RunTicksSync(1);
+        }
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var playerComp = entMan.GetComponent<CassettePlayerComponent>(cassettePlayer);
+            var tracks = entMan.EntityQuery<AudioComponent>()
+                .Where(audio => audio.FileName == "/Audio/_RMC14/Lobby/Super_Nova_In_The_Catacombs.ogg")
+                .ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(tracks, Has.Length.EqualTo(1));
+                Assert.That(playerComp.AudioStream, Is.Not.Null);
+                Assert.That(entMan.GetComponent<AudioComponent>(playerComp.AudioStream!.Value), Is.SameAs(tracks[0]));
+            });
+        });
+
+        await pair.RunTicksSync(5);
+        var client = pair.Client;
+        var clientCassettePlayer = pair.ToClientUid(cassettePlayer);
+        await client.WaitAssertion(() =>
+        {
+            var entMan = client.EntMan;
+            var playerComp = entMan.GetComponent<CassettePlayerComponent>(clientCassettePlayer);
+            var tracks = entMan.EntityQuery<AudioComponent>()
+                .Where(audio => audio.FileName == "/Audio/_RMC14/Lobby/Super_Nova_In_The_Catacombs.ogg")
+                .ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(tracks, Has.Length.EqualTo(1));
+                Assert.That(playerComp.AudioStream, Is.Not.Null);
+                Assert.That(client.Transform(playerComp.AudioStream!.Value).ParentUid, Is.EqualTo(clientCassettePlayer));
+            });
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/_AU14/ColonyEconomy/DepartmentConsoleSalaryTest.cs
+++ b/Content.IntegrationTests/_AU14/ColonyEconomy/DepartmentConsoleSalaryTest.cs
@@ -1,0 +1,85 @@
+using Content.Server.Access.Systems;
+using Content.Server.AU14.ColonyEconomy;
+using Content.Server.Station.Systems;
+using Content.Shared.Access.Components;
+using Content.Shared.AU14.ColonyEconomy;
+using Content.Shared.GameTicking;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests._AU14.ColonyEconomy;
+
+[TestFixture]
+public sealed class DepartmentConsoleSalaryTest
+{
+    [TestCase("AU14JobCivilianHeadPhysician", "AUDepartmentConsoleMedical")]
+    [TestCase("AU14JobCivilianPhysician", "AUDepartmentConsoleMedical")]
+    [TestCase("AU14JobCivilianNurse", "AUDepartmentConsoleMedical")]
+    [TestCase("AU14JobCivilianEthicsAndWellnessAdvisor", "AUDepartmentConsoleMedical")]
+    [TestCase("AU14JobCivilianEmergencyResponseOfficer", "AUDepartmentConsoleMedical")]
+    [TestCase("AU14JobCivilianNurse", "AUDepartmentConsoleCivilian")]
+    public async Task ColonyMedicalRoleReceivesSalaryAfterSpawnRegistration(string jobId, string consoleId)
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true });
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entityManager = server.EntMan;
+            var adminConsoleSystem = server.System<AdminConsoleSystem>();
+            var departmentSystem = server.System<DepartmentConsoleSystem>();
+            var idCardSystem = server.System<IdCardSystem>();
+            var stationSpawning = server.System<StationSpawningSystem>();
+            var profile = new HumanoidCharacterProfile();
+            EntProtoId consolePrototype = consoleId;
+            var console = entityManager.SpawnEntity(consolePrototype, testMap.GridCoords);
+            ProtoId<JobPrototype> job = jobId;
+            var medicalWorker = stationSpawning.SpawnPlayerMob(testMap.GridCoords, job, profile, station: null);
+
+            try
+            {
+                Assert.That(idCardSystem.TryFindIdCard(medicalWorker, out var idCard), Is.True);
+
+                var department = entityManager.GetComponent<DepartmentConsoleComponent>(console);
+                department.DepartmentBudget = department.DefaultSalary;
+                var initialBalance = idCard.Comp.AccountBalance;
+                Assert.That(adminConsoleSystem.GetIncomeTax(), Is.Zero, "The salary regression test requires zero income tax.");
+
+                var spawned = new PlayerSpawnCompleteEvent(
+                    medicalWorker,
+                    pair.Player!,
+                    job.Id,
+                    lateJoin: false,
+                    silent: true,
+                    joinOrder: 1,
+                    station: testMap.MapUid,
+                    profile: profile);
+                entityManager.EventBus.RaiseLocalEvent(medicalWorker, spawned, broadcast: true);
+
+                Assert.That(
+                    department.Members,
+                    Does.Contain(idCard.Owner),
+                    $"The payroll console did not register {job}'s ID card.");
+
+                departmentSystem.DispenseSalaries();
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(idCard.Comp.AccountBalance, Is.EqualTo(initialBalance + department.DefaultSalary));
+                    Assert.That(idCard.Comp.AccountBalance, Is.GreaterThan(initialBalance));
+                    Assert.That(department.DepartmentBudget, Is.Zero);
+                });
+            }
+            finally
+            {
+                entityManager.DeleteEntity(medicalWorker);
+                entityManager.DeleteEntity(console);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/_AU14/Roles/RoundJobProfileTest.cs
+++ b/Content.IntegrationTests/_AU14/Roles/RoundJobProfileTest.cs
@@ -5,8 +5,11 @@ using Content.Server.Jobs;
 using Content.Server.Station.Systems;
 using Content.Shared._CMU14.Round.Roles;
 using Content.Shared._RMC14.Marines;
+using Content.Shared._RMC14.Marines.Squads;
+using Content.Shared.Inventory;
 using Content.Shared.Preferences;
 using Content.Shared.Roles;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Prototypes;
 
 namespace Content.IntegrationTests._AU14.Roles;
@@ -14,9 +17,20 @@ namespace Content.IntegrationTests._AU14.Roles;
 [TestFixture]
 public sealed class RoundJobProfileTest
 {
+    private const string EarsSlot = "ears";
+
     private static readonly ProtoId<JobPrototype> GovforSquadRifleman = "AU14JobGOVFORSquadRifleman";
     private static readonly ProtoId<JobPrototype> OpforSquadRifleman = "AU14JobOPFORSquadRifleman";
     private static readonly ProtoId<JobPrototype> WypmcSquadRifleman = "AU14JobGOVFORSquadRiflemanWYPMC";
+    private static readonly ProtoId<JobPrototype> GovforLogisticsTechnician = "AU14JobGOVFORAuxTech";
+    private static readonly ProtoId<JobPrototype> OpforLogisticsTechnician = "AU14JobOPFORAuxTech";
+    private static readonly ProtoId<JobPrototype> GovforNurse = "AU14JobGOVFORNurse";
+    private static readonly ProtoId<JobPrototype> GovforWorkingJoe = "AU14JobGOVFORWorkingJoe";
+    private static readonly ProtoId<JobPrototype> OpforWorkingJoe = "AU14JobOPFORWorkingJoe";
+    private static readonly EntProtoId GovforAuxiliaryHeadset = "AU14HeadsetGovforAuxiliary";
+    private static readonly EntProtoId OpforAuxiliaryHeadset = "AU14HeadsetOpforAuxiliary";
+    private static readonly EntProtoId GovforAuxiliarySquad = "SquadGovforIntel";
+    private static readonly EntProtoId OpforAuxiliarySquad = "SquadOpforIntel";
 
     [Test]
     public async Task JobsWithRoundProfilesDeclareMetadataAndResolveProfiles()
@@ -147,6 +161,95 @@ public sealed class RoundJobProfileTest
         await pair.CleanReturnAsync();
     }
 
+    [Test]
+    public async Task LogisticsTechniciansUseFactionAuxiliaryHeadsetsInGameAndPreview()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var stationSpawning = server.System<StationSpawningSystem>();
+            var inventory = server.System<InventorySystem>();
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
+            var profile = new HumanoidCharacterProfile();
+            var govfor = stationSpawning.SpawnPlayerMob(
+                testMap.GridCoords,
+                GovforLogisticsTechnician,
+                profile,
+                station: null);
+            var opfor = stationSpawning.SpawnPlayerMob(
+                testMap.GridCoords,
+                OpforLogisticsTechnician,
+                profile,
+                station: null);
+
+            try
+            {
+                Assert.Multiple(() =>
+                {
+                    AssertEquippedPrototype(server.EntMan, inventory, govfor, EarsSlot, GovforAuxiliaryHeadset);
+                    AssertEquippedPrototype(server.EntMan, inventory, opfor, EarsSlot, OpforAuxiliaryHeadset);
+                    AssertDummyGearPrototype(prototypes, GovforLogisticsTechnician, EarsSlot, GovforAuxiliaryHeadset);
+                    AssertDummyGearPrototype(prototypes, OpforLogisticsTechnician, EarsSlot, OpforAuxiliaryHeadset);
+                });
+            }
+            finally
+            {
+                server.EntMan.DeleteEntity(govfor);
+                server.EntMan.DeleteEntity(opfor);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task MilitaryAuxiliaryRolesSpawnInFactionAuxiliarySquads()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var stationSpawning = server.System<StationSpawningSystem>();
+            var profile = new HumanoidCharacterProfile();
+            var jobs = new (ProtoId<JobPrototype> Job, EntProtoId Squad)[]
+            {
+                (GovforLogisticsTechnician, GovforAuxiliarySquad),
+                (OpforLogisticsTechnician, OpforAuxiliarySquad),
+                (GovforNurse, GovforAuxiliarySquad),
+                (GovforWorkingJoe, GovforAuxiliarySquad),
+                (OpforWorkingJoe, OpforAuxiliarySquad),
+            };
+            var members = new List<(EntityUid Entity, ProtoId<JobPrototype> Job, EntProtoId Squad)>();
+
+            try
+            {
+                foreach (var candidate in jobs)
+                {
+                    var entity = stationSpawning.SpawnPlayerMob(testMap.GridCoords, candidate.Job, profile, station: null);
+                    members.Add((entity, candidate.Job, candidate.Squad));
+                }
+
+                Assert.Multiple(() =>
+                {
+                    foreach (var member in members)
+                        AssertSquadPrototype(server.EntMan, member.Entity, member.Squad, member.Job.Id);
+                });
+            }
+            finally
+            {
+                foreach (var member in members)
+                    server.EntMan.DeleteEntity(member.Entity);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
     private static bool HasResolvedComponent(RoundJobProfileSystem profiles, JobPrototype job, string componentName)
     {
         foreach (var components in profiles.GetProfileComponents(job))
@@ -156,5 +259,53 @@ public sealed class RoundJobProfileTest
         }
 
         return false;
+    }
+
+    private static void AssertEquippedPrototype(
+        IEntityManager entityManager,
+        InventorySystem inventory,
+        EntityUid wearer,
+        string slot,
+        EntProtoId expectedPrototype)
+    {
+        var found = inventory.TryGetSlotEntity(wearer, slot, out var equipped);
+        Assert.That(found, Is.True, slot);
+        Assert.That(equipped, Is.Not.Null, slot);
+        if (!found || equipped == null)
+            return;
+
+        var metadata = entityManager.GetComponent<MetaDataComponent>(equipped.Value);
+        Assert.That(metadata.EntityPrototype?.ID, Is.EqualTo(expectedPrototype.Id), slot);
+    }
+
+    private static void AssertDummyGearPrototype(
+        IPrototypeManager prototypes,
+        ProtoId<JobPrototype> jobId,
+        string slot,
+        EntProtoId expectedPrototype)
+    {
+        var job = prototypes.Index(jobId);
+        Assert.That(job.DummyStartingGear, Is.Not.Null, $"{jobId} dummy gear");
+        if (job.DummyStartingGear is not { } dummyGearId)
+            return;
+
+        var dummyGear = prototypes.Index<StartingGearPrototype>(dummyGearId);
+        Assert.That(dummyGear.Equipment.TryGetValue(slot, out var equipped), Is.True, $"{dummyGearId} {slot}");
+        Assert.That(equipped, Is.EqualTo(expectedPrototype), $"{dummyGearId} {slot}");
+    }
+
+    private static void AssertSquadPrototype(
+        IEntityManager entityManager,
+        EntityUid member,
+        EntProtoId expectedPrototype,
+        string context)
+    {
+        var squadMember = entityManager.GetComponent<SquadMemberComponent>(member);
+        Assert.That(squadMember.Squad, Is.Not.Null, context);
+        if (squadMember.Squad is not { } squad)
+            return;
+
+        var metadata = entityManager.GetComponent<MetaDataComponent>(squad);
+        Assert.That(metadata.EntityPrototype?.ID, Is.EqualTo(expectedPrototype.Id), context);
     }
 }

--- a/Content.IntegrationTests/_CMU14/DroneOperator/CMUDroneOperatorZLevelRangeTest.cs
+++ b/Content.IntegrationTests/_CMU14/DroneOperator/CMUDroneOperatorZLevelRangeTest.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Numerics;
+using Content.Server._CMU14.ZLevels.Core;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests._CMU14.DroneOperator;
+
+[TestFixture]
+public sealed class CMUDroneOperatorZLevelRangeTest
+{
+    [Test]
+    public async Task AdjacentLevelDistanceUsesShortestOpeningRoute()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Dirty = true });
+        var lowerMap = await pair.CreateTestMap();
+        var upperMap = await pair.CreateTestMap();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var map = server.System<SharedMapSystem>();
+            var tileDefinitions = server.ResolveDependency<ITileDefinitionManager>();
+            var zLevels = server.System<CMUZLevelsSystem>();
+            var plating = new Tile(tileDefinitions["Plating"].TileId);
+
+            for (var x = -8; x <= 18; x++)
+            {
+                for (var y = -8; y <= 8; y++)
+                {
+                    map.SetTile(upperMap.Grid.Owner, upperMap.Grid.Comp, new Vector2i(x, y), plating);
+                }
+            }
+
+            map.SetTile(upperMap.Grid.Owner, upperMap.Grid.Comp, new Vector2i(-1, 0), Tile.Empty);
+            map.SetTile(upperMap.Grid.Owner, upperMap.Grid.Comp, new Vector2i(5, 0), Tile.Empty);
+
+            var network = zLevels.CreateZNetwork();
+            Assert.That(
+                zLevels.TryAddMapsIntoZNetwork(
+                    network,
+                    new Dictionary<EntityUid, int>
+                    {
+                        [lowerMap.MapUid] = 0,
+                        [upperMap.MapUid] = 1,
+                    }),
+                Is.True);
+
+            var found = zLevels.TryGetDistanceViaAdjacentLevelOpening(
+                upperMap.MapUid,
+                new Vector2(0.5f, 0.5f),
+                lowerMap.MapUid,
+                new Vector2(10.5f, 0.5f),
+                15f,
+                out var distance);
+
+            Assert.That(found, Is.True);
+            Assert.That(distance, Is.EqualTo(10f).Within(0.001f));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/_CMU14/ZLevels/Ordnance/CMUMortarZLevelTest.cs
+++ b/Content.IntegrationTests/_CMU14/ZLevels/Ordnance/CMUMortarZLevelTest.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Numerics;
+using Content.Server._CMU14.ZLevels.Core;
+using Content.Shared._CMU14.ZLevels.Ordnance;
+using Content.Shared._RMC14.Rules;
+using Content.Shared.Maps;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+
+namespace Content.IntegrationTests._CMU14.ZLevels.Ordnance;
+
+[TestFixture]
+public sealed class CMUMortarZLevelTest
+{
+    [Test]
+    public async Task ConnectedPlanetLevelRequiresOpenLaunchColumn()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var map = entMan.System<SharedMapSystem>();
+            var ordnance = entMan.System<CMUTopDownOrdnanceSystem>();
+            var planet = entMan.System<RMCPlanetSystem>();
+            var tile = server.ResolveDependency<ITileDefinitionManager>();
+            var zLevels = entMan.System<CMUZLevelsSystem>();
+
+            var planetMap = map.CreateMap(out var planetMapId);
+            var mortarMap = map.CreateMap(out var mortarMapId);
+            var roofMap = map.CreateMap(out var roofMapId);
+            var network = zLevels.CreateZNetwork();
+
+            try
+            {
+                Assert.That(zLevels.TryAddMapsIntoZNetwork(network, new Dictionary<EntityUid, int>
+                {
+                    [planetMap] = 0,
+                    [mortarMap] = 1,
+                    [roofMap] = 2,
+                }), Is.True);
+
+                var planetComp = entMan.EnsureComponent<RMCPlanetComponent>(planetMap);
+                planetComp.Offset = new Vector2i(17, -9);
+
+                var mortarCoordinates = new MapCoordinates(Vector2.Zero, mortarMapId);
+                Assert.That(planet.TryGetPlanetSurfaceCoordinates(mortarCoordinates, out var planetCoordinates), Is.True);
+                Assert.That(planetCoordinates.MapId, Is.EqualTo(planetMapId));
+                Assert.That(planetCoordinates.Position, Is.EqualTo(mortarCoordinates.Position));
+                Assert.That(planet.TryGetOffset(planetCoordinates, out var offset), Is.True);
+                Assert.That(offset, Is.EqualTo(planetComp.Offset));
+
+                Assert.That(ordnance.IsOpenToSky(mortarCoordinates), Is.True);
+
+                var roofGrid = map.CreateGridEntity(roofMapId);
+                map.SetTile(roofGrid, Vector2i.Zero, new Tile(tile["Plating"].TileId));
+                Assert.That(ordnance.IsOpenToSky(mortarCoordinates), Is.False);
+
+                map.SetTile(roofGrid, Vector2i.Zero, Tile.Empty);
+                Assert.That(ordnance.IsOpenToSky(mortarCoordinates), Is.True);
+            }
+            finally
+            {
+                if (!entMan.Deleted(network))
+                    entMan.DeleteEntity(network);
+
+                map.DeleteMap(roofMapId);
+                map.DeleteMap(mortarMapId);
+                map.DeleteMap(planetMapId);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/_RMC14/LarvaQueueDialogTest.cs
+++ b/Content.IntegrationTests/_RMC14/LarvaQueueDialogTest.cs
@@ -7,6 +7,7 @@ using Content.Server.GameTicking;
 using Content.Server.Mind;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Dialog;
+using Content.Shared._RMC14.Xenonids;
 using Content.Shared._RMC14.Xenonids.Evolution;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.JoinXeno;
@@ -25,6 +26,73 @@ namespace Content.IntegrationTests._RMC14;
 [TestFixture]
 public sealed class LarvaQueueJoinXenoUiTest
 {
+    [Test]
+    public async Task StrandedXenoIsOfferedCreditedBurrowedLarva()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            Dirty = true,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        var entMan = server.EntMan;
+        var hiveSystem = entMan.System<SharedXenoHiveSystem>();
+        var larvaQueue = entMan.System<LarvaQueueSystem>();
+        var mind = entMan.System<MindSystem>();
+        var player = server.PlayerMan.Sessions.Single();
+
+        EntityUid ghost = default;
+        EntityUid hive = default;
+        EntityUid runner = default;
+        EntityUid spawnPoint = default;
+        NetEntity ghostNet = default;
+        await server.WaitAssertion(() =>
+        {
+            ghost = entMan.SpawnEntity(GameTicker.ObserverPrototypeName, map.GridCoords);
+            hive = entMan.SpawnEntity("CMXenoHive", map.GridCoords.Offset(new Vector2(1, 0)));
+            runner = entMan.SpawnEntity("CMXenoRunner", map.GridCoords.Offset(new Vector2(2, 0)));
+            spawnPoint = entMan.SpawnEntity("CMXenoRunner", map.GridCoords.Offset(new Vector2(3, 0)));
+            hiveSystem.SetHive(runner, hive);
+            hiveSystem.SetHive(spawnPoint, hive);
+
+            var mindId = mind.CreateMind(player.UserId, "Runner");
+            mind.TransferTo(mindId, runner);
+            mind.TransferTo(mindId, ghost);
+            mind.SetUserId(mindId, player.UserId);
+            ghostNet = entMan.GetNetEntity(ghost);
+
+            var hiveComp = entMan.GetComponent<HiveComponent>(hive);
+            larvaQueue.AddToLarvaQueueFront((hive, hiveComp), player.UserId);
+            entMan.DeleteEntity(runner);
+            hiveSystem.ChangeBurrowedLarva((hive, hiveComp), 1);
+        });
+
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(player.AttachedEntity, Is.EqualTo(ghost));
+            AssertConfirmDialog(entMan, ghost, "a burrowed larva");
+        });
+
+        await ConfirmDialog(pair, ghostNet);
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(player.AttachedEntity, Is.Not.EqualTo(ghost));
+            Assert.That(player.AttachedEntity, Is.Not.EqualTo(spawnPoint));
+            Assert.That(entMan.HasComponent<XenoComponent>(player.AttachedEntity), Is.True);
+            Assert.That(entMan.GetComponent<HiveComponent>(hive).BurrowedLarva, Is.Zero);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
     [Test]
     public async Task LarvaQueueOffersLarvaInsteadOfGhostedAdult()
     {

--- a/Content.IntegrationTests/_RMC14/LurkerAbilitiesTest.cs
+++ b/Content.IntegrationTests/_RMC14/LurkerAbilitiesTest.cs
@@ -1,0 +1,129 @@
+using System.Numerics;
+using Content.Shared._RMC14.Weapons.Melee;
+using Content.Shared._RMC14.Xenonids.Crippling;
+using Content.Shared._RMC14.Xenonids.Invisibility;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Weapons.Melee;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests._RMC14;
+
+[TestFixture]
+public sealed class LurkerAbilitiesTest
+{
+    [Test]
+    public async Task InvisibilityToggleKeepsCooldownAfterActionPerformed()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        EntityUid xeno = default;
+        EntityUid actionUid = default;
+
+        try
+        {
+            await server.WaitAssertion(() =>
+            {
+                var entMan = server.EntMan;
+                var actions = entMan.System<SharedActionsSystem>();
+                xeno = entMan.SpawnEntity("CMXenoLurker", map.GridCoords.Offset(new Vector2(0.5f, 0.5f)));
+                var action = GetAction(entMan, actions, xeno, "ActionXenoTurnInvisible");
+                actionUid = action;
+
+                actions.PerformAction(xeno, action);
+
+                Assert.That(entMan.HasComponent<XenoActiveInvisibleComponent>(xeno), Is.True);
+                Assert.That(action.Comp.Toggled, Is.True);
+                Assert.That(action.Comp.Cooldown, Is.Not.Null);
+                Assert.That(action.Comp.Cooldown!.Value.End - server.Timing.CurTime,
+                    Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(0.4)));
+
+                actions.PerformAction(xeno, action);
+            });
+
+            await pair.RunTicksSync(1);
+
+            await server.WaitAssertion(() =>
+            {
+                var entMan = server.EntMan;
+                var action = entMan.GetComponent<ActionComponent>(actionUid);
+                Assert.That(entMan.HasComponent<XenoActiveInvisibleComponent>(xeno), Is.False);
+                Assert.That(action.Toggled, Is.False);
+                Assert.That(action.Cooldown, Is.Not.Null);
+                Assert.That(action.Cooldown!.Value.End - server.Timing.CurTime,
+                    Is.GreaterThanOrEqualTo(TimeSpan.FromSeconds(1.5)));
+            });
+        }
+        finally
+        {
+            await server.WaitPost(() =>
+            {
+                if (server.EntMan.EntityExists(xeno))
+                    server.EntMan.DeleteEntity(xeno);
+            });
+        }
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CripplingStrikeResetsWeaponAndUserMeleeCooldowns()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        EntityUid xeno = default;
+
+        try
+        {
+            await server.WaitAssertion(() =>
+            {
+                var entMan = server.EntMan;
+                var actions = entMan.System<SharedActionsSystem>();
+                xeno = entMan.SpawnEntity("CMXenoLurker", map.GridCoords.Offset(new Vector2(0.5f, 0.5f)));
+                var action = GetAction(entMan, actions, xeno, "ActionXenoCripplingStrike");
+                var weapon = entMan.GetComponent<MeleeWeaponComponent>(xeno);
+                var userCooldown = entMan.EnsureComponent<RMCMeleeUserCooldownComponent>(xeno);
+                var originalCooldown = server.Timing.CurTime + TimeSpan.FromSeconds(1);
+                weapon.NextAttack = originalCooldown;
+                userCooldown.NextAttack = originalCooldown;
+
+                actions.PerformAction(xeno, action);
+
+                Assert.That(entMan.HasComponent<XenoActiveCripplingStrikeComponent>(xeno), Is.True);
+                Assert.That(entMan.HasComponent<MeleeResetComponent>(xeno), Is.True);
+                Assert.That(weapon.NextAttack, Is.LessThanOrEqualTo(server.Timing.CurTime));
+                Assert.That(userCooldown.NextAttack, Is.LessThanOrEqualTo(server.Timing.CurTime));
+            });
+        }
+        finally
+        {
+            await server.WaitPost(() =>
+            {
+                if (server.EntMan.EntityExists(xeno))
+                    server.EntMan.DeleteEntity(xeno);
+            });
+        }
+
+        await pair.CleanReturnAsync();
+    }
+
+    private static Entity<ActionComponent> GetAction(
+        IEntityManager entMan,
+        SharedActionsSystem actions,
+        EntityUid performer,
+        string prototype)
+    {
+        foreach (var action in actions.GetActions(performer))
+        {
+            if (entMan.GetComponent<MetaDataComponent>(action).EntityPrototype?.ID == prototype)
+                return action;
+        }
+
+        Assert.Fail($"Expected {performer} to have action {prototype}");
+        throw new InvalidOperationException();
+    }
+}

--- a/Content.IntegrationTests/_RMC14/XenoBulwarkTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoBulwarkTest.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Content.Shared._RMC14.Actions;
 using Content.Shared._RMC14.Aura;
 using Content.Shared._RMC14.Xenonids.Bulwark;
+using Content.Shared.Actions;
 using Content.Shared.Actions.Components;
 using Content.Shared.Damage;
 using Content.Shared.Projectiles;
@@ -282,6 +284,49 @@ public sealed class XenoBulwarkTest
                 entMan.DeleteEntity(xeno);
                 entMan.DeleteEntity(encaseAction.Owner);
                 entMan.DeleteEntity(reflectAction.Owner);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ReflectiveShieldEarlyCancellationUsesMinimumCooldown()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var actions = entMan.System<SharedActionsSystem>();
+            var rmcActions = entMan.System<SharedRMCActionsSystem>();
+            var xeno = entMan.SpawnEntity("CMXenoWarriorBulwark", map.GridCoords);
+
+            try
+            {
+                var encaseAction = rmcActions.GetActionsWithEvent<XenoEncasedPlatesActionEvent>(xeno).Single();
+                var reflectAction = rmcActions.GetActionsWithEvent<XenoReflectiveShieldActionEvent>(xeno).Single();
+
+                actions.PerformAction(xeno, encaseAction);
+                actions.PerformAction(xeno, reflectAction);
+                actions.ClearCooldown(reflectAction.AsNullable());
+                actions.PerformAction(xeno, reflectAction);
+
+                var bulwark = entMan.GetComponent<XenoBulwarkComponent>(xeno);
+                var cooldown = reflectAction.Comp.Cooldown;
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(bulwark.Reflecting, Is.False);
+                    Assert.That(cooldown, Is.Not.Null);
+                    Assert.That(cooldown!.Value.End - cooldown.Value.Start, Is.EqualTo(bulwark.ReflectMinCooldown));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(xeno);
             }
         });
 

--- a/Content.IntegrationTests/_RMC14/XenoChargeTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoChargeTest.cs
@@ -2,9 +2,11 @@ using System.Numerics;
 using Content.Shared._RMC14.Xenonids.Charge;
 using Content.Shared._RMC14.Xenonids.Charge.CursorCharge;
 using Content.Shared.Actions.Components;
+using Content.Shared.Damage;
 using Content.Shared.Movement.Pulling.Components;
 using Content.Shared.Movement.Pulling.Systems;
 using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
 using Robust.Shared.Map;
 
 namespace Content.IntegrationTests._RMC14;
@@ -132,6 +134,63 @@ public sealed class XenoChargeTest
             });
 
             await pair.CleanReturnAsync();
+        }
+    }
+
+    [Test]
+    public async Task ChargerLungeCannotDestroyUnchargeableStructure()
+    {
+        var (server, _) = await PoolManager.GenerateServer(new PoolSettings(), TestContext.Out);
+
+        EntityUid charger = default;
+        EntityUid structure = default;
+        EntityCoordinates gridCoords = default;
+
+        try
+        {
+            await server.WaitPost(() =>
+            {
+                var mapSystem = server.System<SharedMapSystem>();
+                mapSystem.CreateMap(out var mapId);
+                var grid = mapSystem.CreateGridEntity(mapId);
+                gridCoords = new EntityCoordinates(grid, 0, 0);
+
+                var tileDefinitionManager = server.ResolveDependency<ITileDefinitionManager>();
+                var plating = tileDefinitionManager["Plating"];
+                mapSystem.SetTile(grid.Owner, grid.Comp, gridCoords, new Tile(plating.TileId));
+            });
+
+            await server.WaitAssertion(() =>
+            {
+                var entMan = server.EntMan;
+
+                charger = entMan.SpawnEntity("MobHuman", gridCoords.Offset(new Vector2(0.5f, 0.5f)));
+                structure = entMan.SpawnEntity("CMWallMetal", gridCoords.Offset(new Vector2(2.5f, 0.5f)));
+                entMan.RemoveComponent<XenoCrusherChargableComponent>(structure);
+
+                Assert.That(entMan.HasComponent<DamageableComponent>(structure), Is.True);
+                Assert.That(entMan.HasComponent<XenoCrusherChargableComponent>(structure), Is.False);
+
+                var chargerComp = entMan.EnsureComponent<XenoChargerComponent>(charger);
+                var state = entMan.EnsureComponent<XenoChargerStateComponent>(charger);
+                state.MoveState = XenoChargerMoveState.Lunging;
+                state.Stage = chargerComp.MaxStage;
+                state.LungeDirection = Vector2.UnitX;
+                state.LungeDistanceRemaining = chargerComp.LungeDistance +
+                                               state.Stage * chargerComp.LungeDistancePerStage;
+            });
+
+            await server.WaitRunTicks(20);
+
+            await server.WaitAssertion(() =>
+            {
+                Assert.That(server.EntMan.EntityExists(structure), Is.True);
+                Assert.That(server.EntMan.HasComponent<XenoChargerStateComponent>(charger), Is.False);
+            });
+        }
+        finally
+        {
+            server.Dispose();
         }
     }
 

--- a/Content.IntegrationTests/_RMC14/XenoLeapTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoLeapTest.cs
@@ -10,6 +10,59 @@ namespace Content.IntegrationTests._RMC14;
 public sealed class XenoLeapTest
 {
     [Test]
+    public async Task LeapTravelsConfiguredRange()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        EntityUid xeno = default;
+        Vector2 origin = default;
+
+        try
+        {
+            await server.WaitAssertion(() =>
+            {
+                var entMan = server.EntMan;
+                xeno = entMan.SpawnEntity("CMXenoLurker", map.GridCoords.Offset(new Vector2(0.5f, 0.5f)));
+                origin = entMan.System<SharedTransformSystem>().GetMapCoordinates(xeno).Position;
+
+                var target = map.GridCoords.Offset(new Vector2(10.5f, 0.5f));
+                var leap = new XenoLeapDoAfterEvent(entMan.GetNetCoordinates(target));
+                leap.DoAfter = new DoAfter(
+                    0,
+                    new DoAfterArgs(entMan, xeno, TimeSpan.Zero, leap, xeno),
+                    TimeSpan.Zero);
+
+                entMan.EventBus.RaiseLocalEvent(xeno, leap);
+
+                Assert.That(entMan.HasComponent<XenoLeapingComponent>(xeno), Is.True);
+            });
+
+            await pair.RunSeconds(0.5f);
+
+            await server.WaitAssertion(() =>
+            {
+                var position = server.EntMan.System<SharedTransformSystem>().GetMapCoordinates(xeno).Position;
+                var displacement = position - origin;
+                Assert.That(displacement.X, Is.EqualTo(6f).Within(0.25f));
+                Assert.That(displacement.Y, Is.EqualTo(0f).Within(0.25f));
+                Assert.That(server.EntMan.HasComponent<XenoLeapingComponent>(xeno), Is.False);
+            });
+        }
+        finally
+        {
+            await server.WaitPost(() =>
+            {
+                if (server.EntMan.EntityExists(xeno))
+                    server.EntMan.DeleteEntity(xeno);
+            });
+        }
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
     public async Task LeapDoAfterDoesNotStartLeapingWhenPlasmaSpendFails()
     {
         await using var pair = await PoolManager.GetServerClient();

--- a/Content.IntegrationTests/_RMC14/XenoStompTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoStompTest.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.Xenonids.Stomp;
+using Content.Shared.DoAfter;
 using Content.Shared.Physics;
 using Content.Shared.StatusEffect;
 using Robust.Shared.GameObjects;
@@ -13,7 +14,7 @@ namespace Content.IntegrationTests._RMC14;
 public sealed class XenoStompTest
 {
     [Test]
-    public async Task BurrowerStompParalyzesMarineBehindBarricade()
+    public async Task BurrowerStompPassesBarricadesButNotWalls()
     {
         await using var pair = await PoolManager.GetServerClient();
         var server = pair.Server;
@@ -22,6 +23,8 @@ public sealed class XenoStompTest
         EntityUid burrower = default;
         EntityUid barricade = default;
         EntityUid marine = default;
+        EntityUid wall = default;
+        EntityUid wallMarine = default;
 
         try
         {
@@ -31,6 +34,8 @@ public sealed class XenoStompTest
                 burrower = entMan.SpawnEntity("CMXenoBurrower", map.GridCoords.Offset(new Vector2(0.5f, 0.5f)));
                 barricade = entMan.SpawnEntity("CMBarricadeMetal", map.GridCoords.Offset(new Vector2(0.5f, 1.5f)));
                 marine = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(0.5f, 2.5f)));
+                wall = entMan.SpawnEntity("WallSolid", map.GridCoords.Offset(new Vector2(1.5f, 0.5f)));
+                wallMarine = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(2.5f, 0.5f)));
             });
 
             await pair.RunTicksSync(1);
@@ -42,18 +47,46 @@ public sealed class XenoStompTest
                 var status = entMan.System<StatusEffectQuerySystem>();
                 var transform = entMan.System<SharedTransformSystem>();
                 var origin = transform.GetMapCoordinates(burrower);
-                var target = transform.GetMapCoordinates(marine);
-                var diff = target.Position - origin.Position;
-                var ray = new CollisionRay(origin.Position, Vector2.Normalize(diff), (int) CollisionGroup.BarricadeImpassable);
-                var hit = physics.IntersectRay(origin.MapId, ray, diff.Length(), burrower, returnOnFirstHit: true).Single();
+                var barricadeTarget = transform.GetMapCoordinates(marine);
+                var barricadeDiff = barricadeTarget.Position - origin.Position;
+                var barricadeRay = new CollisionRay(
+                    origin.Position,
+                    Vector2.Normalize(barricadeDiff),
+                    (int) CollisionGroup.BarricadeImpassable);
+                var barricadeHit = physics.IntersectRay(
+                    origin.MapId,
+                    barricadeRay,
+                    barricadeDiff.Length(),
+                    burrower,
+                    returnOnFirstHit: true).Single();
 
-                Assert.That(hit.HitEntity, Is.EqualTo(barricade));
+                Assert.That(barricadeHit.HitEntity, Is.EqualTo(barricade));
+
+                var wallTarget = transform.GetMapCoordinates(wallMarine);
+                var wallDiff = wallTarget.Position - origin.Position;
+                var wallRay = new CollisionRay(
+                    origin.Position,
+                    Vector2.Normalize(wallDiff),
+                    (int) (CollisionGroup.Impassable | CollisionGroup.InteractImpassable));
+                var wallHit = physics.IntersectRay(
+                    origin.MapId,
+                    wallRay,
+                    wallDiff.Length(),
+                    burrower,
+                    returnOnFirstHit: true).Single();
+
+                Assert.That(wallHit.HitEntity, Is.EqualTo(wall));
 
                 var stomp = new XenoStompDoAfterEvent();
+                stomp.DoAfter = new DoAfter(
+                    0,
+                    new DoAfterArgs(entMan, burrower, TimeSpan.Zero, stomp, burrower),
+                    TimeSpan.Zero);
                 entMan.EventBus.RaiseLocalEvent(burrower, stomp);
 
                 Assert.That(stomp.Handled, Is.True);
                 Assert.That(status.TryGetTime(marine, "Stun", out _), Is.True);
+                Assert.That(status.TryGetTime(wallMarine, "Stun", out _), Is.False);
             });
         }
         finally
@@ -69,6 +102,12 @@ public sealed class XenoStompTest
 
                 if (entMan.EntityExists(marine))
                     entMan.DeleteEntity(marine);
+
+                if (entMan.EntityExists(wall))
+                    entMan.DeleteEntity(wall);
+
+                if (entMan.EntityExists(wallMarine))
+                    entMan.DeleteEntity(wallMarine);
             });
 
             await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/_RMC14/XenoStompTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoStompTest.cs
@@ -1,0 +1,77 @@
+using System.Linq;
+using System.Numerics;
+using Content.Shared._RMC14.Xenonids.Stomp;
+using Content.Shared.Physics;
+using Content.Shared.StatusEffect;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
+
+namespace Content.IntegrationTests._RMC14;
+
+[TestFixture]
+public sealed class XenoStompTest
+{
+    [Test]
+    public async Task BurrowerStompParalyzesMarineBehindBarricade()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        EntityUid burrower = default;
+        EntityUid barricade = default;
+        EntityUid marine = default;
+
+        try
+        {
+            await server.WaitAssertion(() =>
+            {
+                var entMan = server.EntMan;
+                burrower = entMan.SpawnEntity("CMXenoBurrower", map.GridCoords.Offset(new Vector2(0.5f, 0.5f)));
+                barricade = entMan.SpawnEntity("CMBarricadeMetal", map.GridCoords.Offset(new Vector2(0.5f, 1.5f)));
+                marine = entMan.SpawnEntity("CMMobHuman", map.GridCoords.Offset(new Vector2(0.5f, 2.5f)));
+            });
+
+            await pair.RunTicksSync(1);
+
+            await server.WaitAssertion(() =>
+            {
+                var entMan = server.EntMan;
+                var physics = entMan.System<SharedPhysicsSystem>();
+                var status = entMan.System<StatusEffectQuerySystem>();
+                var transform = entMan.System<SharedTransformSystem>();
+                var origin = transform.GetMapCoordinates(burrower);
+                var target = transform.GetMapCoordinates(marine);
+                var diff = target.Position - origin.Position;
+                var ray = new CollisionRay(origin.Position, Vector2.Normalize(diff), (int) CollisionGroup.BarricadeImpassable);
+                var hit = physics.IntersectRay(origin.MapId, ray, diff.Length(), burrower, returnOnFirstHit: true).Single();
+
+                Assert.That(hit.HitEntity, Is.EqualTo(barricade));
+
+                var stomp = new XenoStompDoAfterEvent();
+                entMan.EventBus.RaiseLocalEvent(burrower, stomp);
+
+                Assert.That(stomp.Handled, Is.True);
+                Assert.That(status.TryGetTime(marine, "Stun", out _), Is.True);
+            });
+        }
+        finally
+        {
+            await server.WaitPost(() =>
+            {
+                var entMan = server.EntMan;
+                if (entMan.EntityExists(burrower))
+                    entMan.DeleteEntity(burrower);
+
+                if (entMan.EntityExists(barricade))
+                    entMan.DeleteEntity(barricade);
+
+                if (entMan.EntityExists(marine))
+                    entMan.DeleteEntity(marine);
+            });
+
+            await pair.CleanReturnAsync();
+        }
+    }
+}

--- a/Content.Server/AU14/ColonyEconomy/DepartmentConsoleSystem.cs
+++ b/Content.Server/AU14/ColonyEconomy/DepartmentConsoleSystem.cs
@@ -30,6 +30,7 @@ public sealed partial class DepartmentConsoleSystem : EntitySystem
 
     private static readonly Dictionary<string, string[]> DepartmentFallbacks = new()
     {
+        ["AU14DepartmentColonyMedical"] = new[] { "AU14DepartmentCivilian" },
         ["AU14DepartmentCivilian"] = new[] { "AU14DepartmentServices" },
         ["AU14DepartmentLabor"] = new[] { "AU14DepartmentLumbermill" },
         ["AU14DepartmentServices"] = new[] { "AU14DepartmentHydroponics" },

--- a/Content.Server/GameTicking/Commands/JoinGameCommand.cs
+++ b/Content.Server/GameTicking/Commands/JoinGameCommand.cs
@@ -56,7 +56,7 @@ namespace Content.Server.GameTicking.Commands
                 shell.WriteLine("Round has not started.");
                 return;
             }
-            else if (ticker.RunLevel == GameRunLevel.InRound)
+            else if (ticker.RunLevel is GameRunLevel.InRound or GameRunLevel.PostRound)
             {
                 string id = args[0];
 

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -91,9 +91,14 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
     private static readonly HashSet<string> AuxiliarySquadRoundRoles = new(StringComparer.OrdinalIgnoreCase)
     {
         "AuxSupportSynth",
+        "AuxTech",
+        "EngineeringTech",
+        "IntelOfficer",
         "JuniorOfficer",
-        "VehicleCrewman",
-        "IntelOfficer"
+        "Nurse",
+        "WorkingJoe",
+        "VehicleCommander",
+        "VehicleCrewman"
     };
 
     // Legacy fallback for jobs that have not been migrated to roundRole yet.
@@ -250,6 +255,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
             if (originalPrototype != null && TryComp(jobEntity, out MetaDataComponent? metaDataJobEntity))
                 SetPdaAndIdCardData(jobEntity, metaDataJobEntity.EntityName, originalPrototype, station);
 
+            AssignRoundStartSquad(jobEntity, coordinates, job, originalPrototype, jobId, team);
             return jobEntity;
         }
 
@@ -354,127 +360,67 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
         ApplyRegulationAppearance(entity.Value, profile);
         _identity.QueueIdentityUpdate(entity.Value);
 
-        string? teamCheckJobId = originalJob?.ToString();
+        AssignRoundStartSquad(entity.Value, coordinates, job, originalPrototype, jobId, team);
 
-        bool assignToSquad = team != null && ShouldAssignToSquad(originalPrototype, teamCheckJobId);
-        if (assignToSquad)
+        ApplyTeamFaction(entity.Value, team);
+        return entity.Value;
+    }
+
+    private void AssignRoundStartSquad(
+        EntityUid entity,
+        EntityCoordinates coordinates,
+        ProtoId<JobPrototype>? job,
+        JobPrototype? originalPrototype,
+        string? originalJobId,
+        string? team)
+    {
+        if (team == null || !ShouldAssignToSquad(originalPrototype, originalJobId))
+            return;
+
+        string protoId;
+
+        // Roles that should go into the intel/auxiliary squad
+        if (IsAuxiliarySquadRole(originalPrototype, originalJobId))
+            protoId = team == "govfor" ? "SquadGovforIntel" : "SquadOpforIntel";
+        else
         {
-            string protoId;
+            var candidates = team == "govfor" ? _govforSquads : _opforSquads;
 
-            // Roles that should go into the intel/auxiliary squad
-            if (IsAuxiliarySquadRole(originalPrototype, jobId))
-                protoId = team == "govfor" ? "SquadGovforIntel" : "SquadOpforIntel";
-            else
+            // New: prioritize distributing Sergeants, Automatic Riflemen, and Radio Telephone Operators
+            var isSergeant = IsSquadLeaderRole(originalPrototype, originalJobId);
+            var isAutomaticRifleman = IsRoundRole(originalPrototype, "SquadAutomaticRifleman") ||
+                                      originalJobId?.Contains("automaticrifleman", StringComparison.OrdinalIgnoreCase) == true ||
+                                      originalJobId?.Contains("autora", StringComparison.OrdinalIgnoreCase) == true ||
+                                      originalJobId?.Contains("auto", StringComparison.OrdinalIgnoreCase) == true ||
+                                      originalJobId?.Contains("afn", StringComparison.OrdinalIgnoreCase) == true ||
+                                      originalJobId?.EndsWith("squadautomaticrifleman", StringComparison.OrdinalIgnoreCase) == true;
+            var isRadioTelephone = IsRoundRole(originalPrototype, "RadioTelephoneOperator") ||
+                                   originalJobId?.Contains("radiotelephoneoperator", StringComparison.OrdinalIgnoreCase) == true ||
+                                   originalJobId?.Contains("radio", StringComparison.OrdinalIgnoreCase) == true ||
+                                   originalJobId?.Contains("rto", StringComparison.OrdinalIgnoreCase) == true ||
+                                   originalJobId?.EndsWith("radiotelephoneoperator", StringComparison.OrdinalIgnoreCase) == true;
+
+            // Sergeants: try to place into a squad without a leader where possible (existing behavior)
+            if (isSergeant)
             {
-                var candidates = team == "govfor" ? _govforSquads : _opforSquads;
-
-                // New: prioritize distributing Sergeants, Automatic Riflemen, and Radio Telephone Operators
-                var isSergeant = IsSquadLeaderRole(originalPrototype, jobId);
-                var isAutomaticRifleman = IsRoundRole(originalPrototype, "SquadAutomaticRifleman") ||
-                                          jobId?.Contains("automaticrifleman", StringComparison.OrdinalIgnoreCase) == true ||
-                                          jobId?.Contains("autora", StringComparison.OrdinalIgnoreCase) == true ||
-                                          jobId?.Contains("auto", StringComparison.OrdinalIgnoreCase) == true ||
-                                          jobId?.Contains("afn", StringComparison.OrdinalIgnoreCase) == true ||
-                                          jobId?.EndsWith("squadautomaticrifleman", StringComparison.OrdinalIgnoreCase) == true;
-                var isRadioTelephone = IsRoundRole(originalPrototype, "RadioTelephoneOperator") ||
-                                       jobId?.Contains("radiotelephoneoperator", StringComparison.OrdinalIgnoreCase) == true ||
-                                       jobId?.Contains("radio", StringComparison.OrdinalIgnoreCase) == true ||
-                                       jobId?.Contains("rto", StringComparison.OrdinalIgnoreCase) == true ||
-                                       jobId?.EndsWith("radiotelephoneoperator", StringComparison.OrdinalIgnoreCase) == true;
-
-                // Sergeants: try to place into a squad without a leader where possible (existing behavior)
-                if (isSergeant)
+                string? chosen = null;
+                foreach (var candidate in candidates)
                 {
-                    string? chosen = null;
-                    foreach (var cand in candidates)
+                    if (_squadSystem.TryEnsureSquad(candidate, out var squad) &&
+                        !_squadSystem.TryGetSquadLeader(squad, out _))
                     {
-                        if (_squadSystem.TryEnsureSquad(cand, out var s) && !_squadSystem.TryGetSquadLeader(s, out _))
-                        {
-                            chosen = cand;
-                            break;
-                        }
-                    }
-
-                    if (chosen != null)
-                    {
-                        protoId = chosen;
-                    }
-                    else
-                    {
-                        // all squads already have leaders, fall back to round-robin
-                        if (team == "govfor")
-                        {
-                            protoId = candidates[_govforNextSquadIndex % candidates.Length];
-                            _govforNextSquadIndex = (_govforNextSquadIndex + 1) % candidates.Length;
-                        }
-                        else
-                        {
-                            protoId = candidates[_opforNextSquadIndex % candidates.Length];
-                            _opforNextSquadIndex = (_opforNextSquadIndex + 1) % candidates.Length;
-                        }
+                        chosen = candidate;
+                        break;
                     }
                 }
-                // Automatic riflemen and radio telephone operators: try to evenly distribute so each squad gets one of each
-                else if (isAutomaticRifleman || isRadioTelephone)
-                {
-                    string? chosen = null;
-                    // Prefer squads that exist and don't yet have this role
-                    foreach (var cand in candidates)
-                    {
-                        if (_squadSystem.TryEnsureSquad(cand, out var s))
-                        {
-                            // If job is available as a ProtoId, check the role count in the squad.
-                            if (job != null)
-                            {
-                                s.Comp.Roles.TryGetValue(job.Value, out var existingCount);
-                                if (existingCount == 0)
-                                {
-                                    chosen = cand;
-                                    break;
-                                }
-                            }
-                            else
-                            {
-                                // If we don't have a proto id for the job for whatever reason,
-                                // prefer squads that exist but currently have fewer members (heuristic)
-                                if (_squadSystem.GetSquadMembersAlive(s) == 0)
-                                {
-                                    chosen = cand;
-                                    break;
-                                }
-                            }
-                        }
-                        else
-                        {
-                            // Squad doesn't exist yet, so it definitely has none of the role
-                            chosen = cand;
-                            break;
-                        }
-                    }
 
-                    if (chosen != null)
-                    {
-                        protoId = chosen;
-                    }
-                    else
-                    {
-                        // Fallback to round-robin distribution when every squad already has the role
-                        if (team == "govfor")
-                        {
-                            protoId = candidates[_govforNextSquadIndex % candidates.Length];
-                            _govforNextSquadIndex = (_govforNextSquadIndex + 1) % candidates.Length;
-                        }
-                        else
-                        {
-                            protoId = candidates[_opforNextSquadIndex % candidates.Length];
-                            _opforNextSquadIndex = (_opforNextSquadIndex + 1) % candidates.Length;
-                        }
-                    }
+                if (chosen != null)
+                {
+                    protoId = chosen;
                 }
                 else
                 {
-                    // Default distribution (round-robin)
-                    // Sergeants already handled above; everyone else falls through here.
+                    // All squads already have leaders, fall back to round-robin.
                     if (team == "govfor")
                     {
                         protoId = candidates[_govforNextSquadIndex % candidates.Length];
@@ -487,28 +433,97 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
                     }
                 }
             }
-
-            if (!_squadSystem.TryEnsureSquad(protoId, out Entity<SquadTeamComponent> ensured))
+            // Automatic riflemen and radio telephone operators: try to evenly distribute so each squad gets one of each
+            else if (isAutomaticRifleman || isRadioTelephone)
             {
-                // Fallback: spawn a new entity with SquadTeamComponent
-                var squadEnt = Spawn(protoId, coordinates);
-                var squadComp = EnsureComp<SquadTeamComponent>(squadEnt);
-                ensured = (squadEnt, squadComp);
+                string? chosen = null;
+                // Prefer squads that exist and don't yet have this role
+                foreach (var candidate in candidates)
+                {
+                    if (_squadSystem.TryEnsureSquad(candidate, out var squad))
+                    {
+                        // If job is available as a ProtoId, check the role count in the squad.
+                        if (job != null)
+                        {
+                            squad.Comp.Roles.TryGetValue(job.Value, out var existingCount);
+                            if (existingCount == 0)
+                            {
+                                chosen = candidate;
+                                break;
+                            }
+                        }
+                        else
+                        {
+                            // If we don't have a proto id for the job for whatever reason,
+                            // prefer squads that exist but currently have fewer members (heuristic)
+                            if (_squadSystem.GetSquadMembersAlive(squad) == 0)
+                            {
+                                chosen = candidate;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Squad doesn't exist yet, so it definitely has none of the role
+                        chosen = candidate;
+                        break;
+                    }
+                }
+
+                if (chosen != null)
+                {
+                    protoId = chosen;
+                }
+                else
+                {
+                    // Fallback to round-robin distribution when every squad already has the role
+                    if (team == "govfor")
+                    {
+                        protoId = candidates[_govforNextSquadIndex % candidates.Length];
+                        _govforNextSquadIndex = (_govforNextSquadIndex + 1) % candidates.Length;
+                    }
+                    else
+                    {
+                        protoId = candidates[_opforNextSquadIndex % candidates.Length];
+                        _opforNextSquadIndex = (_opforNextSquadIndex + 1) % candidates.Length;
+                    }
+                }
             }
-
-            _squadSystem.AssignSquad(entity.Value, (ensured.Owner, (SquadTeamComponent?)ensured.Comp), job);
-
-            // If this is the sergeant, set as squad leader
-            if (IsSquadLeaderRole(originalPrototype, jobId))
+            else
             {
-                var memberComp = EnsureComp<SquadMemberComponent>(entity.Value);
-                var leaderIcon = ensured.Comp.LeaderIcon;
-                _squadSystem.PromoteSquadLeader((entity.Value, memberComp), entity.Value, leaderIcon);
+                // Default distribution (round-robin)
+                // Sergeants already handled above; everyone else falls through here.
+                if (team == "govfor")
+                {
+                    protoId = candidates[_govforNextSquadIndex % candidates.Length];
+                    _govforNextSquadIndex = (_govforNextSquadIndex + 1) % candidates.Length;
+                }
+                else
+                {
+                    protoId = candidates[_opforNextSquadIndex % candidates.Length];
+                    _opforNextSquadIndex = (_opforNextSquadIndex + 1) % candidates.Length;
+                }
             }
         }
 
-        ApplyTeamFaction(entity.Value, team);
-        return entity.Value;
+        if (!_squadSystem.TryEnsureSquad(protoId, out Entity<SquadTeamComponent> ensured))
+        {
+            // Fallback: spawn a new entity with SquadTeamComponent
+            var squadEnt = Spawn(protoId, coordinates);
+            var squadComp = EnsureComp<SquadTeamComponent>(squadEnt);
+            ensured = (squadEnt, squadComp);
+        }
+
+        _squadSystem.AssignSquad(entity, (ensured.Owner, (SquadTeamComponent?) ensured.Comp), job);
+
+        // If this is the sergeant, set as squad leader
+        if (IsSquadLeaderRole(originalPrototype, originalJobId))
+        {
+            var memberComp = EnsureComp<SquadMemberComponent>(entity);
+            var leaderIcon = ensured.Comp.LeaderIcon;
+            _squadSystem.PromoteSquadLeader((entity, memberComp), entity, leaderIcon);
+        }
     }
 
     private static string? GetTeamForSide(RoundJobSide side)

--- a/Content.Server/_CMU14/DroneOperator/CMUDroneOperatorSystem.cs
+++ b/Content.Server/_CMU14/DroneOperator/CMUDroneOperatorSystem.cs
@@ -12,6 +12,7 @@ using Content.Server.Radio.EntitySystems;
 using Content.Server._RMC14.Humanoid.Markings;
 using Content.Shared._CMU14.DroneOperator;
 using Content.Shared._CMU14.Threats.Mobs.Xeno.Caste.Warlock;
+using Content.Shared._CMU14.ZLevels.Core.EntitySystems;
 using Content.Shared._RMC14.Humanoid.Markings;
 using Content.Shared._RMC14.Marines.Skills;
 using Content.Shared._RMC14.Synth;
@@ -89,6 +90,7 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
     [Dependency] private SharedToolSystem _tool = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private CMUXenoWarlockSystem _warlockParticles = default!;
+    [Dependency] private CMUSharedZLevelsSystem _zLevels = default!;
 
     private static readonly EntProtoId EndControlActionId = "CMUActionDroneEndControl";
     private static readonly TimeSpan LeashCheckInterval = TimeSpan.FromSeconds(0.5);
@@ -1450,7 +1452,7 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
             return false;
         }
 
-        if (!IsSameMapInRange(user, drone.Owner, tablet.Comp.Range))
+        if (!IsInControlRange(user, drone.Owner, tablet.Comp.Range))
         {
             reason = Loc.GetString("cmu-drone-follow-out-of-range");
             return false;
@@ -1749,7 +1751,7 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
             return false;
         }
 
-        if (!IsSameMapInRange(user, drone.Owner, tablet.Comp.Range))
+        if (!IsInControlRange(user, drone.Owner, tablet.Comp.Range))
         {
             reason = Loc.GetString("cmu-drone-control-out-of-range");
             return false;
@@ -1792,7 +1794,7 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
             return;
         }
 
-        if (!TryGetSameMapDistance(drone.Comp.Operator, drone.Owner, out var distance) ||
+        if (!TryGetControlDistance(drone.Comp.Operator, drone.Owner, tablet.Range, out var distance) ||
             distance > tablet.Range)
         {
             QueueEndControl(drone, Loc.GetString("cmu-drone-control-ended-leash"));
@@ -2380,12 +2382,12 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
                !TerminatingOrDeleted(drone);
     }
 
-    private bool IsSameMapInRange(EntityUid first, EntityUid second, float range)
+    private bool IsInControlRange(EntityUid first, EntityUid second, float range)
     {
-        return TryGetSameMapDistance(first, second, out var distance) && distance <= range;
+        return TryGetControlDistance(first, second, range, out var distance) && distance <= range;
     }
 
-    private bool TryGetSameMapDistance(EntityUid first, EntityUid second, out float distance)
+    private bool TryGetControlDistance(EntityUid first, EntityUid second, float maxDistance, out float distance)
     {
         distance = 0f;
 
@@ -2395,14 +2397,26 @@ public sealed partial class CMUDroneOperatorSystem : EntitySystem
         var firstCoords = _transform.GetMapCoordinates(first);
         var secondCoords = _transform.GetMapCoordinates(second);
 
-        if (firstCoords.MapId != secondCoords.MapId ||
-            firstCoords.MapId == MapId.Nullspace)
-        {
+        if (firstCoords.MapId == MapId.Nullspace || secondCoords.MapId == MapId.Nullspace)
             return false;
+
+        if (firstCoords.MapId == secondCoords.MapId)
+        {
+            distance = Vector2.Distance(firstCoords.Position, secondCoords.Position);
+            return true;
         }
 
-        distance = (firstCoords.Position - secondCoords.Position).Length();
-        return true;
+        var firstMap = Transform(first).MapUid;
+        var secondMap = Transform(second).MapUid;
+        return firstMap is { } resolvedFirstMap &&
+               secondMap is { } resolvedSecondMap &&
+               _zLevels.TryGetDistanceViaAdjacentLevelOpening(
+                   resolvedFirstMap,
+                   firstCoords.Position,
+                   resolvedSecondMap,
+                   secondCoords.Position,
+                   maxDistance,
+                   out distance);
     }
 
     private bool TryDistance(EntityUid first, EntityUid second, out float distance)

--- a/Content.Server/_RMC14/Mortar/MortarSystem.cs
+++ b/Content.Server/_RMC14/Mortar/MortarSystem.cs
@@ -7,7 +7,6 @@ using Content.Shared._CMU14.ZLevels.Ordnance;
 using Content.Shared._RMC14.Areas;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Mortar;
-using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Rangefinder;
 using Content.Shared.Maps;
 using Robust.Server.Containers;
@@ -30,7 +29,6 @@ public sealed partial class MortarSystem : SharedMortarSystem
     [Dependency] private PopupSystem _popup = default!;
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private RMCMapSystem _rmcMap = default!;
-    [Dependency] private RMCPlanetSystem _rmcPlanet = default!;
     [Dependency] private ITileDefinitionManager _tile = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private CMUTopDownOrdnanceSystem _topDownOrdnance = default!;
@@ -51,6 +49,12 @@ public sealed partial class MortarSystem : SharedMortarSystem
         if (!mortar.Comp.Deployed)
         {
             _popup.PopupEntity(Loc.GetString("rmc-mortar-not-deployed", ("mortar", mortar)), user, user, SmallCaution);
+            return false;
+        }
+
+        if (!CanOperateMortarAt(_transform.GetMoverCoordinates(mortar)))
+        {
+            _popup.PopupEntity(Loc.GetString("rmc-mortar-covered", ("mortar", mortar)), user, user, SmallCaution);
             return false;
         }
 
@@ -126,7 +130,7 @@ public sealed partial class MortarSystem : SharedMortarSystem
         }
 
         coordinates = new MapCoordinates(Vector2.Zero, mortarCoordinates.MapId);
-        _rmcPlanet.TryGetOffset(coordinates, out var offset);
+        TryGetPlanetOffset(coordinates, out var offset);
 
         target -= offset;
         coordinates = coordinates.Offset(target);
@@ -138,7 +142,7 @@ public sealed partial class MortarSystem : SharedMortarSystem
         travelTime = default;
 
         // Check if target is on planet or in space
-        if (_rmcPlanet.IsOnPlanet(coordinates))
+        if (IsOnPlanetZLevel(coordinates))
         {
             travelTime = shell?.Comp.TravelDelay ?? default;
         }

--- a/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
+++ b/Content.Server/_RMC14/Rules/CMDistressSignalRuleSystem.cs
@@ -8,6 +8,7 @@ using Content.Server._RMC14.Marines;
 using Content.Server._RMC14.Power;
 using Content.Server._RMC14.Stations;
 using Content.Server._RMC14.Xenonids.Hive;
+using Content.Server._RMC14.Xenonids.JoinXeno;
 using Content.Server.Administration.Logs;
 using Content.Server.Administration.Managers;
 using Content.Server.AU14.Round;
@@ -126,6 +127,7 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
     [Dependency] private XenoHiveSystem _hive = default!;
     [Dependency] private HungerSystem _hunger = default!;
     [Dependency] private ItemCamouflageSystem _camo = default!;
+    [Dependency] private LarvaQueueSystem _larvaQueue = default!;
     [Dependency] private MapLoaderSystem _mapLoader = default!;
     [Dependency] private IMapManager _mapManager = default!;
     [Dependency] private MapSystem _mapSystem = default!;
@@ -939,6 +941,9 @@ public sealed partial class CMDistressSignalRuleSystem : GameRuleSystem<CMDistre
 
                         var origin = _transform.GetMoverCoordinates(xeno);
                         _popup.PopupCoordinates(Loc.GetString("rmc-xeno-hibernation"), origin, Filter.SinglePlayer(session), true, PopupType.MediumXeno);
+
+                        if (comp.CountedInSlots && _hive.GetHive(xeno) is { } hive)
+                            _larvaQueue.AddToLarvaQueueFront(hive, session.UserId);
                     }
 
                     QueueDel(xeno);

--- a/Content.Server/_RMC14/Weapons/Ranged/Sharp/SharpSystem.cs
+++ b/Content.Server/_RMC14/Weapons/Ranged/Sharp/SharpSystem.cs
@@ -37,6 +37,7 @@ public sealed partial class SharpSystem : EntitySystem
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedAudioSystem _audio = default!;
     [Dependency] private SharedAuraSystem _aura = default!;
+    [Dependency] private CollisionWakeSystem _collisionWake = default!;
     [Dependency] private GunIFFSystem _gunIff = default!;
     [Dependency] private EntityLookupSystem _lookup = default!;
     [Dependency] private MobStateSystem _mobState = default!;
@@ -320,6 +321,7 @@ public sealed partial class SharpSystem : EntitySystem
         var mine = Spawn(projectile.Comp.Mine, coordinates);
         var xform = Transform(mine);
         _transform.AnchorEntity(mine, xform);
+        _collisionWake.SetEnabled(mine, false);
         _physics.SetBodyType(mine, BodyType.Static);
 
         if (_projectileIffQuery.TryComp(projectile, out var projectileIff) &&

--- a/Content.Server/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/JoinXeno/LarvaQueueSystem.cs
@@ -267,6 +267,16 @@ public sealed partial class LarvaQueueSystem : EntitySystem
         return _queues.TryGetValue(hive, out queue!);
     }
 
+    public void AddToLarvaQueueFront(Entity<HiveComponent> hive, NetUserId userId)
+    {
+        if (_pendingClaims.ContainsKey(userId))
+            return;
+
+        RemoveFromAllQueues(userId);
+        QueueFor(hive.Owner).AddReadyFirst(userId);
+        NotifyReadyPositions(hive.Owner);
+    }
+
     public void TryClaimQueueable(EntityUid uid)
     {
         if (TryComp(uid, out HiveMemberComponent? member) &&

--- a/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.View.cs
+++ b/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.View.cs
@@ -14,8 +14,9 @@ public abstract partial class CMUSharedZLevelsSystem
 {
     [Dependency] protected ITileDefinitionManager TilDefMan = default!;
 
-    private readonly CMUZLevelOpeningCache _sharedOpeningCache = new();
+    private readonly List<(Vector2 Center, float Distance)> _distanceOpeningCandidates = new();
     private readonly List<Entity<MapGridComponent>> _openingGridScratch = new();
+    private readonly CMUZLevelOpeningCache _sharedOpeningCache = new();
 
     private void InitView()
     {
@@ -155,6 +156,61 @@ public abstract partial class CMUSharedZLevelsSystem
             _transform,
             TilDefMan,
             edgeOnly: false);
+    }
+
+    /// <summary>
+    /// Gets the shortest distance between positions on adjacent z-levels by routing through an opening.
+    /// </summary>
+    public bool TryGetDistanceViaAdjacentLevelOpening(
+        EntityUid firstMap,
+        Vector2 firstPosition,
+        EntityUid secondMap,
+        Vector2 secondPosition,
+        float searchRadius,
+        out float distance)
+    {
+        distance = 0f;
+
+        if (!float.IsFinite(searchRadius) ||
+            searchRadius < 0f ||
+            !_zMapQuery.TryComp(firstMap, out var firstZMap) ||
+            !_zMapQuery.TryComp(secondMap, out var secondZMap) ||
+            !firstZMap.NetworkUid.IsValid() ||
+            firstZMap.NetworkUid != secondZMap.NetworkUid ||
+            Math.Abs(firstZMap.Depth - secondZMap.Depth) != 1)
+        {
+            return false;
+        }
+
+        var openingMap = firstZMap.Depth > secondZMap.Depth ? firstMap : secondMap;
+        if (!_mapQuery.TryComp(openingMap, out var openingMapComp))
+            return false;
+
+        _distanceOpeningCandidates.Clear();
+        _sharedOpeningCache.FindOpeningCentersNear(
+            openingMapComp.MapId,
+            firstPosition,
+            searchRadius,
+            _distanceOpeningCandidates,
+            _openingGridScratch,
+            _mapManager,
+            _map,
+            _transform,
+            TilDefMan,
+            edgeOnly: false);
+
+        var shortestDistance = float.PositiveInfinity;
+        foreach (var (opening, firstDistance) in _distanceOpeningCandidates)
+        {
+            var routeDistance = firstDistance + Vector2.Distance(opening, secondPosition);
+            shortestDistance = MathF.Min(shortestDistance, routeDistance);
+        }
+
+        if (float.IsPositiveInfinity(shortestDistance))
+            return false;
+
+        distance = shortestDistance;
+        return true;
     }
 
     public bool TryFindZShotOpening(

--- a/Content.Shared/_CMU14/ZLevels/Ordnance/CMUTopDownOrdnanceSystem.cs
+++ b/Content.Shared/_CMU14/ZLevels/Ordnance/CMUTopDownOrdnanceSystem.cs
@@ -139,6 +139,40 @@ public sealed partial class CMUTopDownOrdnanceSystem : EntitySystem
         return false;
     }
 
+    /// <summary>
+    /// Checks whether every connected Z-level above these coordinates is open.
+    /// Maps outside a Z-level network have no additional surfaces above them.
+    /// </summary>
+    public bool IsOpenToSky(MapCoordinates coordinates)
+    {
+        if (!_map.TryGetMap(coordinates.MapId, out var mapUid) ||
+            mapUid is not { } resolvedMapUid)
+        {
+            return false;
+        }
+
+        if (!_zLevels.TryGetZNetwork(resolvedMapUid, out var network))
+            return true;
+
+        if (!_zLevels.TryGetDepthBounds(network.Value, out _, out var maxDepth) ||
+            !TryGetDepth(network.Value, resolvedMapUid, out var currentDepth))
+        {
+            return false;
+        }
+
+        for (var depth = currentDepth + 1; depth <= maxDepth; depth++)
+        {
+            if (!_zLevels.TryGetMapAtDepth(network.Value, depth, out _, out var mapComp))
+                continue;
+
+            var above = new MapCoordinates(coordinates.Position, mapComp.MapId);
+            if (!IsOpening(above))
+                return false;
+        }
+
+        return true;
+    }
+
     public bool IsOpening(MapCoordinates coordinates)
     {
         if (!_map.TryFindGridAt(coordinates, out var gridUid, out var grid))

--- a/Content.Shared/_RMC14/Cassette/SharedCassetteSystem.cs
+++ b/Content.Shared/_RMC14/Cassette/SharedCassetteSystem.cs
@@ -184,7 +184,7 @@ public abstract partial class SharedCassetteSystem : EntitySystem
                 audioParams = audioParams.WithVolume(SharedAudioSystem.GainToVolume(gain));
             }
 
-            player.Comp.AudioStream = _audio.PlayGlobal(song, actor, audioParams)?.Entity;
+            player.Comp.AudioStream = _audio.PlayEntity(song, actor, player, audioParams)?.Entity;
         }
 
         player.Comp.Tape = tape.Value;

--- a/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
+++ b/Content.Shared/_RMC14/Mortar/SharedMortarSystem.cs
@@ -149,7 +149,7 @@ public abstract partial class SharedMortarSystem : EntitySystem
         _transform.SetCoordinates(mortar, xform, coordinates, rotation);
         _transform.AnchorEntity((mortar, xform));
 
-        if (!_rmcPlanet.IsOnPlanet(coordinates))
+        if (!IsOnPlanetZLevel(_transform.ToMapCoordinates(coordinates)))
             _popup.PopupClient(Loc.GetString("rmc-mortar-deploy-end-not-planet"), user, user, PopupType.MediumCaution);
 
         _audio.PlayPredicted(mortar.Comp.DeploySound, mortar, user);
@@ -172,7 +172,7 @@ public abstract partial class SharedMortarSystem : EntitySystem
         var target = args.Vector;
         var position = _transform.GetMapCoordinates(mortar).Position;
         var offset = target;
-        if (_rmcPlanet.TryGetOffset(_transform.GetMapCoordinates(mortar.Owner), out var planetOffset))
+        if (TryGetPlanetOffset(_transform.GetMapCoordinates(mortar.Owner), out var planetOffset))
             offset -= planetOffset;
 
         mortar.Comp.Target = target;
@@ -393,7 +393,7 @@ public abstract partial class SharedMortarSystem : EntitySystem
         Spawn(ent.Comp.Flare, coords);
         var camera = Spawn(ent.Comp.Camera, coords);
 
-        if (_rmcPlanet.TryGetOffset(coords, out var offset))
+        if (TryGetPlanetOffset(coords, out var offset))
             coords = coords.Offset(offset);
 
         var (x, y) = coords.Position;
@@ -490,12 +490,39 @@ public abstract partial class SharedMortarSystem : EntitySystem
         return false;
     }
 
+    protected bool CanOperateMortarAt(EntityCoordinates coordinates)
+    {
+        var mapCoordinates = _transform.ToMapCoordinates(coordinates);
+        if (!_topDownOrdnance.IsOpenToSky(mapCoordinates))
+            return false;
+
+        if (_area.CanMortarPlacement(coordinates))
+            return true;
+
+        return _rmcPlanet.TryGetPlanetSurfaceCoordinates(mapCoordinates, out var planetCoordinates) &&
+               planetCoordinates.MapId != mapCoordinates.MapId;
+    }
+
+    protected bool IsOnPlanetZLevel(MapCoordinates coordinates)
+    {
+        return _rmcPlanet.TryGetPlanetSurfaceCoordinates(coordinates, out _);
+    }
+
+    protected bool TryGetPlanetOffset(MapCoordinates coordinates, out Vector2i offset)
+    {
+        if (_rmcPlanet.TryGetPlanetSurfaceCoordinates(coordinates, out var planetCoordinates))
+            return _rmcPlanet.TryGetOffset(planetCoordinates, out offset);
+
+        offset = default;
+        return false;
+    }
+
     private bool CanDeployPopup(Entity<MortarComponent> mortar, EntityUid user)
     {
         if (!HasSkillPopup(mortar, user, true))
             return false;
 
-        if (!_area.CanMortarPlacement(user.ToCoordinates()))
+        if (!CanOperateMortarAt(user.ToCoordinates()))
         {
             _popup.PopupClient(Loc.GetString("rmc-mortar-covered", ("mortar", mortar)), user, user, PopupType.SmallCaution);
             return false;

--- a/Content.Shared/_RMC14/Rules/RMCPlanetSystem.cs
+++ b/Content.Shared/_RMC14/Rules/RMCPlanetSystem.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Linq;
+using Content.Shared._CMU14.ZLevels.Core.EntitySystems;
 using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Power;
 using Content.Shared._RMC14.TacticalMap;
@@ -28,6 +29,7 @@ public sealed partial class RMCPlanetSystem : EntitySystem
     [Dependency] private IRobustRandom _random = default!;
     [Dependency] private SharedRMCPowerSystem _rmcPower = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private CMUSharedZLevelsSystem _zLevels = default!;
 
     private int _coordinateVariance;
     private float _hijackSongGain;
@@ -120,6 +122,30 @@ public sealed partial class RMCPlanetSystem : EntitySystem
     public bool IsOnPlanet(MapCoordinates coordinates)
     {
         return IsOnPlanet(_transform.ToCoordinates(coordinates));
+    }
+
+    /// <summary>
+    /// Resolves coordinates on a connected Z-level to the depth-zero planet map.
+    /// Coordinates already on a planet map or grid are returned unchanged.
+    /// </summary>
+    public bool TryGetPlanetSurfaceCoordinates(MapCoordinates coordinates, out MapCoordinates planetCoordinates)
+    {
+        planetCoordinates = coordinates;
+        if (IsOnPlanet(coordinates))
+            return true;
+
+        var entityCoordinates = _transform.ToCoordinates(coordinates);
+        if (_transform.GetMap(entityCoordinates) is not { } mapUid ||
+            !_zLevels.TryGetZNetwork(mapUid, out var network) ||
+            !_zLevels.TryGetMapAtDepth(network.Value, 0, out var planetMap) ||
+            !_zLevels.TryGetMapCoordinates(planetMap, coordinates.Position, out planetCoordinates) ||
+            !IsOnPlanet(planetCoordinates))
+        {
+            planetCoordinates = default;
+            return false;
+        }
+
+        return true;
     }
 
     public bool TryGetOffset(MapCoordinates coordinates, out Vector2i offset)

--- a/Content.Shared/_RMC14/Sentry/SharedSentryTargettingSystem.cs
+++ b/Content.Shared/_RMC14/Sentry/SharedSentryTargettingSystem.cs
@@ -328,10 +328,11 @@ public abstract partial class SharedSentryTargetingSystem : EntitySystem
 
     private void UpdateSentryIFF(Entity<SentryTargetingComponent> ent)
     {
-        if (!TryComp<UserIFFComponent>(ent.Owner, out var userIff))
-            return;
+        EnsureComp<EntityIFFComponent>(ent.Owner);
+        var userIff = EnsureComp<UserIFFComponent>(ent.Owner);
 
-        _iff.ClearUserFactions((ent.Owner, userIff));
+        foreach (var managedIff in SentryFactionToIff.Values)
+            _iff.RemoveUserFaction((ent.Owner, userIff), managedIff);
 
         foreach (var faction in ent.Comp.FriendlyFactions)
         {

--- a/Content.Shared/_RMC14/Weapons/Melee/MeleeResetComponent.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/MeleeResetComponent.cs
@@ -8,4 +8,10 @@ public sealed partial class MeleeResetComponent : Component
 {
     [DataField, AutoNetworkedField]
     public TimeSpan OriginalTime;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan OriginalUserTime;
+
+    [DataField, AutoNetworkedField]
+    public bool ResetUserCooldown;
 }

--- a/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Melee/SharedRMCMeleeWeaponSystem.cs
@@ -71,6 +71,15 @@ public abstract partial class SharedRMCMeleeWeaponSystem : EntitySystem
 
         ent.Comp.OriginalTime = weapon.NextAttack;
         weapon.NextAttack = _timing.CurTime;
+
+        ent.Comp.ResetUserCooldown = TryComp(ent, out RMCMeleeUserCooldownComponent? userCooldown);
+        if (userCooldown != null)
+        {
+            ent.Comp.OriginalUserTime = userCooldown.NextAttack;
+            userCooldown.NextAttack = _timing.CurTime;
+            Dirty(ent, userCooldown);
+        }
+
         Dirty(ent, weapon);
         Dirty(ent, ent.Comp);
     }
@@ -213,7 +222,15 @@ public abstract partial class SharedRMCMeleeWeaponSystem : EntitySystem
             return;
 
         if (disarm)
+        {
             weapon.NextAttack = reset.OriginalTime;
+
+            if (reset.ResetUserCooldown && TryComp(weaponUid, out RMCMeleeUserCooldownComponent? userCooldown))
+            {
+                userCooldown.NextAttack = reset.OriginalUserTime;
+                Dirty(weaponUid, userCooldown);
+            }
+        }
 
         RemComp<MeleeResetComponent>(weaponUid);
         Dirty(weaponUid, weapon);

--- a/Content.Shared/_RMC14/Xenonids/Bulwark/XenoBulwarkSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bulwark/XenoBulwarkSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared._RMC14.Weapons.Ranged.Prediction;
 using Content.Shared._RMC14.Xenonids.Projectile;
 using Content.Shared._RMC14.Xenonids.Sweep;
 using Content.Shared.Actions;
+using Content.Shared.Actions.Events;
 using Content.Shared.Coordinates;
 using Content.Shared.Damage;
 using Content.Shared.Interaction;
@@ -67,6 +68,7 @@ public sealed partial class XenoBulwarkSystem : EntitySystem
         SubscribeLocalEvent<XenoBulwarkComponent, XenoBulwarkTailSwingActionEvent>(OnTailSwingAction);
         SubscribeLocalEvent<XenoBulwarkComponent, XenoReflectiveShieldActionEvent>(OnReflectiveShieldAction);
         SubscribeLocalEvent<XenoBulwarkComponent, ProjectileReflectAttemptEvent>(OnReflectAttempt);
+        SubscribeLocalEvent<XenoReflectiveShieldActionComponent, ActionPerformedEvent>(OnReflectiveShieldPerformed);
     }
 
     private void OnGetArmor(Entity<XenoBulwarkComponent> xeno, ref CMGetArmorEvent args)
@@ -270,6 +272,14 @@ public sealed partial class XenoBulwarkSystem : EntitySystem
             _actions.SetToggled(action.AsNullable(), true);
     }
 
+    private void OnReflectiveShieldPerformed(Entity<XenoReflectiveShieldActionComponent> action, ref ActionPerformedEvent args)
+    {
+        if (!TryComp(args.Performer, out XenoBulwarkComponent? bulwark) || bulwark.Reflecting)
+            return;
+
+        _actions.SetCooldown(action.Owner, GetReflectCooldown((args.Performer, bulwark), true));
+    }
+
     private void OnReflectAttempt(Entity<XenoBulwarkComponent> xeno, ref ProjectileReflectAttemptEvent args)
     {
         if (args.Cancelled || !xeno.Comp.Reflecting || HasComp<XenoProjectileComponent>(args.ProjUid))
@@ -347,25 +357,25 @@ public sealed partial class XenoBulwarkSystem : EntitySystem
         xeno.Comp.Reflecting = false;
         Dirty(xeno);
 
-        TimeSpan cooldown;
-        if (refund)
-        {
-            var elapsed = _timing.CurTime - xeno.Comp.ReflectStartedAt;
-            var seconds = Math.Max(
-                xeno.Comp.ReflectMinCooldown.TotalSeconds,
-                elapsed.TotalSeconds * xeno.Comp.ReflectCooldownPerSecond);
-            cooldown = TimeSpan.FromSeconds(seconds);
-        }
-        else
-        {
-            cooldown = xeno.Comp.ReflectFullCooldown;
-        }
+        var cooldown = GetReflectCooldown(xeno, refund);
 
         foreach (var action in _rmcActions.GetActionsWithEvent<XenoReflectiveShieldActionEvent>(xeno))
         {
             _actions.SetToggled(action.AsNullable(), false);
             _actions.SetCooldown(action.AsNullable(), cooldown);
         }
+    }
+
+    private TimeSpan GetReflectCooldown(Entity<XenoBulwarkComponent> xeno, bool refund)
+    {
+        if (!refund)
+            return xeno.Comp.ReflectFullCooldown;
+
+        var elapsed = _timing.CurTime - xeno.Comp.ReflectStartedAt;
+        var seconds = Math.Max(
+            xeno.Comp.ReflectMinCooldown.TotalSeconds,
+            elapsed.TotalSeconds * xeno.Comp.ReflectCooldownPerSecond);
+        return TimeSpan.FromSeconds(seconds);
     }
 
     private void SetTailSwingCooldown(EntityUid xeno, TimeSpan cooldown)

--- a/Content.Shared/_RMC14/Xenonids/Bulwark/XenoReflectiveShieldActionComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Bulwark/XenoReflectiveShieldActionComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Bulwark;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoBulwarkSystem))]
+public sealed partial class XenoReflectiveShieldActionComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Charge/CursorCharge/XenoChargerCollisionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/CursorCharge/XenoChargerCollisionSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._RMC14.Vehicle;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.Destructible;
 using Content.Shared.FixedPoint;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
@@ -35,6 +36,7 @@ public sealed partial class XenoChargerCollisionSystem : EntitySystem
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private DamageableSystem _damageable = default!;
+    [Dependency] private SharedDestructibleSystem _destructible = default!;
     [Dependency] private SharedStunSystem _stun = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private XenoSystem _xeno = default!;
@@ -360,11 +362,8 @@ public sealed partial class XenoChargerCollisionSystem : EntitySystem
         if (_physicsQuery.TryGetComponent(target, out var wallPhysics) &&
             wallPhysics.Hard && wallPhysics.BodyType == BodyType.Static)
         {
-
-            if (TryComp(target, out XenoCrusherChargableComponent? crushchargable) && crushchargable.PassOnDestroy)
-                return;
-
-            if (!HasComp<DamageableComponent>(target))
+            if (!HasComp<XenoCrusherChargableComponent>(target) ||
+                !HasComp<DamageableComponent>(target))
             {
                 _movement.ResetToIdle(charger);
                 return;
@@ -372,12 +371,21 @@ public sealed partial class XenoChargerCollisionSystem : EntitySystem
 
             var damage = new DamageSpecifier();
             damage.DamageDict[_blunt] = (stage + 1) * xeno.ChargedDamageBase;
-            _damageable.TryChangeDamage(target, damage);
+            var damageChanged = _damageable.TryChangeDamage(target, damage);
+
+            if (damageChanged == null || damageChanged.GetTotal() <= FixedPoint2.Zero)
+            {
+                _movement.ResetToIdle(charger);
+                return;
+            }
 
             if (stage >= 7)
             {
-                if (_net.IsServer)
-                    BreakWall(charger, target, state.LungeDirection);
+                if (!TryBreakWall(target))
+                {
+                    _movement.ResetToIdle(charger);
+                    return;
+                }
 
                 state.Stage = Math.Max(0, state.Stage - 1);
                 Dirty(charger, state);
@@ -395,21 +403,15 @@ public sealed partial class XenoChargerCollisionSystem : EntitySystem
         }
     }
 
-    private void BreakWall(EntityUid charger, EntityUid wall, Vector2 lungeDirection)
+    private bool TryBreakWall(EntityUid wall)
     {
-        //WIP but not really that important.
-
         if (!_net.IsServer)
-            return;
+            return false;
 
-        if (TerminatingOrDeleted(charger))
-            return;
+        if (TerminatingOrDeleted(wall))
+            return true;
 
-        //if its not indestructible, delete.
-        if (HasComp<DamageableComponent>(wall))
-            Del(wall);
-
-        //was gonna add some shrapnel throwing code here, but it had hands so im not doing it now.
+        return _destructible.DestroyEntity(wall);
     }
 
     private Vector2 GetWallNormal(EntityUid charger, EntityUid wall)

--- a/Content.Shared/_RMC14/Xenonids/Invisibility/XenoInvisibilitySystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Invisibility/XenoInvisibilitySystem.cs
@@ -5,6 +5,8 @@ using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Leap;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Actions.Events;
 using Content.Shared.DoAfter;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Systems;
@@ -30,6 +32,7 @@ public sealed partial class XenoInvisibilitySystem : EntitySystem
     [Dependency] private XenoPlasmaSystem _xenoPlasma = default!;
 
     private readonly HashSet<EntityUid> _contacts = new();
+    private readonly Dictionary<EntityUid, PendingActionState> _pendingActionStates = new();
 
     private EntityQuery<MarineComponent> _marineQuery;
     private EntityQuery<MobCollisionComponent> _mobCollisionQuery;
@@ -42,6 +45,7 @@ public sealed partial class XenoInvisibilitySystem : EntitySystem
         _xenoQuery = GetEntityQuery<XenoComponent>();
 
         SubscribeLocalEvent<XenoTurnInvisibleComponent, XenoTurnInvisibleActionEvent>(OnXenoTurnInvisibleAction);
+        SubscribeLocalEvent<ActionComponent, ActionPerformedEvent>(OnActionPerformed);
 
         SubscribeLocalEvent<XenoActiveInvisibleComponent, ComponentRemove>(OnXenoActiveInvisibleRemove);
         SubscribeLocalEvent<XenoActiveInvisibleComponent, MeleeHitEvent>(OnXenoActiveInvisibleMeleeHit);
@@ -63,7 +67,7 @@ public sealed partial class XenoInvisibilitySystem : EntitySystem
         if (TryComp<XenoActiveInvisibleComponent>(xeno, out var invis))
         {
             var refundedCooldown = GetRefundedCooldown(xeno, invis, xeno.Comp.ManualRefundMultiplier);
-            RemoveInvisibility((xeno, invis), refundedCooldown);
+            RemoveInvisibility((xeno, invis), refundedCooldown, args.Action);
         }
         else
         {
@@ -74,9 +78,19 @@ public sealed partial class XenoInvisibilitySystem : EntitySystem
             Dirty(xeno, active);
 
             //Half a second cooldown to prevent double clicks
-            StartCooldown((xeno, active), xeno.Comp.ToggleLockoutTime, true);
+            QueueActionState(args.Action, xeno.Comp.ToggleLockoutTime, true);
             _movementSpeed.RefreshMovementSpeedModifiers(xeno);
         }
+    }
+
+    private void OnActionPerformed(Entity<ActionComponent> action, ref ActionPerformedEvent args)
+    {
+        if (!_pendingActionStates.Remove(action, out var pending))
+            return;
+
+        var actionEnt = action.AsNullable();
+        _actions.SetCooldown(actionEnt, pending.Cooldown);
+        _actions.SetToggled(actionEnt, pending.Toggled);
     }
 
     private void OnXenoActiveInvisibleRemove(Entity<XenoActiveInvisibleComponent> xeno, ref ComponentRemove args)
@@ -141,10 +155,19 @@ public sealed partial class XenoInvisibilitySystem : EntitySystem
         }
     }
 
-    private void RemoveInvisibility(Entity<XenoActiveInvisibleComponent> xeno, TimeSpan cooldownTime)
+    private void QueueActionState(EntityUid action, TimeSpan cooldownTime, bool toggledStatus)
+    {
+        _pendingActionStates[action] = new PendingActionState(cooldownTime, toggledStatus);
+    }
+
+    private void RemoveInvisibility(Entity<XenoActiveInvisibleComponent> xeno, TimeSpan cooldownTime, EntityUid? performedAction = null)
     {
         RemCompDeferred<XenoActiveInvisibleComponent>(xeno);
-        StartCooldown(xeno, cooldownTime, false);
+        if (performedAction is { } action)
+            QueueActionState(action, cooldownTime, false);
+        else
+            StartCooldown(xeno, cooldownTime, false);
+
         _movementSpeed.RefreshMovementSpeedModifiers(xeno);
 
         if (!xeno.Comp.DidPopup)
@@ -203,4 +226,6 @@ public sealed partial class XenoInvisibilitySystem : EntitySystem
             RemoveInvisibility((uid, active), active.FullCooldown);
         }
     }
+
+    private readonly record struct PendingActionState(TimeSpan Cooldown, bool Toggled);
 }

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapSystem.cs
@@ -87,6 +87,8 @@ public sealed partial class XenoLeapSystem : EntitySystem
 
     public override void Initialize()
     {
+        UpdatesAfter.Add(typeof(SharedPhysicsSystem));
+
         _physicsQuery = GetEntityQuery<PhysicsComponent>();
         _fixturesQuery = GetEntityQuery<FixturesComponent>();
 
@@ -218,6 +220,8 @@ public sealed partial class XenoLeapSystem : EntitySystem
         var impulse = direction.Normalized() * xeno.Comp.Strength * physics.Mass;
 
         leaping.Origin = _transform.GetMoverCoordinates(xeno);
+        leaping.Destination = origin.Offset(direction);
+        leaping.Direction = direction.Normalized();
         leaping.ParalyzeTime = xeno.Comp.KnockdownTime;
         leaping.LeapSound = xeno.Comp.LeapSound;
         leaping.LeapEndTime = _timing.CurTime + TimeSpan.FromSeconds(direction.Length() / xeno.Comp.Strength);
@@ -671,6 +675,15 @@ public sealed partial class XenoLeapSystem : EntitySystem
         var leaping = EntityQueryEnumerator<XenoLeapingComponent>();
         while (leaping.MoveNext(out var uid, out var comp))
         {
+            var coordinates = _transform.GetMapCoordinates(uid);
+            if (coordinates.MapId == comp.Destination.MapId &&
+                Vector2.Dot(coordinates.Position - comp.Destination.Position, comp.Direction) >= 0)
+            {
+                _transform.SetMapCoordinates(uid, comp.Destination);
+                StopLeap((uid, comp));
+                continue;
+            }
+
             if (time < comp.LeapEndTime)
                 continue;
 

--- a/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapingComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Leap/XenoLeapingComponent.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Shared.Damage;
 using Content.Shared.Physics;
 using Robust.Shared.Audio;
@@ -14,6 +15,12 @@ public sealed partial class XenoLeapingComponent : Component
 {
     [DataField, AutoNetworkedField]
     public EntityCoordinates Origin;
+
+    [DataField, AutoNetworkedField]
+    public MapCoordinates Destination;
+
+    [DataField, AutoNetworkedField]
+    public Vector2 Direction;
 
     [DataField, AutoNetworkedField]
     public TimeSpan ParalyzeTime;

--- a/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
@@ -180,6 +180,13 @@ public sealed partial class XenoStompSystem : EntitySystem
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
                 continue;
 
+            if (IsBlockedByObstacle(
+                    origin,
+                    _transform.GetMapCoordinates(receiver),
+                    xeno.Owner,
+                    ignoreBarricades: xeno.Comp.StompsThroughBarricades))
+                continue;
+
             if (xeno.Comp.SlowBigInsteadOfStun && _size.TryGetSize(receiver, out var size) && size >= RMCSizes.Big)
                 _slow.TrySlowdown(receiver, xeno.Comp.DebuffsHurtXenosMore ? _xeno.TryApplyXenoDebuffMultiplier(receiver, xeno.Comp.ParalyzeTime)
                     : xeno.Comp.ParalyzeTime, true);
@@ -316,7 +323,11 @@ public sealed partial class XenoStompSystem : EntitySystem
         }
     }
 
-    private bool IsBlockedByObstacle(MapCoordinates origin, MapCoordinates target, EntityUid ignore)
+    private bool IsBlockedByObstacle(
+        MapCoordinates origin,
+        MapCoordinates target,
+        EntityUid ignore,
+        bool ignoreBarricades = false)
     {
         if (origin.MapId != target.MapId)
             return true;
@@ -326,8 +337,11 @@ public sealed partial class XenoStompSystem : EntitySystem
         if (distance < 0.1f)
             return false;
 
-        var mask = (int) (CollisionGroup.Impassable | CollisionGroup.InteractImpassable | CollisionGroup.BarricadeImpassable);
-        var ray = new CollisionRay(origin.Position, diff.Normalized(), mask);
+        var mask = CollisionGroup.Impassable | CollisionGroup.InteractImpassable;
+        if (!ignoreBarricades)
+            mask |= CollisionGroup.BarricadeImpassable;
+
+        var ray = new CollisionRay(origin.Position, diff.Normalized(), (int) mask);
         foreach (var _ in _physics.IntersectRay(origin.MapId, ray, distance, ignore, returnOnFirstHit: true))
         {
             return true;

--- a/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/SharedXenoStompSystem.cs
@@ -180,9 +180,6 @@ public sealed partial class XenoStompSystem : EntitySystem
             if (!_xeno.CanAbilityAttackTarget(xeno, receiver))
                 continue;
 
-            if (IsBlockedByObstacle(origin, _transform.GetMapCoordinates(receiver), xeno.Owner))
-                continue;
-
             if (xeno.Comp.SlowBigInsteadOfStun && _size.TryGetSize(receiver, out var size) && size >= RMCSizes.Big)
                 _slow.TrySlowdown(receiver, xeno.Comp.DebuffsHurtXenosMore ? _xeno.TryApplyXenoDebuffMultiplier(receiver, xeno.Comp.ParalyzeTime)
                     : xeno.Comp.ParalyzeTime, true);

--- a/Content.Shared/_RMC14/Xenonids/Stomp/XenoStompComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stomp/XenoStompComponent.cs
@@ -46,6 +46,12 @@ public sealed partial class XenoStompComponent : Component
     [DataField, AutoNetworkedField]
     public float Range = 2.82f;
 
+    /// <summary>
+    ///     Whether circular stomp effects can pass through barricades. Walls, doors, and windows still block them.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool StompsThroughBarricades;
+
     [DataField, AutoNetworkedField]
     public TimeSpan Delay = TimeSpan.Zero;
 

--- a/Content.Tests/Client/UserInterface/Systems/Chat/ChatMarkupParserTest.cs
+++ b/Content.Tests/Client/UserInterface/Systems/Chat/ChatMarkupParserTest.cs
@@ -1,0 +1,34 @@
+using Content.Client.UserInterface.Systems.Chat;
+using NUnit.Framework;
+using Robust.Shared.Utility;
+
+namespace Content.Tests.Client.UserInterface.Systems.Chat;
+
+[TestFixture]
+[TestOf(typeof(ChatMarkupParser))]
+public sealed class ChatMarkupParserTest
+{
+    [Test]
+    public void ValidMarkupUsesStrictParser()
+    {
+        var message = new FormattedMessage();
+
+        var error = ChatMarkupParser.AddMarkup(message, "[bold]Valid message.[/bold]");
+
+        Assert.That(error, Is.Null);
+        Assert.That(message.ToString(), Is.EqualTo("Valid message."));
+    }
+
+    [Test]
+    public void InvalidMarkupFallsBackWithoutThrowing()
+    {
+        var message = new FormattedMessage();
+        const string markup = "[bold invalid.attribute]Visible message.[/bold]";
+
+        string? error = null;
+        Assert.DoesNotThrow(() => error = ChatMarkupParser.AddMarkup(message, markup));
+
+        Assert.That(error, Is.Not.Null);
+        Assert.That(message.ToString(), Does.Contain("Visible message."));
+    }
+}

--- a/Content.Tests/Client/_CMU14/Weapons/CMUMuzzleFlashLightTest.cs
+++ b/Content.Tests/Client/_CMU14/Weapons/CMUMuzzleFlashLightTest.cs
@@ -1,0 +1,29 @@
+using Content.Client.Weapons.Ranged.Systems;
+using NUnit.Framework;
+using Robust.Client.GameObjects;
+using Robust.Shared.GameObjects;
+using Robust.Shared.IoC;
+using Robust.Shared.Map;
+using Robust.UnitTesting;
+
+namespace Content.Tests.Client._CMU14.Weapons;
+
+[TestFixture]
+public sealed class CMUMuzzleFlashLightTest : RobustUnitTest
+{
+    public override UnitTestProject Project => UnitTestProject.Client;
+
+    [Test]
+    public void MuzzleFlashDoesNotConsumeShadowCastingLightCapacity()
+    {
+        var entityManager = IoCManager.Resolve<IEntityManager>();
+        var lights = entityManager.System<PointLightSystem>();
+        var uid = entityManager.SpawnEntity(null, MapCoordinates.Nullspace);
+        var light = lights.EnsureLight(uid);
+
+        GunSystem.ConfigureMuzzleFlashLight(uid, light, lights);
+
+        Assert.That(light.CastShadows, Is.False,
+            "Temporary muzzle flashes must not displace persistent lights from the shadow-light budget.");
+    }
+}

--- a/Resources/Prototypes/_CMU14/Entities/Mobs/drone_android.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Mobs/drone_android.yml
@@ -31,7 +31,7 @@
     generation: cmu-species-drone-android-generation
     critThreshold: 74
     deadThreshold: 80
-    repairTime: 35
+    repairTime: 5
     selfRepairTime: 9999
     hideGeneration: true
     useHumanHealthIcons: true

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Base/round_job_profiles.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Base/round_job_profiles.yml
@@ -23,7 +23,7 @@
     - auwy
   - type: TacticalMapIcon
     icon:
-      sprite: /Textures/_AU14/Interface/au14govforhud.rsi
+      sprite: /Textures/_AU14/Interface/au14colonyjobicons.rsi
       state: working_joe
   - type: Language
     preset: AU14LanguagePresetSynth

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Orbital/AU14JobCivilianOrbitalArbiter.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Orbital/AU14JobCivilianOrbitalArbiter.yml
@@ -76,7 +76,6 @@
     id: AU14IDCardOrbitalArbiter
     ears: AU14OrbitalHeadsetManagement
     back: CMSatchel
-    pocket1: AU14StampOrbitalArb
   storage:
     back:
     - RMCRadioHandheldColonyOff

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Orbital/AU14JobCivilianOrbitalLawyer.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Orbital/AU14JobCivilianOrbitalLawyer.yml
@@ -75,7 +75,6 @@
     ears: AU14OrbitalHeadset
     back: CMSatchel
     neck: AU14MedalLawyerBadge
-    pocket1: AU14StampOrbitalCnsl
   storage:
     back:
     - RMCRadioHandheldColonyOff

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Base/round_job_profiles.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Base/round_job_profiles.yml
@@ -111,7 +111,7 @@
       - DoorBumpOpener
     - type: TacticalMapIcon
       icon:
-        sprite: /Textures/_AU14/Interface/au14govforjobicons.rsi
+        sprite: /Textures/_AU14/Interface/au14opforjobicons.rsi
         state: working_joe
     - type: Language
       preset: AU14LanguagePresetSynth

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Engineering/AuxTech.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Engineering/AuxTech.yml
@@ -165,6 +165,7 @@
   equipment:
     shoes: CMBootsBlackFilled
     back: CMSatchelMarine
+    ears: AU14HeadsetOpforAuxiliary
   storage:
     back:
     - CMStampApproved

--- a/Resources/Prototypes/_CMU14/Roles/WeYu/Loadouts/securityguard.yml
+++ b/Resources/Prototypes/_CMU14/Roles/WeYu/Loadouts/securityguard.yml
@@ -43,7 +43,7 @@
 - type: loadout
   id: WYJumpsuitVeteranPMCCorporateAU14
   equipment:
-    jumpsuit: AU14JumpsuitVeteranPMCCorporate
+    jumpsuit: RMCJumpsuitVeteranPMCCorporate
 
 - type: loadout
   id: WYJumpsuitVeteranPMCKutjevoAU14

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_self_actions.yml
@@ -621,6 +621,7 @@
     useDelay: 1
   - type: InstantAction
     event: !type:Content.Shared._RMC14.Xenonids.Bulwark.XenoReflectiveShieldActionEvent
+  - type: XenoReflectiveShieldAction
   - type: ActionBlockIfResting
 
 - type: entity

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -71,6 +71,7 @@
     selfEffect: CMEffectSelfStomp
     shortRange: 0
     range: 4
+    stompsThroughBarricades: true
     plasmaCost: 100
     paralyzeTime: 2
     slowBigInsteadOfStun: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/vehicle_supply.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/vehicle_supply.yml
@@ -479,7 +479,7 @@
         name: Support
         options:
         - id: VehicleTankWarningArray
-          name: warning array
+          name: weapons sensor array
           item: VehicleTankWarningArray
           slot: support
         - id: VehicleTankOverdriveEnhancer
@@ -603,7 +603,7 @@
         name: Support
         options:
         - id: VehicleTankWarningArray
-          name: warning array
+          name: weapons sensor array
           item: VehicleTankWarningArray
           slot: support
         - id: VehicleTankOverdriveEnhancer
@@ -699,7 +699,7 @@
           item: VehicleSPPTankFlareModule
           slot: support
         - id: VehicleSPPTankWarningArray
-          name: warning array
+          name: weapons sensor array
           item: VehicleSPPTankWarningArray
           slot: support
         - id: VehicleSPPTankOverdriveEnhancer

--- a/Resources/ServerInfo/Guidebook/_AU14/UCMJ/Protectionacts/TheGenevaConventions.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/UCMJ/Protectionacts/TheGenevaConventions.xml
@@ -296,7 +296,7 @@
 
   This goes for Colonists, Corporations, Protected Species and others. This does not include Military NJPs.
 
-# Article 39    Civilian Rights.
+# Article 38    Civilian Rights.
 
   They have rights to free speech, proper protection from threats, access to food and water, access to proper hygienic and medical installations, recreational activities, and other. They shall not be abused in any way by any party.
 


### PR DESCRIPTION
:cl:
- fix: Corrected the Geneva Conventions civilian-rights article number.
- fix: Egg-sac visuals now fall back to the nearest available sprite state instead of showing an error sprite.
- fix: Removed duplicate orbital-law stamps from Orbital Arbiter and Orbital Lawyer loadouts.
- fix: Drone operators can control drones across connected adjacent z-level openings, and drone repair time is corrected.
- fix: The body-zone targeting doll now restores its selected zone after the HUD reloads.
- fix: The corporate security loadout now uses the correct corporate PMC uniform.
- fix: Cancelling a Bulwark reflective shield early now applies its minimum cooldown.
- fix: Burrower stomp can pass through barricades without passing through walls or other protected structures.
- fix: Malformed chat markup now falls back safely instead of crashing chat rendering.
- fix: Stranded xenos are correctly offered eligible burrowed larva through the larva queue.
- fix: Sustained gunfire no longer causes muzzle-flash lighting to flicker or consume shadow-casting light capacity.
- fix: Mortars can fire across connected z-levels when an open launch column exists.
- fix: Sharp projectile mines and sentry IFF now use the correct collision and faction state.
- fix: Cassette audio is owned by and follows the cassette player instead of playing globally.
- fix: Delayed post-round role selection now preserves and processes the selected job.
- fix: Lurker invisibility, leap, and crippling-strike cooldown behavior is corrected.
- fix: Charger lunges no longer destroy structures that are protected from charging.
- fix: Auxiliary Support Synths, Logistics Technicians, Engineering Technicians, Intel and Junior Officers, Nurses, Working Joes, Vehicle Commanders, and Vehicle Crew now join their faction auxiliary squad.
- fix: Working Joes use the correct colony and OPFOR tactical-map icons while retaining their dedicated Working Joe headsets.
- fix: The OPFOR Logistics Technician lobby preview now includes its auxiliary headset.
- fix: Tank computers now label warning-array modules as weapons sensor arrays.
- fix: Colony medical personnel fall back to Civilian payroll when the Medical payroll console is unavailable, preventing missed salaries in Colony Fall and Insurgency.