### PR TITLE
Fix queen's missing 30 minute resin boost 

### DIFF
--- a/Content.Server/_RMC14/Xenonids/Construction/QueenBuildingBoostSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/QueenBuildingBoostSystem.cs
@@ -1,0 +1,78 @@
+﻿using Content.Server.GameTicking;
+using Content.Shared._RMC14.QueenSpawned;
+using Content.Shared._RMC14.Xenonids.Construction;
+using Content.Shared._RMC14.Xenonids;
+using Content.Shared.GameTicking;
+
+namespace Content.Server._RMC14.Xenonids.Construction;
+
+public sealed class QueenBuildingBoostSystem : EntitySystem
+{
+    [Dependency] private readonly GameTicker _gameTicker = default!;
+
+    private static readonly TimeSpan QueenBoostDuration = TimeSpan.FromMinutes(30);
+
+    private bool _boostExpired;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<QueenSpawnedEvent>(OnQueenSpawned);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+    }
+
+    private void OnQueenSpawned(QueenSpawnedEvent args)
+    {
+        if (_boostExpired)
+            return;
+
+        ApplyQueenBoost(args.Queen);
+    }
+
+    private void ApplyQueenBoost(EntityUid queen)
+    {
+        var construction = EntityManager.System<SharedXenoConstructionSystem>();
+
+        construction.GiveQueenBoost(
+            queen,
+            1.5f,
+            10f);
+
+        Log.Info($"Queen building boost applied to {queen}");
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (_boostExpired)
+            return;
+
+        if (_gameTicker.RunLevel != GameRunLevel.InRound)
+            return;
+
+        if (_gameTicker.RoundDuration() < QueenBoostDuration)
+            return;
+
+        RemoveQueenBoosts();
+        _boostExpired = true;
+    }
+
+    private void OnRoundRestartCleanup(RoundRestartCleanupEvent args)
+    {
+        _boostExpired = false;
+    }
+
+    private void RemoveQueenBoosts()
+    {
+        var construction = EntityManager.System<SharedXenoConstructionSystem>();
+
+        var queens = EntityQueryEnumerator<QueenBuildingBoostComponent>();
+
+        while (queens.MoveNext(out var queen, out _))
+        {
+            construction.RemoveQueenBoost(queen);
+
+            Log.Info($"Removed queen building boost from {queen}");
+        }
+    }
+}

--- a/Content.Server/_RMC14/Xenonids/Construction/QueenBuildingBoostSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Construction/QueenBuildingBoostSystem.cs
@@ -11,6 +11,8 @@ public sealed class QueenBuildingBoostSystem : EntitySystem
     [Dependency] private readonly GameTicker _gameTicker = default!;
 
     private static readonly TimeSpan QueenBoostDuration = TimeSpan.FromMinutes(30);
+    private const float QueenBoostSpeedMultiplier = 0.5f;
+    private const float QueenBoostRemoteRange = 50f;
 
     private bool _boostExpired;
 
@@ -36,10 +38,10 @@ public sealed class QueenBuildingBoostSystem : EntitySystem
 
         construction.GiveQueenBoost(
             queen,
-            1.5f,
-            10f);
+            QueenBoostSpeedMultiplier,
+            QueenBoostRemoteRange);
 
-        Log.Info($"Queen building boost applied to {queen}");
+        Logger.GetSawmill("content").Info($"Queen building boost applied to {queen}");
     }
 
     public override void Update(float frameTime)
@@ -53,8 +55,8 @@ public sealed class QueenBuildingBoostSystem : EntitySystem
         if (_gameTicker.RoundDuration() < QueenBoostDuration)
             return;
 
-        RemoveQueenBoosts();
         _boostExpired = true;
+        RemoveQueenBoosts();
     }
 
     private void OnRoundRestartCleanup(RoundRestartCleanupEvent args)
@@ -72,7 +74,7 @@ public sealed class QueenBuildingBoostSystem : EntitySystem
         {
             construction.RemoveQueenBoost(queen);
 
-            Log.Info($"Removed queen building boost from {queen}");
+            Logger.GetSawmill("content").Info($"Removed queen building boost from {queen}");
         }
     }
 }

