### PR TITLE
Fix prototype serialization, barricade deconstruction, and stacked re…

### DIFF
--- a/Content.Server/_AU14/Construction/CustomConstruction/CustomConstructionMenuSystem.cs
+++ b/Content.Server/_AU14/Construction/CustomConstruction/CustomConstructionMenuSystem.cs
@@ -943,6 +943,25 @@ public sealed partial class CustomConstructionMenuSystem : EntitySystem
         return byList.ToDictionary(kv => kv.Key, kv => kv.Value.ToList());
     }
 
+    /// <summary>
+    /// Stack type of an entity prototype, when it is stackable at all (barbed wire, sheets, rods...).
+    /// Recipe amounts for these mean UNITS of the stack, not that many separate items.
+    /// </summary>
+    private bool TryGetStackType(string protoId, out string stackType)
+    {
+        stackType = string.Empty;
+
+        if (!_prototype.TryIndex<EntityPrototype>(protoId, out var proto) ||
+            !proto.TryGetComponent<StackComponent>(out var stack, _componentFactory))
+            return false;
+
+        if (string.IsNullOrWhiteSpace(stack.StackTypeId))
+            return false;
+
+        stackType = stack.StackTypeId;
+        return true;
+    }
+
     private sealed record EntryInfo(string Entity, string Spawnlist, string Category, List<CustomConstructionStepData> Steps, List<CustomConstructionStepData> DeconstructSteps, int Health);
 
     private EntryInfo? ReadHeaders(string path)
