### PR TITLE
fix(radio): stop ANPRC antenna lookups erroring on sets without ItemSlots

### DIFF
--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
@@ -297,7 +297,7 @@ public sealed partial class ANPRCRadioSystem
 
         var antennaLabel = "NONE";
 
-        if (_itemSlots.TryGetSlot(ent.Owner, AntennaSlotId, out var antennaSlot) &&
+        if (TryGetRadioSlot(ent.Owner, AntennaSlotId, out var antennaSlot) &&
             TryComp(antennaSlot.Item, out ANPRCAntennaComponent? antenna))
         {
             antennaLabel = antenna.Label;

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Content.Server._RMC14.Marines.Roles.Ranks;
 using Content.Server._RMC14.TacticalMap;
 using Content.Server.Chat.Managers;
@@ -361,6 +362,18 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         radio.Comp.GrantedChannels.Clear();
     }
 
+    // ItemSlotsSystem.TryGetSlot resolves with logMissing on, so calling it directly logs
+    // an error for any set that has no ItemSlots component. AllComponentsOneToOneDeleteTest
+    // builds a bare entity carrying only ANPRCRadio, which hits exactly that. always come
+    // through here rather than calling TryGetSlot on a radio directly
+    private bool TryGetRadioSlot(EntityUid uid, string slotId, [NotNullWhen(true)] out ItemSlot? slot)
+    {
+        slot = null;
+
+        return TryComp(uid, out ItemSlotsComponent? slots) &&
+               _itemSlots.TryGetSlot(uid, slotId, out slot, slots);
+    }
+
     private void UpdateRelayAnchor(Entity<ANPRCRadioComponent> ent)
     {
         if ((!ent.Comp.IsEquipped && !ent.Comp.Planted) || !ent.Comp.Enabled)
@@ -390,7 +403,7 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         anchor.RangeMultiplier = rangeMultiplier;
         anchor.Planted = ent.Comp.Planted;
 
-        if (_itemSlots.TryGetSlot(ent.Owner, AntennaSlotId, out var antennaSlot) &&
+        if (TryGetRadioSlot(ent.Owner, AntennaSlotId, out var antennaSlot) &&
             TryComp(antennaSlot.Item, out ANPRCAntennaComponent? antenna))
         {
             anchor.FullRange = antenna.FullRange * rangeMultiplier;
@@ -578,7 +591,7 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         var mast = false;
         var state = ANPRCPackVisualState.Bare;
 
-        if (_itemSlots.TryGetSlot(ent.Owner, AntennaSlotId, out var slot) &&
+        if (TryGetRadioSlot(ent.Owner, AntennaSlotId, out var slot) &&
             TryComp(slot.Item, out ANPRCAntennaComponent? antenna))
         {
             // the mast is the only stationary antenna, anything else draws as a whip


### PR DESCRIPTION
## About the PR

`ItemSlotsSystem.TryGetSlot` resolves its component with `logMissing` enabled, so calling it directly logs an error for any entity that carries `ANPRCRadio` without an `ItemSlots` component. `AllComponentsOneToOneDeleteTest` builds exactly that and `MapInit` runs `UpdatePackVisuals` straight into the lookup, which fails the `entity_counts` shard on master

This routes the three antenna slot lookups through a `TryGetRadioSlot` helper so a missing component is a quiet `false` instead of a logged error

## Why / Balance

Fixes the `entity_counts` shard, which is currently red on master

## Technical details

- `ANPRCRadioSystem.cs`: adds `TryGetRadioSlot(uid, slotId, out slot)`, which `TryComp`s
  `ItemSlotsComponent` first and passes it into `TryGetSlot` so `Resolve` never logs
- Three call sites switched over, all of them the antenna slot:
  - `UpdateRelayAnchor` (`ANPRCRadioSystem.cs`)
  - `UpdatePackVisuals` (`ANPRCRadioSystem.cs`)
  - `UpdateBuiState` (`ANPRCRadioSystem.Bui.cs`)

`AllComponentsOneToOneDeleteTest` passes on this branch

## Media

N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- code: AN/PRC antenna slot lookups no longer log a resolve error on entities without an ItemSlots component, fixing the entity_counts test shard.