--- a/Content.Shared/_RMC14/QueenSpawned/QueenSpawnedEvent.cs
+++ b/Content.Shared/_RMC14/QueenSpawned/QueenSpawnedEvent.cs
@@ -1,0 +1,11 @@
+﻿namespace Content.Shared._RMC14.QueenSpawned;
+
+public sealed class QueenSpawnedEvent : EntityEventArgs
+{
+    public EntityUid Queen { get; }
+
+    public QueenSpawnedEvent(EntityUid queen)
+    {
+        Queen = queen;
+    }
+}

--- a/Content.Shared/_RMC14/Xenonids/Construction/QueenBuildingBoostComponent .cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/QueenBuildingBoostComponent .cs
@@ -3,7 +3,7 @@ using Robust.Shared.GameStates;
 namespace Content.Shared._RMC14.Xenonids.Construction;
 
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-[Access(typeof(SharedXenoConstructionSystem))]
+[Access(typeof(SharedXenoConstructionSystem), typeof(XenoSystem))]
 public sealed partial class QueenBuildingBoostComponent : Component
 {
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Tackle;
 using Content.Shared._RMC14.Vendors;
 using Content.Shared._RMC14.Weapons.Melee;
+using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Construction.Nest;
 using Content.Shared._RMC14.Xenonids.Devour;
 using Content.Shared._RMC14.Xenonids.Egg;
@@ -185,6 +186,16 @@ public sealed partial class XenoSystem : EntitySystem
 
         _eye.RefreshVisibilityMask(xeno.Owner);
         Dirty(xeno);
+
+        if (xeno.Comp.Role == "CMXenoQueen")
+        {
+            var boost = EnsureComp<QueenBuildingBoostComponent>(xeno);
+            boost.BuildSpeedMultiplier = 1.5f;
+            boost.RemoteUpgradeRange = 10f;
+            Dirty(xeno, boost);
+
+            Log.Info($"Queen building boost applied to {xeno.Owner}");
+        }
     }
 
     private void OnXenoGetAdditionalAccess(Entity<XenoComponent> xeno, ref GetAccessTagsEvent args)

--- a/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/XenoSystem.cs
@@ -9,6 +9,7 @@ using Content.Shared._RMC14.Marines;
 using Content.Shared._RMC14.Medical.Scanner;
 using Content.Shared._RMC14.Mentor.ImaginaryFriend;
 using Content.Shared._RMC14.NightVision;
+using Content.Shared._RMC14.QueenSpawned;
 using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Tackle;
 using Content.Shared._RMC14.Vendors;
@@ -189,12 +190,7 @@ public sealed partial class XenoSystem : EntitySystem
 
         if (xeno.Comp.Role == "CMXenoQueen")
         {
-            var boost = EnsureComp<QueenBuildingBoostComponent>(xeno);
-            boost.BuildSpeedMultiplier = 1.5f;
-            boost.RemoteUpgradeRange = 10f;
-            Dirty(xeno, boost);
-
-            Log.Info($"Queen building boost applied to {xeno.Owner}");
+            RaiseLocalEvent(new QueenSpawnedEvent(xeno.Owner));
         }
     }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fix queen's missing resin boost that allows her to make hivelord-level resin for the first 30 minutes of the round
Forgot to mention I also buffed the range of the resin upgrade

## Technical details
Half of what made the resin boost work was baked into `CMDistressSignalRuleSystem`. We do not use this rule system anymore as it is leftover from RMC, and as an additional problem, we have multiple gamemodes, so it is inefficient to track it through those. Instead, the following is done:

`XenoSystem` detects when a queen initializes, so it doesn't matter whether a queen is admin spawned, mapped, or a xeno evolves into a queen
New `QueenBuildingBoostSystem` listens for `QueenSpawnedEvent` and applies the boost, handles removing it, and uses its own duration(the cvars probably dont work now but who's gonna use those)

Another issue is that this doesn't work for CF since it only tracks minutes via round start and not via when the queen spawns but since CF is a slower gamemode it shouldn't matter much. Mostly intended for DS

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed queen's missing 30 minute resin boost 