@@ -1268,7 +1287,19 @@ public sealed partial class CustomConstructionMenuSystem : EntitySystem
             switch (step.Kind)
             {
                 case CustomConstructionStepKind.EntityMaterial:
-                    // Require `amount` separate copies of the entity (each insert consumes one).
+                    // A STACKABLE entity means N units of that stack, not N separate one-unit entities.
+                    // Picking BarbedWire1 with an amount of 2 used to emit two entityId steps, so the recipe
+                    // demanded two separate single-wire items and a stack of 2 would not satisfy it. Emit a
+                    // material step against the stack type instead, which counts units the way players expect.
+                    if (TryGetStackType(step.Value, out var stackType))
+                    {
+                        sb.AppendLine($"      - material: {stackType}");
+                        sb.AppendLine($"        amount: {amount}");
+                        sb.AppendLine($"        doAfter: {doAfter}");
+                        break;
+                    }
+
+                    // Non-stackable: require `amount` separate copies of the entity (each insert consumes one).
                     for (var i = 0; i < amount; i++)
                     {
                         sb.AppendLine($"      - entityId: {step.Value}");

--- a/Content.Server/_AU14/Smelting/SmeltingPotSystem.cs
+++ b/Content.Server/_AU14/Smelting/SmeltingPotSystem.cs
@@ -538,7 +538,7 @@ public sealed class SmeltingPotSystem : EntitySystem
     }
 
     private SmeltingRecipe? FindRecipe(Entity<SmeltingPotComponent> pot, ProtoId<StackPrototype> input) =>
-        pot.Comp.Recipes.FirstOrDefault(r => !r.InputAnyElectronics && r.Input == input);
+        pot.Comp.Recipes.FirstOrDefault(r => !r.InputAnyElectronics && r.Input is { } recipeInput && recipeInput == input);
 
     private bool IsOnLitFire(Entity<SmeltingPotComponent> pot) =>
         pot.Comp.Fire is { } fire &&

--- a/Content.Shared/_AU14/Smelting/SmeltingPotComponent.cs
+++ b/Content.Shared/_AU14/Smelting/SmeltingPotComponent.cs
@@ -82,9 +82,15 @@ public sealed partial class SmeltingPotComponent : Component
 [DataDefinition]
 public sealed partial class SmeltingRecipe
 {
-    /// <summary>Input stack type. Ignored when <see cref="InputAnyElectronics"/> is set.</summary>
+    /// <summary>
+    /// Input stack type. Null for an electronics recipe, which matches on components instead of a stack.
+    ///
+    /// Nullable on purpose: the electronics recipe leaves this unset, and a non-nullable ProtoId serialises
+    /// that as null, which then throws NullNotAllowedException when the prototype is read back. That is what
+    /// broke ServerPrototypeSaveLoadSaveTest / ClientPrototypeSaveLoadSaveTest.
+    /// </summary>
     [DataField]
-    public ProtoId<StackPrototype> Input;
+    public ProtoId<StackPrototype>? Input;
 
     /// <summary>Matches any circuit board instead of a stack type - the same "any electronics" rule the
     /// sapper workbench uses (machine board, computer board or door electronics).</summary>

--- a/Resources/Prototypes/_AU14/Buildables/au14_barricades.yml
+++ b/Resources/Prototypes/_AU14/Buildables/au14_barricades.yml
@@ -22,6 +22,57 @@
         doAfter: 3
   - node: built
     entity: AU14BarricadeMetal
+    edges:
+    # Deconstruct. Mirrors the original RMC barricade graphs: unbolt it first, then unscrew and pry it apart,
+    # refunding less the more damaged it is. These AU14 ghost-build graphs never had a way back out of the
+    # "built" node, so anything raised through the construction menu could not be taken down again.
+    - to: start
+      completed:
+      - !type:ConditionalAction
+        condition:
+          !type:MinHealth
+          threshold: 1
+          byProportion: true
+        action:
+          !type:SpawnPrototype
+          prototype: CMSheetMetal1
+          amount: 4
+        else:
+          !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 0.78
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: CMSheetMetal1
+            amount: 3
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.56
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 2
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
+          amount: 1
+      - !type:DeleteEntity
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2
 
 - type: entity
   parent: CMBarricadeMetal
@@ -65,6 +116,57 @@
         doAfter: 3
   - node: built
     entity: AU14BarricadeMetalDoor
+    edges:
+    # Deconstruct. Mirrors the original RMC barricade graphs: unbolt it first, then unscrew and pry it apart,
+    # refunding less the more damaged it is. These AU14 ghost-build graphs never had a way back out of the
+    # "built" node, so anything raised through the construction menu could not be taken down again.
+    - to: start
+      completed:
+      - !type:ConditionalAction
+        condition:
+          !type:MinHealth
+          threshold: 1
+          byProportion: true
+        action:
+          !type:SpawnPrototype
+          prototype: CMSheetMetal1
+          amount: 5
+        else:
+          !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 0.78
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: CMSheetMetal1
+            amount: 4
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.56
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: CMSheetMetal1
+              amount: 3
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
+          amount: 1
+      - !type:DeleteEntity
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2
 
 - type: entity
   parent: CMBarricadeMetalDoor
@@ -108,6 +210,57 @@
         doAfter: 3
   - node: built
     entity: AU14BarricadePlasteel
+    edges:
+    # Deconstruct. Mirrors the original RMC barricade graphs: unbolt it first, then unscrew and pry it apart,
+    # refunding less the more damaged it is. These AU14 ghost-build graphs never had a way back out of the
+    # "built" node, so anything raised through the construction menu could not be taken down again.
+    - to: start
+      completed:
+      - !type:ConditionalAction
+        condition:
+          !type:MinHealth
+          threshold: 1
+          byProportion: true
+        action:
+          !type:SpawnPrototype
+          prototype: CMSheetPlasteel1
+          amount: 4
+        else:
+          !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 0.78
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: CMSheetPlasteel1
+            amount: 3
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.56
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: CMSheetPlasteel1
+              amount: 2
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
+          amount: 1
+      - !type:DeleteEntity
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2
 
 - type: entity
   parent: RMCBarricadePlasteel
@@ -151,6 +304,57 @@
         doAfter: 3
   - node: built
     entity: AU14BarricadePlasteelDoor
+    edges:
+    # Deconstruct. Mirrors the original RMC barricade graphs: unbolt it first, then unscrew and pry it apart,
+    # refunding less the more damaged it is. These AU14 ghost-build graphs never had a way back out of the
+    # "built" node, so anything raised through the construction menu could not be taken down again.
+    - to: start
+      completed:
+      - !type:ConditionalAction
+        condition:
+          !type:MinHealth
+          threshold: 1
+          byProportion: true
+        action:
+          !type:SpawnPrototype
+          prototype: CMSheetPlasteel1
+          amount: 5
+        else:
+          !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 0.78
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: CMSheetPlasteel1
+            amount: 4
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.56
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: CMSheetPlasteel1
+              amount: 3
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
+          amount: 1
+      - !type:DeleteEntity
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2
 
 - type: entity
   parent: CMBarricadePlasteelDoor
@@ -194,6 +398,57 @@
         doAfter: 3
   - node: built
     entity: AU14BarricadeWood
+    edges:
+    # Deconstruct. Mirrors the original RMC barricade graphs: unbolt it first, then unscrew and pry it apart,
+    # refunding less the more damaged it is. These AU14 ghost-build graphs never had a way back out of the
+    # "built" node, so anything raised through the construction menu could not be taken down again.
+    - to: start
+      completed:
+      - !type:ConditionalAction
+        condition:
+          !type:MinHealth
+          threshold: 1
+          byProportion: true
+        action:
+          !type:SpawnPrototype
+          prototype: RMCPlankWood1
+          amount: 4
+        else:
+          !type:ConditionalAction
+          condition:
+            !type:MinHealth
+            threshold: 0.78
+            byProportion: true
+          action:
+            !type:SpawnPrototype
+            prototype: RMCPlankWood1
+            amount: 3
+          else:
+            !type:ConditionalAction
+            condition:
+              !type:MinHealth
+              threshold: 0.56
+              byProportion: true
+            action:
+              !type:SpawnPrototype
+              prototype: RMCPlankWood1
+              amount: 2
+      - !type:ConditionalAction
+        condition:
+          !type:IsBarbed
+        action:
+          !type:SpawnPrototype
+          prototype: BarbedWire1
+          amount: 1
+      - !type:DeleteEntity
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Prying
+        doAfter: 2
 
 - type: entity
   parent: RMCBarricadeWood

--- a/Resources/Prototypes/_AU14/CustomConstruction/Generated/Overrides/AU14MenuOverrides.yml
+++ b/Resources/Prototypes/_AU14/CustomConstruction/Generated/Overrides/AU14MenuOverrides.yml
@@ -5,4 +5,5 @@
   id: AU14MenuOverrides
   hiddenRecipes:
   - AU14BuildBarrelGreenRecipe
+  - AU14Custom_AU14BuildPottedPlant__AU14__Debug
   - AU14Custom_CMPosterMissApril__AU14__Debug


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Three fixes on top of the building overhaul work.

The CI one first: `AU14SmeltingPot` couldn't survive a save/load/save round trip, which was failing both prototype serialization tests. Then barricades built through the construction menu turned out to be permanent, there was no way to take them back down. And custom recipes couldn't ask for multiple units of a stackable item properly, they'd demand that many separate items instead.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Metal, plasteel and wooden barricades built through the construction menu can now be deconstructed again.
- fix: Custom recipes can now ask for multiple units of stackable items like barbed wire, instead of demanding that many separate items.