### PR TITLE
feat(radio): CLF comms loop - anchor-gated nets, base station, band sweep, log intercepts

### DIFF
--- a/Content.Client/_AU14/Radio/ANPRCRadioBoundUserInterface.cs
+++ b/Content.Client/_AU14/Radio/ANPRCRadioBoundUserInterface.cs
@@ -33,6 +33,9 @@ public sealed class ANPRCRadioBoundUserInterface : BoundUserInterface
         _window.OnRadioCheck += () => SendMessage(new ANPRCRadioCheckMsg());
         _window.OnOpenDirectory += () => SendMessage(new ANPRCOpenDirectoryMsg());
         _window.OnManualFrequency += (slot, text) => SendMessage(new ANPRCManualFrequencyMsg(slot, text));
+        _window.OnSetSweep += enabled => SendMessage(new ANPRCSetSweepMsg(enabled));
+        _window.OnTuneContact += (slot, freq) => SendMessage(new ANPRCTuneContactMsg(slot, freq));
+        _window.OnPrintLog += intercepts => SendMessage(new ANPRCPrintLogMsg(intercepts));
     }
 
     protected override void UpdateState(BoundUserInterfaceState state)

--- a/Content.Client/_AU14/Radio/ANPRCRadioWindow.xaml
+++ b/Content.Client/_AU14/Radio/ANPRCRadioWindow.xaml
@@ -187,6 +187,26 @@
             </BoxContainer>
           </PanelContainer>
 
+          <!-- Search receiver -->
+          <BoxContainer Orientation="Horizontal" Margin="2,1,2,0">
+            <Label Text="SEARCH" FontColorOverride="#A9C3E8" HorizontalExpand="True" />
+            <Label Name="SweepStatusLabel" Text="IDLE" FontColorOverride="#687A9A" />
+          </BoxContainer>
+          <PanelContainer>
+            <PanelContainer.PanelOverride>
+              <gfx:StyleBoxFlat BackgroundColor="#17181D" BorderColor="#3D4059" BorderThickness="1" />
+            </PanelContainer.PanelOverride>
+            <BoxContainer Orientation="Vertical" Margin="6,5" SeparationOverride="4">
+              <Label Name="SweepBandLabel" Text="BAND IDLE" FontColorOverride="#4A7A55" />
+              <Label Name="SweepHintLabel"
+                     Text="Searching drops all nets and blocks transmit."
+                     FontColorOverride="#687A9A" />
+              <Button Name="SweepButton" Text="START SEARCH" />
+              <Label Text="CONTACTS" FontColorOverride="#A9C3E8" Margin="0,3,0,0" />
+              <BoxContainer Name="SweepContactList" Orientation="Vertical" SeparationOverride="2" />
+            </BoxContainer>
+          </PanelContainer>
+
           <!-- COMSEC -->
           <BoxContainer Orientation="Horizontal" Margin="2,1,2,0">
             <Label Text="COMSEC" FontColorOverride="#A9C3E8" HorizontalExpand="True" />
@@ -220,6 +240,10 @@
                   HorizontalExpand="True"
                   PlaceHolder="Filter sender / text" />
         <Button Name="NetLogFilterClearButton" Text="CLR" MinWidth="44" />
+      </BoxContainer>
+      <BoxContainer Orientation="Horizontal" SeparationOverride="4">
+        <Button Name="PrintLogButton"        Text="PRINT LOG"        HorizontalExpand="True" />
+        <Button Name="PrintInterceptsButton" Text="PRINT INTERCEPTS" HorizontalExpand="True" />
       </BoxContainer>
       <PanelContainer VerticalExpand="True" SizeFlagsStretchRatio="2">
         <PanelContainer.PanelOverride>

--- a/Content.Client/_AU14/Radio/ANPRCRadioWindow.xaml.cs
+++ b/Content.Client/_AU14/Radio/ANPRCRadioWindow.xaml.cs
@@ -37,6 +37,9 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
     public event Action? OnRadioCheck;
     public event Action? OnOpenDirectory;
     public event Action<int, string>? OnManualFrequency;
+    public event Action<bool>? OnSetSweep;
+    public event Action<int, int>? OnTuneContact;
+    public event Action<bool>? OnPrintLog;
 
     private static readonly Color LcdBright = Color.FromHex("#3FCF8E");
     private static readonly Color LcdMid = Color.FromHex("#2D9E60");
@@ -211,6 +214,15 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
         RadioCheckButton.OnPressed += _ => OnRadioCheck?.Invoke();
         DirectoryButton.OnPressed += _ => OnOpenDirectory?.Invoke();
 
+        SweepButton.OnPressed += _ =>
+        {
+            if (_lastState == null) return;
+            OnSetSweep?.Invoke(!_lastState.SweepEnabled);
+        };
+
+        PrintLogButton.OnPressed += _ => OnPrintLog?.Invoke(false);
+        PrintInterceptsButton.OnPressed += _ => OnPrintLog?.Invoke(true);
+
         NetLogChannelFilter.OnItemSelected += args =>
         {
             NetLogChannelFilter.SelectId(args.Id);
@@ -231,7 +243,11 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
             _netLogChannelFilter = null;
             _netLogSearchFilter = string.Empty;
             NetLogSearchEdit.Text = string.Empty;
-            NetLogChannelFilter.SelectId(0);
+
+            // the dropdown is empty until the first state arrives, and selecting an
+            // id it does not carry throws rather than no-opping
+            if (NetLogChannelFilter.ItemCount > 0)
+                NetLogChannelFilter.SelectId(0);
             if (_lastState != null)
                 RebuildNetLog(_lastState);
         };
@@ -516,7 +532,11 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
 
         RadioCheckButton.Disabled = !ready;
 
+        RebuildSweep(state);
         RebuildNetLog(state);
+
+        PrintLogButton.Disabled = !online || state.NetLog.Count == 0;
+        PrintInterceptsButton.Disabled = !online || state.NetLog.All(e => !e.Intercepted);
 
         PowerButton.Text = state.Enabled
             ? Loc.GetString("anprc-power-off-button")
@@ -683,6 +703,101 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
         }
     }
 
+    private void RebuildSweep(ANPRCRadioState state)
+    {
+        var online = state.Enabled && (state.IsEquipped || state.Planted);
+
+        SweepButton.Disabled = !online;
+        SweepButton.Text = state.SweepEnabled ? "STOP SEARCH" : "START SEARCH";
+        SweepButton.Pressed = state.SweepEnabled && online;
+
+        SweepStatusLabel.Text = !online ? "OFFLINE" : state.SweepEnabled ? "SEARCHING" : "IDLE";
+        SweepStatusLabel.FontColorOverride = state.SweepEnabled && online ? TextWarn : TextDim;
+
+        if (state.SweepEnabled && online)
+        {
+            SweepBandLabel.Text = $"HEAD: {FormatFreq(state.SweepPosition)} MHz";
+            SweepBandLabel.FontColorOverride = LcdBright;
+            SweepHintLabel.Text = "NETS DROPPED · TX INHIBITED";
+            SweepHintLabel.FontColorOverride = TextWarn;
+        }
+        else
+        {
+            SweepBandLabel.Text = "BAND IDLE";
+            SweepBandLabel.FontColorOverride = LcdOff;
+            SweepHintLabel.Text = "Searching drops all nets and blocks transmit.";
+            SweepHintLabel.FontColorOverride = TextDim;
+        }
+
+        SweepContactList.RemoveAllChildren();
+
+        if (state.SweepContacts.Count == 0)
+        {
+            SweepContactList.AddChild(new Label
+            {
+                Text = "NO CONTACTS",
+                FontColorOverride = TextDim,
+            });
+
+            return;
+        }
+
+        foreach (var contact in state.SweepContacts)
+        {
+            var row = new BoxContainer
+            {
+                Orientation = BoxContainer.LayoutOrientation.Horizontal,
+                SeparationOverride = 4,
+            };
+
+            if (contact.Resolved)
+            {
+                // an own net is dimmed and tagged: it is on the band, but it was never
+                // work, and it should not read like a prize the operator won
+                row.AddChild(new Label
+                {
+                    Text = contact.Known
+                        ? $"{FormatFreq(contact.Frequency)} MHz · {contact.ChannelName.ToUpperInvariant()} · OWN NET"
+                        : $"{FormatFreq(contact.Frequency)} MHz · {contact.ChannelName.ToUpperInvariant()}",
+                    FontColorOverride = contact.Known ? TextDim : TextGood,
+                    HorizontalExpand = true,
+                    ClipText = true,
+                });
+
+                // own nets are already sitting in the operator's presets, so only a
+                // fixed foreign net gets the shortcut
+                if (!contact.Known)
+                {
+                    var tuneBtn = new Button
+                    {
+                        Text = "TUNE",
+                        MinWidth = 52,
+                        Disabled = state.ActiveSlot < 0 || !state.SlotLabels.ContainsKey(state.ActiveSlot),
+                    };
+
+                    var captured = contact.Frequency;
+                    var slot = state.ActiveSlot;
+                    tuneBtn.OnPressed += _ => OnTuneContact?.Invoke(slot, captured);
+
+                    row.AddChild(tuneBtn);
+                }
+            }
+            else
+            {
+                // partial fix: only the digits earned so far, the rest still masked
+                row.AddChild(new Label
+                {
+                    Text = $"~{MaskDigits(FormatFreq(contact.Frequency), contact.Tier, contact.TierMax)} MHz · PARTIAL {contact.Tier}/{contact.TierMax}",
+                    FontColorOverride = TextWarn,
+                    HorizontalExpand = true,
+                    ClipText = true,
+                });
+            }
+
+            SweepContactList.AddChild(row);
+        }
+    }
+
     private void RebuildNetLog(ANPRCRadioState state)
     {
         RebuildNetLogChannelFilter(state);
@@ -701,8 +816,10 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
 
             var line = new Label
             {
-                Text = $"[{timeStr}] {entry.SenderName} · {entry.ChannelDisplay}",
-                FontColorOverride = TextLog,
+                Text = entry.Intercepted
+                    ? $"[{timeStr}] {entry.SenderName} · {entry.ChannelDisplay} · INTERCEPT"
+                    : $"[{timeStr}] {entry.SenderName} · {entry.ChannelDisplay}",
+                FontColorOverride = entry.Intercepted ? TextWarn : TextLog,
                 ClipText = true,
             };
             var msg = new Label
@@ -750,7 +867,10 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
             .OrderBy(c => c, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        if (channels.SequenceEqual(_netLogChannels))
+        // on a fresh window with an empty log both lists are empty, so the equality
+        // check alone would skip the build and leave the dropdown with no ALL NETS
+        // entry for the clear button to select back to
+        if (NetLogChannelFilter.ItemCount > 0 && channels.SequenceEqual(_netLogChannels))
             return;
 
         _netLogChannels.Clear();
@@ -779,6 +899,17 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
 
     private static string FormatFreq(int raw)
         => raw >= 1000 ? $"{raw / 1000}.{raw % 1000:D3}" : $"00.{raw:D3}";
+
+    // replace the digits the operator has not earned with X, so a partial fix reads
+    // as 2.4XX instead of a falsely precise 2.400
+    private static string MaskDigits(string formatted, int tier, int tierMax)
+    {
+        var unknown = Math.Clamp(tierMax - tier, 0, formatted.Length);
+
+        return unknown > 0
+            ? formatted[..^unknown] + new string('X', unknown)
+            : formatted;
+    }
 
     private static string BandName(int f)
         => f < 3000 ? "LF" : f < 30000 ? "HF" : f < 88000 ? "VHF" : f < 300000 ? "UHF" : "SHF";

--- a/Content.Server/_AU14/Callsigns/AU14CallsignSystem.cs
+++ b/Content.Server/_AU14/Callsigns/AU14CallsignSystem.cs
@@ -29,8 +29,6 @@ public sealed partial class AU14CallsignSystem : EntitySystem
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IConfigurationManager _config = default!;
 
-    private static readonly HashSet<string> CallsignFactions = ["govfor", "opfor", "clf"];
-
     private static readonly Dictionary<string, string> DefaultCommandWords = new()
     {
         ["govfor"] = "HAVOC",
@@ -183,7 +181,7 @@ public sealed partial class AU14CallsignSystem : EntitySystem
 
     private void TryAssignSwept(EntityUid mob, string? faction)
     {
-        if (faction == null || !CallsignFactions.Contains(faction))
+        if (faction == null || !AU14Callsigns.Factions.Contains(faction))
             return;
 
         if (TryComp(mob, out AU14CallsignComponent? existing) &&
@@ -208,7 +206,7 @@ public sealed partial class AU14CallsignSystem : EntitySystem
             ? "clf"
             : CompOrNull<MarineComponent>(ev.Mob)?.Faction;
 
-        if (faction == null || !CallsignFactions.Contains(faction))
+        if (faction == null || !AU14Callsigns.Factions.Contains(faction))
             return;
 
         var callsign = EnsureComp<AU14CallsignComponent>(ev.Mob);
@@ -399,6 +397,14 @@ public sealed partial class AU14CallsignSystem : EntitySystem
     private void OnCallsignSpeak(Entity<AU14CallsignComponent> ent, ref EntitySpokeEvent args)
     {
         if (!_commsEnabled || args.Channel == null || string.IsNullOrEmpty(ent.Comp.Callsign))
+            return;
+
+        // the callsign only holds on the callsign factions' nets. on an open named
+        // channel - colony, WEYU, CMB - the speaker goes out under their own name
+        // and rank like anyone else. frequency 0 is a sentinel channel (ANPRC or
+        // tunable raw-frequency path), which stays masked: the real audience there
+        // is whoever tuned in, not the public
+        if (args.Channel.Frequency > 0 && !AU14Callsigns.IsCallsignChannel(args.Channel))
             return;
 
         ent.Comp.RadioMaskTick = _timing.CurTick;

--- a/Content.Server/_AU14/Radio/ANPRCFrequencyPlanSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCFrequencyPlanSystem.cs
@@ -75,6 +75,22 @@ public sealed partial class ANPRCFrequencyPlanSystem : EntitySystem
             : channel.Frequency;
     }
 
+    // a frequency the operator already holds: an unfactioned net, or one belonging to
+    // their own faction. the sweep uses this so nobody is made to grind out a number
+    // that is already printed on their own freq card
+    public bool IsKnownTo(int frequency, string? operatorFaction)
+    {
+        if (!TryGetChannelByFrequency(frequency, out var channel) ||
+            !_prototype.TryIndex(channel, out var proto))
+        {
+            return false;
+        }
+
+        return string.IsNullOrEmpty(proto.Faction) ||
+               string.IsNullOrEmpty(operatorFaction) ||
+               string.Equals(proto.Faction, operatorFaction, StringComparison.OrdinalIgnoreCase);
+    }
+
     public bool TryGetChannelByFrequency(int frequency, out ProtoId<RadioChannelPrototype> channel)
     {
         if (_channelsByFrequency == null)

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
@@ -1,6 +1,8 @@
 using System.Linq;
+using System.Text;
 using Content.Shared._AU14.Radio;
 using Content.Shared.Chat;
+using Content.Shared.Paper;
 using Content.Shared.Radio;
 using Content.Shared.Verbs;
 using Robust.Shared.Prototypes;
@@ -9,6 +11,8 @@ namespace Content.Server._AU14.Radio;
 
 public sealed partial class ANPRCRadioSystem
 {
+    private static readonly EntProtoId LogPaperId = "ANPRCNetLogPrintout";
+
     private void OnGetAltVerbs(Entity<ANPRCRadioComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
     {
         if (!args.CanAccess || !args.CanInteract || args.Hands == null)
@@ -182,10 +186,15 @@ public sealed partial class ANPRCRadioSystem
             ent.Comp.FrequencyOverrides.Remove(args.Slot);
             ent.Comp.Presets[args.Slot] = channel;
         }
-        else
+        else if (InDirectBand(frequency))
         {
             ent.Comp.FrequencyOverrides[args.Slot] = frequency;
             ent.Comp.Presets.Remove(args.Slot);
+        }
+        else
+        {
+            _cmChat.ChatMessageToOne(Loc.GetString("anprc-frequency-out-of-band"), args.Actor);
+            return;
         }
 
         Dirty(ent);
@@ -204,6 +213,17 @@ public sealed partial class ANPRCRadioSystem
                 ("slot", label),
                 ("freq", TunableFrequencySystem.FormatFreq(frequency))),
             args.Actor);
+    }
+
+    // a raw frequency has to land in a band some receiver in the game can reach: the
+    // military band the search receiver walks, or the softwave band the colony's
+    // handhelds and tunable headsets live in. anything else would be a private net
+    // nothing on the planet could ever find
+    private static bool InDirectBand(int frequency)
+    {
+        return frequency
+            is >= ANPRCRadioComponent.SweepBandMin and <= ANPRCRadioComponent.SweepBandMax
+            or >= ANPRCRadioComponent.SoftwaveBandMin and <= ANPRCRadioComponent.SoftwaveBandMax;
     }
 
     private void OnTogglePower(Entity<ANPRCRadioComponent> ent, ref ANPRCTogglePowerMsg args)
@@ -255,6 +275,143 @@ public sealed partial class ANPRCRadioSystem
 
         UpdateEquippedChannels(ent);
         UpdateBuiState(ent);
+    }
+
+    private void OnSetSweep(Entity<ANPRCRadioComponent> ent, ref ANPRCSetSweepMsg args)
+    {
+        if (args.Enabled == ent.Comp.SweepEnabled)
+            return;
+
+        if (!args.Enabled)
+        {
+            _sweep.StopSweep(ent);
+            UpdateEquippedChannels(ent);
+            UpdateBuiState(ent);
+            return;
+        }
+
+        if (!ent.Comp.Enabled || (!ent.Comp.IsEquipped && !ent.Comp.Planted))
+        {
+            _cmChat.ChatMessageToOne(Loc.GetString("anprc-sweep-needs-online"), args.Actor);
+            return;
+        }
+
+        ent.Comp.SweepEnabled = true;
+        ent.Comp.SweepLastUpdate = TimeSpan.Zero;
+        Dirty(ent);
+
+        // dropping every net the moment the search starts is the whole cost of the mode
+        UpdateEquippedChannels(ent);
+        UpdateBuiState(ent);
+
+        _cmChat.ChatMessageToOne(Loc.GetString("anprc-sweep-started"), args.Actor);
+    }
+
+    // tuning a fixed contact writes the raw frequency, so the operator never has to
+    // copy a number off the panel and back into the keypad
+    private void OnTuneContact(Entity<ANPRCRadioComponent> ent, ref ANPRCTuneContactMsg args)
+    {
+        if (!ent.Comp.SlotLabels.ContainsKey(args.Slot))
+            return;
+
+        if (!ent.Comp.DiscoveredFrequencies.Contains(args.Frequency))
+            return;
+
+        if (_freqPlan.TryGetChannelByFrequency(args.Frequency, out var channel))
+        {
+            ent.Comp.FrequencyOverrides.Remove(args.Slot);
+            ent.Comp.Presets[args.Slot] = channel;
+        }
+        else
+        {
+            ent.Comp.FrequencyOverrides[args.Slot] = args.Frequency;
+            ent.Comp.Presets.Remove(args.Slot);
+        }
+
+        Dirty(ent);
+
+        UpdateEquippedChannels(ent);
+        UpdateRelayAnchor(ent);
+        UpdateBuiState(ent);
+
+        _cmChat.ChatMessageToOne(
+            Loc.GetString(
+                "anprc-frequency-set",
+                ("slot", ent.Comp.SlotLabels[args.Slot]),
+                ("freq", TunableFrequencySystem.FormatFreq(args.Frequency))),
+            args.Actor);
+    }
+
+    // the log lives in the set and rolls over at 50 entries. printing is how an
+    // intercept becomes something the cell can act on after the operator moves on
+    private void OnPrintLog(Entity<ANPRCRadioComponent> ent, ref ANPRCPrintLogMsg args)
+    {
+        if (!ent.Comp.Enabled || (!ent.Comp.IsEquipped && !ent.Comp.Planted))
+        {
+            _cmChat.ChatMessageToOne(Loc.GetString("anprc-sweep-needs-online"), args.Actor);
+            return;
+        }
+
+        var interceptsOnly = args.InterceptsOnly;
+
+        var entries = ent.Comp.NetLog
+            .Where(entry => !interceptsOnly || entry.Intercepted)
+            .ToList();
+
+        if (entries.Count == 0)
+        {
+            _cmChat.ChatMessageToOne(Loc.GetString("anprc-log-print-empty"), args.Actor);
+            return;
+        }
+
+        var paper = Spawn(LogPaperId, Transform(ent.Owner).Coordinates);
+
+        if (TryComp(paper, out PaperComponent? paperComp))
+            _paper.SetContent((paper, paperComp), BuildLogReport(ent, entries, interceptsOnly));
+
+        _hands.TryPickupAnyHand(args.Actor, paper);
+
+        _cmChat.ChatMessageToOne(
+            Loc.GetString("anprc-log-printed", ("count", entries.Count)),
+            args.Actor);
+    }
+
+    private string BuildLogReport(
+        Entity<ANPRCRadioComponent> ent,
+        List<ANPRCNetLogEntry> entries,
+        bool interceptsOnly)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine(interceptsOnly
+            ? "[head=2]INTERCEPT LOG[/head]"
+            : "[head=2]NET LOG[/head]");
+
+        var station = !string.IsNullOrEmpty(ent.Comp.Callsign)
+            ? ent.Comp.Callsign
+            : GetWearerCallsign(ent.Owner);
+
+        if (string.IsNullOrEmpty(station))
+            station = "UNKNOWN STATION";
+
+        sb.AppendLine($"[bold]STATION:[/bold] {station}");
+        sb.AppendLine($"[bold]ENTRIES:[/bold] {entries.Count}");
+        sb.AppendLine();
+
+        foreach (var entry in entries)
+        {
+            var ts = TimeSpan.FromSeconds(entry.Timestamp);
+            var time = $"{(int) ts.TotalMinutes:D2}:{ts.Seconds:D2}";
+            var marker = entry.Intercepted ? " [bold](INTERCEPT)[/bold]" : string.Empty;
+
+            sb.AppendLine($"[{time}] {entry.SenderName} - {entry.ChannelDisplay}{marker}");
+            sb.AppendLine($"  {entry.Message}");
+        }
+
+        sb.AppendLine();
+        sb.Append("[italic]Transcribed from an AN/PRC-117G net log. Times are set clock, not local.[/italic]");
+
+        return sb.ToString();
     }
 
     private void OnSetTxPower(Entity<ANPRCRadioComponent> ent, ref ANPRCSetTxPowerMsg args)
@@ -330,10 +487,16 @@ public sealed partial class ANPRCRadioSystem
                 batteryFraction,
                 hasBattery,
                 antennaLabel,
-                BuildChannelFrequencies()));
+                BuildChannelFrequencies(ent.Comp),
+                ent.Comp.SweepEnabled,
+                ent.Comp.SweepPosition,
+                BuildSweepContacts(ent.Comp)));
     }
 
-    private Dictionary<string, int> BuildChannelFrequencies()
+    // the client only ever learns the operator's own nets, the unfactioned ones, and
+    // whatever the search receiver has actually fixed. sending the whole plan would
+    // hand every enemy frequency to anyone willing to read the state off the wire
+    private Dictionary<string, int> BuildChannelFrequencies(ANPRCRadioComponent radio)
     {
         var frequencies = new Dictionary<string, int>();
 
@@ -342,10 +505,54 @@ public sealed partial class ANPRCRadioSystem
             if (proto.Frequency <= 0)
                 continue;
 
-            frequencies[proto.ID] = _freqPlan.GetFrequency(proto);
+            var frequency = _freqPlan.GetFrequency(proto);
+
+            var known = string.IsNullOrEmpty(proto.Faction) ||
+                        string.IsNullOrEmpty(radio.OperatorFaction) ||
+                        string.Equals(proto.Faction, radio.OperatorFaction, StringComparison.OrdinalIgnoreCase) ||
+                        radio.DiscoveredFrequencies.Contains(frequency);
+
+            if (known)
+                frequencies[proto.ID] = frequency;
         }
 
         return frequencies;
+    }
+
+    // unresolved contacts go out with the unearned digits zeroed, so the exact number
+    // is not sitting in the BUI state before the operator has worked for it
+    private List<ANPRCSweepContact> BuildSweepContacts(ANPRCRadioComponent radio)
+    {
+        var contacts = new List<ANPRCSweepContact>();
+        var tierMax = radio.SweepTierThresholds.Count;
+
+        foreach (var (frequency, confidence) in radio.SweepContacts)
+        {
+            var tier = ANPRCSweepSystem.TierOf(radio, confidence);
+
+            if (tier <= 0)
+                continue;
+
+            // the operator's own nets are never a fix, they arrive already identified
+            var known = _freqPlan.IsKnownTo(frequency, radio.OperatorFaction);
+            var resolved = known || radio.DiscoveredFrequencies.Contains(frequency);
+
+            contacts.Add(new ANPRCSweepContact(
+                resolved ? frequency : ANPRCSweepSystem.MaskFrequency(frequency, tier),
+                confidence,
+                resolved,
+                resolved ? _sweep.GetChannelName(frequency) : string.Empty,
+                resolved ? tierMax : tier,
+                tierMax,
+                known));
+        }
+
+        // unknowns first: they are the ones worth the operator's attention
+        return contacts
+            .OrderBy(contact => contact.Known)
+            .ThenByDescending(contact => contact.Resolved)
+            .ThenBy(contact => contact.Frequency)
+            .ToList();
     }
 
     private static string Sanitize(string input, int maxLength)

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Handset.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Handset.cs
@@ -86,6 +86,8 @@ public sealed partial class ANPRCRadioSystem
     {
         _container.EnsureContainer<ContainerSlot>(ent, ANPRCRadioComponent.HandsetContainerId);
 
+        SeedDefaultSlots(ent);
+
         // whatever antenna state exists at init; the antenna-insert event corrects
         // it if the starting whip lands in the slot after this runs
         UpdatePackVisuals(ent);
@@ -95,6 +97,31 @@ public sealed partial class ANPRCRadioSystem
 
         ent.Comp.Handset = handset;
         Comp<ANPRCHandsetComponent>(handset.Value).Radio = ent;
+        Dirty(ent);
+    }
+
+    private void SeedDefaultSlots(Entity<ANPRCRadioComponent> ent)
+    {
+        // only ever seeds a virgin set, so a mapper-placed or already-tuned station
+        // does not get its slots stamped over on init
+        if (ent.Comp.DefaultSlots.Count == 0 || ent.Comp.SlotLabels.Count > 0)
+            return;
+
+        var slot = 0;
+
+        foreach (var preset in ent.Comp.DefaultSlots)
+        {
+            if (slot >= ANPRCRadioComponent.MaxSlots)
+                break;
+
+            ent.Comp.SlotLabels[slot] = preset.Label;
+            ent.Comp.Presets[slot] = preset.Channel;
+            slot++;
+        }
+
+        if (slot > 0 && ent.Comp.ActiveSlot < 0)
+            ent.Comp.ActiveSlot = 0;
+
         Dirty(ent);
     }
 

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
@@ -165,8 +165,10 @@ public sealed partial class ANPRCRadioSystem
                 TryComp(wearing.Radio, out ANPRCRadioComponent? logRadio) &&
                 logRadio.Enabled)
             {
-                // log headset traffic under what actually went on air
-                var logName = TryComp(ent.Owner, out AU14CallsignComponent? ownCallsign) &&
+                // log headset traffic under what actually went on air: the callsign
+                // on a callsign-faction net, the plain name on an open channel
+                var logName = AU14Callsigns.IsCallsignChannel(args.Channel) &&
+                              TryComp(ent.Owner, out AU14CallsignComponent? ownCallsign) &&
                               !string.IsNullOrEmpty(ownCallsign.Callsign)
                     ? ownCallsign.Callsign
                     : Name(ent.Owner);
@@ -248,6 +250,14 @@ public sealed partial class ANPRCRadioSystem
 
         _powerCell.TryUseCharge(pack.Owner, GetTransmitCost(radio));
 
+        // callsigns are procedure on the callsign factions' nets only. a pack tuned
+        // to an open channel - colony, WEYU, CMB - puts the speaker on air under
+        // their own name and rank, and the log records what actually went out
+        var callsignNet = _commsEnabled && AU14Callsigns.IsCallsignChannel(channel);
+
+        if (!callsignNet)
+            senderName = Name(speaker);
+
         var unsecured = !string.IsNullOrEmpty(channel.Faction) &&
                         radio.Mode != RadioMode.PlainText &&
                         !_crypto.HasMatchingCrypto(pack.Owner, channel);
@@ -272,16 +282,17 @@ public sealed partial class ANPRCRadioSystem
             EnsureComp<TelecomExemptComponent>(pack.Owner);
 
         // strip the job prefix for the duration of the send so the radio line is just
-        // the callsign, no name no role. with the overhaul disabled this goes out unmasked
+        // the callsign, no name no role. with the overhaul disabled, or on an open
+        // channel where the callsign does not apply, this goes out unmasked
         JobPrefixComponent? jobPrefix = null;
-        var hadJobPrefix = _commsEnabled && TryComp(speaker, out jobPrefix);
+        var hadJobPrefix = callsignNet && TryComp(speaker, out jobPrefix);
         var savedPrefix = jobPrefix?.Prefix ?? default;
         var savedAdditionalPrefix = jobPrefix?.AdditionalPrefix;
 
         if (hadJobPrefix)
             RemComp<JobPrefixComponent>(speaker);
 
-        radio.NameMaskActive = _commsEnabled;
+        radio.NameMaskActive = callsignNet;
 
         try
         {

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
@@ -211,6 +211,14 @@ public sealed partial class ANPRCRadioSystem
     {
         var radio = pack.Comp;
 
+        // the set cannot search and talk at once. stay silent or stop sweeping
+        if (radio.SweepEnabled)
+        {
+            args.Channel = null;
+            _cmChat.ChatMessageToOne(Loc.GetString("anprc-sweep-tx-blocked"), speaker);
+            return;
+        }
+
         // callsign goes out as the speaker name, message body carries no prefix
         var outMessage = args.Message;
 

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
@@ -20,6 +20,7 @@ using Content.Shared.Hands;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
+using Content.Shared.Paper;
 using Content.Shared.Item;
 using Content.Shared.PowerCell;
 using Content.Shared.Popups;
@@ -54,6 +55,8 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
     [Dependency] private ANPRCFrequencyPlanSystem _freqPlan = default!;
     [Dependency] private ANPRCGarbleSystem _garble = default!;
     [Dependency] private ANPRCRangeSystem _range = default!;
+    [Dependency] private ANPRCSweepSystem _sweep = default!;
+    [Dependency] private PaperSystem _paper = default!;
     [Dependency] private PowerCellSystem _powerCell = default!;
     [Dependency] private ItemSlotsSystem _itemSlots = default!;
     [Dependency] private TacticalMapSystem _tacticalMap = default!;
@@ -125,6 +128,9 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
             subs.Event<ANPRCManualFrequencyMsg>(OnManualFrequency);
             subs.Event<ANPRCRadioCheckMsg>(OnRadioCheck);
             subs.Event<ANPRCOpenDirectoryMsg>(OnOpenDirectory);
+            subs.Event<ANPRCSetSweepMsg>(OnSetSweep);
+            subs.Event<ANPRCTuneContactMsg>(OnTuneContact);
+            subs.Event<ANPRCPrintLogMsg>(OnPrintLog);
         });
 
         SubscribeLocalEvent<ANPRCRadioComponent, ANPRCPlantDoAfterEvent>(OnPlantDoAfter);
@@ -136,6 +142,8 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         SubscribeLocalEvent<PropCallerComponent, MapInitEvent>(OnAdminObserverMapInit);
 
         SubscribeLocalEvent<ANPRCRadioComponent, ANPRCDirectScanSwitchedEvent>(OnDirectScanSwitched);
+        SubscribeLocalEvent<ANPRCRadioComponent, ANPRCSweepStoppedEvent>(OnSweepStopped);
+        SubscribeLocalEvent<ANPRCRadioComponent, ANPRCSweepUpdatedEvent>(OnSweepUpdated);
         SubscribeLocalEvent<ANPRCRadioComponent, ANPRCCryptoChangedEvent>(OnCryptoChanged);
         SubscribeLocalEvent<ANPRCRadioComponent, PowerCellSlotEmptyEvent>(OnBatteryEmpty);
         SubscribeLocalEvent<ANPRCRadioComponent, EntInsertedIntoContainerMessage>(OnAntennaInserted);
@@ -197,12 +205,21 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         {
             var heard = _garble.ApplyComsecGarble(args.MessageSource, ent.Owner, args.Channel, args.Message);
 
+            // traffic on somebody else's faction net is an intercept: flagged in the
+            // log so it can be picked back out and carried off the radio on paper
+            var intercepted = !string.IsNullOrEmpty(args.Channel.Faction) &&
+                              !string.Equals(
+                                  args.Channel.Faction,
+                                  radio.OperatorFaction,
+                                  StringComparison.OrdinalIgnoreCase);
+
             AppendNetLog(
                 radio,
                 _timing.CurTime.TotalSeconds,
                 GetSenderDisplayName(args.MessageSource),
                 $"{args.Channel.LocalizedName} ({TunableFrequencySystem.FormatFreq(_freqPlan.GetFrequency(args.Channel))} MHz)",
-                heard);
+                heard,
+                intercepted);
 
             UpdateBuiState(ent);
 
@@ -308,6 +325,11 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
     private void GrantReceiveChannels(Entity<ANPRCRadioComponent> radio)
     {
         if (!radio.Comp.Enabled || (!radio.Comp.IsEquipped && !radio.Comp.Planted))
+            return;
+
+        // the set has one receiver. searching the band means it is not sitting on any
+        // of the operator's own nets - going deaf is the price of hunting
+        if (radio.Comp.SweepEnabled)
             return;
 
         var active = EnsureComp<ActiveRadioComponent>(radio.Owner);
@@ -636,6 +658,17 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         UpdateBuiState(ent);
     }
 
+    private void OnSweepStopped(Entity<ANPRCRadioComponent> ent, ref ANPRCSweepStoppedEvent args)
+    {
+        UpdateEquippedChannels(ent);
+        UpdateBuiState(ent);
+    }
+
+    private void OnSweepUpdated(Entity<ANPRCRadioComponent> ent, ref ANPRCSweepUpdatedEvent args)
+    {
+        UpdateBuiState(ent);
+    }
+
     private void UpdateEquippedChannels(Entity<ANPRCRadioComponent> ent)
     {
         RevokeReceiveChannels(ent);
@@ -693,9 +726,10 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         double timestamp,
         string sender,
         string channel,
-        string message)
+        string message,
+        bool intercepted = false)
     {
-        radio.NetLog.Enqueue(new ANPRCNetLogEntry((float) timestamp, sender, channel, message));
+        radio.NetLog.Enqueue(new ANPRCNetLogEntry((float) timestamp, sender, channel, message, intercepted));
 
         while (radio.NetLog.Count > ANPRCRadioComponent.MaxNetLogEntries)
         {

--- a/Content.Server/_AU14/Radio/ANPRCSweepSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCSweepSystem.cs
@@ -1,0 +1,358 @@
+using System.Linq;
+using System.Numerics;
+using Content.Server.PowerCell;
+using Content.Server.Radio;
+using Content.Shared._AU14.CCVar;
+using Content.Shared._AU14.Radio;
+using Content.Shared._RMC14.Chat;
+using Content.Shared.Radio;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.Server._AU14.Radio;
+
+// the search receiver. an operator can walk the band hunting for somebody else's net,
+// but the set can only do one job at a time: while it sweeps it will not transmit and
+// it carries no traffic on the operator's own nets. a fix is built out of repeated
+// catches on the same frequency, so it costs sustained time spent deaf and silent
+// within earshot of a transmitter that keeps talking - not proximity alone
+public sealed class ANPRCSweepSystem : EntitySystem
+{
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SharedCMChatSystem _cmChat = default!;
+    [Dependency] private PowerCellSystem _powerCell = default!;
+    [Dependency] private ANPRCFrequencyPlanSystem _freqPlan = default!;
+
+    // traffic seen on each frequency: where the last emission came from, when it
+    // landed, and how many have stacked up since the run began. a net that keeps
+    // talking builds a heavier signature than one passing the odd message
+    private readonly Dictionary<int, BandEmission> _band = new();
+
+    private static readonly TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
+
+    // gap after which a frequency is treated as having gone quiet and its traffic
+    // count starts over. matches the default activity window a sweeping set uses
+    private static readonly TimeSpan TrafficWindow = TimeSpan.FromSeconds(20);
+
+    private TimeSpan _nextUpdate;
+
+    private bool _commsEnabled;
+
+    public override void Initialize()
+    {
+        Subs.CVar(_config, AU14CCVars.NewCommsSystem, v => _commsEnabled = v, true);
+
+        SubscribeLocalEvent<RadioSendAttemptEvent>(OnAnySend);
+    }
+
+    // every channel transmission puts energy on its frequency whether or not the
+    // intended receiver was in range, so this records on the attempt, not the delivery
+    private void OnAnySend(ref RadioSendAttemptEvent args)
+    {
+        if (!_commsEnabled)
+            return;
+
+        RecordEmission(args.RadioSource, _freqPlan.GetFrequency(args.Channel));
+    }
+
+    public void RecordEmission(EntityUid source, int frequency)
+    {
+        if (!_commsEnabled || frequency <= 0 || Deleted(source))
+            return;
+
+        var xform = Transform(source);
+        var now = _timing.CurTime;
+
+        // a run of traffic only counts while it stays unbroken. let the net fall
+        // silent past the window and the next message starts the count from one
+        var count = _band.TryGetValue(frequency, out var previous) &&
+                    now - previous.Time <= TrafficWindow
+            ? previous.Count + 1
+            : 1;
+
+        _band[frequency] = new BandEmission(
+            _transform.GetWorldPosition(xform),
+            xform.MapID,
+            now,
+            count);
+    }
+
+    public override void Update(float frameTime)
+    {
+        if (!_commsEnabled || _timing.CurTime < _nextUpdate)
+            return;
+
+        _nextUpdate = _timing.CurTime + UpdateInterval;
+
+        PruneBand();
+
+        var query = EntityQueryEnumerator<ANPRCRadioComponent>();
+
+        while (query.MoveNext(out var uid, out var radio))
+        {
+            if (!radio.SweepEnabled)
+                continue;
+
+            UpdateSweep((uid, radio));
+        }
+    }
+
+    private void PruneBand()
+    {
+        // the longest window any radio could care about; cheap enough to use the max
+        var cutoff = _timing.CurTime - TimeSpan.FromSeconds(60);
+
+        foreach (var frequency in _band.Keys.ToArray())
+        {
+            if (_band[frequency].Time < cutoff)
+                _band.Remove(frequency);
+        }
+    }
+
+    private void UpdateSweep(Entity<ANPRCRadioComponent> ent)
+    {
+        var radio = ent.Comp;
+
+        // a set that is off, unworn or flat cannot search
+        if (!radio.Enabled || (!radio.IsEquipped && !radio.Planted))
+        {
+            StopSweep(ent, "anprc-sweep-aborted");
+            return;
+        }
+
+        if (!_powerCell.TryUseCharge(ent.Owner, radio.SweepChargeCostPerSecond))
+        {
+            StopSweep(ent, "anprc-sweep-aborted-power");
+            return;
+        }
+
+        var now = _timing.CurTime;
+        var elapsed = radio.SweepLastUpdate == TimeSpan.Zero
+            ? UpdateInterval
+            : now - radio.SweepLastUpdate;
+
+        radio.SweepLastUpdate = now;
+
+        var seconds = (float) elapsed.TotalSeconds;
+
+        DecayContacts(radio, seconds);
+
+        var start = radio.SweepPosition;
+        var advance = Math.Max(1, (int) MathF.Round(radio.SweepStepPerSecond * seconds));
+
+        var xform = Transform(ent.Owner);
+        var position = _transform.GetWorldPosition(xform);
+        var map = xform.MapID;
+
+        var cutoff = now - radio.SweepActivityWindow;
+        var rangeSquared = radio.SweepInterceptRange * radio.SweepInterceptRange;
+
+        for (var i = 0; i < advance; i++)
+        {
+            var frequency = Wrap(start + i);
+
+            if (!_band.TryGetValue(frequency, out var emission) ||
+                emission.Time < cutoff ||
+                emission.Map != map ||
+                (emission.Position - position).LengthSquared() > rangeSquared)
+            {
+                continue;
+            }
+
+            RegisterHit(ent, frequency, emission.Count);
+        }
+
+        radio.SweepPosition = Wrap(start + advance);
+        Dirty(ent);
+
+        // contacts and their confidence live only in the BUI state, so Dirty alone
+        // leaves an open panel frozen. push a refresh each tick the head moves
+        var ev = new ANPRCSweepUpdatedEvent();
+        RaiseLocalEvent(ent.Owner, ref ev);
+    }
+
+    private void DecayContacts(ANPRCRadioComponent radio, float seconds)
+    {
+        var decay = radio.SweepConfidenceDecayPerSecond * seconds;
+
+        foreach (var frequency in radio.SweepContacts.Keys.ToArray())
+        {
+            var confidence = radio.SweepContacts[frequency];
+
+            // a fix already made is written down, it does not rot back out
+            if (radio.DiscoveredFrequencies.Contains(frequency))
+                continue;
+
+            var reduced = confidence - decay;
+
+            if (reduced <= 0f)
+                radio.SweepContacts.Remove(frequency);
+            else
+                radio.SweepContacts[frequency] = reduced;
+        }
+    }
+
+    private void RegisterHit(Entity<ANPRCRadioComponent> ent, int frequency, int traffic)
+    {
+        var radio = ent.Comp;
+
+        if (radio.DiscoveredFrequencies.Contains(frequency))
+            return;
+
+        var wearer = Transform(ent.Owner).ParentUid;
+
+        // a net this set already holds the frequency for is not a puzzle. it surfaces
+        // fully identified the moment the head crosses live traffic and costs the
+        // operator nothing, so their own nets never compete with a real contact.
+        // seeing your own command net light up is also the plainest possible lesson
+        // that the other side can see it too
+        if (_freqPlan.IsKnownTo(frequency, radio.OperatorFaction))
+        {
+            radio.SweepContacts[frequency] = radio.SweepResolveThreshold;
+            return;
+        }
+
+        // the first message on a busy frequency is worth a plain hit, each one after
+        // it sharpens the catch until the ceiling. spamming the net past that buys
+        // nothing, so the pressure is to keep traffic down rather than to game it
+        var multiplier = Math.Min(
+            radio.SweepTrafficMultiplierMax,
+            1f + (traffic - 1) * radio.SweepTrafficBonusPerEmission);
+
+        var previous = radio.SweepContacts.GetValueOrDefault(frequency);
+        var previousTier = TierOf(radio, previous);
+
+        var confidence = previous + radio.SweepConfidencePerHit * multiplier;
+        var tier = TierOf(radio, confidence);
+
+        if (tier < radio.SweepTierThresholds.Count)
+        {
+            radio.SweepContacts[frequency] = confidence;
+
+            // only speak up when a digit actually falls in. reporting every catch
+            // would bury the operator in identical readouts on a busy net
+            if (tier > previousTier && wearer.IsValid())
+            {
+                _cmChat.ChatMessageToOne(
+                    Loc.GetString(
+                        "anprc-sweep-contact",
+                        ("freq", FormatMasked(frequency, tier))),
+                    wearer);
+            }
+
+            return;
+        }
+
+        radio.SweepContacts[frequency] = radio.SweepResolveThreshold;
+        radio.DiscoveredFrequencies.Add(frequency);
+
+        if (wearer.IsValid())
+        {
+            _cmChat.ChatMessageToOne(
+                Loc.GetString(
+                    "anprc-sweep-resolved",
+                    ("freq", TunableFrequencySystem.FormatFreq(frequency)),
+                    ("net", GetChannelName(frequency))),
+                wearer);
+        }
+    }
+
+    public void StopSweep(Entity<ANPRCRadioComponent> ent, string? reasonLoc = null)
+    {
+        if (!ent.Comp.SweepEnabled)
+            return;
+
+        ent.Comp.SweepEnabled = false;
+        ent.Comp.SweepLastUpdate = TimeSpan.Zero;
+        Dirty(ent);
+
+        var wearer = Transform(ent.Owner).ParentUid;
+
+        if (reasonLoc != null && wearer.IsValid())
+            _cmChat.ChatMessageToOne(Loc.GetString(reasonLoc), wearer);
+
+        // the radio system owns channel granting, tell it to put the set back on the
+        // operator's nets now that the receiver is free
+        var ev = new ANPRCSweepStoppedEvent();
+        RaiseLocalEvent(ent.Owner, ref ev);
+    }
+
+    // how many of the ladder's gates this much confidence has cleared, which is also
+    // how many digits of the frequency the operator has earned
+    public static int TierOf(ANPRCRadioComponent radio, float confidence)
+    {
+        var tier = 0;
+
+        foreach (var threshold in radio.SweepTierThresholds)
+        {
+            if (confidence < threshold)
+                break;
+
+            tier++;
+        }
+
+        return tier;
+    }
+
+    // zero out the digits the operator has not earned. the masked value is what goes
+    // over the wire, so the exact number is never in the BUI state early
+    public static int MaskFrequency(int frequency, int tier)
+    {
+        return tier switch
+        {
+            <= 0 => 0,
+            1 => frequency / 1000 * 1000,
+            2 => frequency / 100 * 100,
+            3 => frequency / 10 * 10,
+            _ => frequency,
+        };
+    }
+
+    // the masked value rendered with X in place of the unknown digits, so a partial
+    // fix reads as 2.4XX rather than a misleadingly precise 2.400
+    public static string FormatMasked(int frequency, int tier)
+    {
+        var text = TunableFrequencySystem.FormatFreq(MaskFrequency(frequency, tier));
+        var unknown = Math.Max(0, DigitCount - tier);
+
+        return unknown > 0
+            ? text[..^unknown] + new string('X', unknown)
+            : text;
+    }
+
+    // digits in a band frequency, and so the length of a full ladder
+    public const int DigitCount = 4;
+
+    public string GetChannelName(int frequency)
+    {
+        return _freqPlan.TryGetChannelByFrequency(frequency, out var channel) &&
+               _prototype.TryIndex(channel, out var proto)
+            ? proto.LocalizedName
+            : Loc.GetString("anprc-sweep-unknown-net");
+    }
+
+    private static int Wrap(int frequency)
+    {
+        var span = ANPRCRadioComponent.SweepBandMax - ANPRCRadioComponent.SweepBandMin + 1;
+        var offset = (frequency - ANPRCRadioComponent.SweepBandMin) % span;
+
+        if (offset < 0)
+            offset += span;
+
+        return ANPRCRadioComponent.SweepBandMin + offset;
+    }
+
+    private readonly record struct BandEmission(Vector2 Position, MapId Map, TimeSpan Time, int Count);
+}
+
+[ByRefEvent]
+public record struct ANPRCSweepStoppedEvent;
+
+// the head moved or a contact firmed up, an open panel needs the new state
+[ByRefEvent]
+public record struct ANPRCSweepUpdatedEvent;

--- a/Content.Server/_AU14/Radio/TunableFrequencySystem.cs
+++ b/Content.Server/_AU14/Radio/TunableFrequencySystem.cs
@@ -35,6 +35,7 @@ public sealed partial class TunableFrequencySystem : EntitySystem
     [Dependency] private ANPRCGarbleSystem _garble = default!;
     [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private ANPRCRangeSystem _range = default!;
+    [Dependency] private ANPRCSweepSystem _sweep = default!;
 
     // direct frequencies reach one z-level up or down, same as a worn manpack
     private const int DirectFreqLevelReach = 1;
@@ -134,6 +135,10 @@ public sealed partial class TunableFrequencySystem : EntitySystem
         var senderPos = _transform.GetWorldPosition(sender);
         var senderMap = Transform(sender).MapID;
         var senderJam = _garble.GetJamIntensity(sender);
+
+        // custom frequencies radiate like any other, so a search receiver can find the
+        // squad nets an RTO thought were private for being off the published plan
+        _sweep.RecordEmission(sender, frequency);
 
         var query = EntityQueryEnumerator<TunedFrequencyComponent, TransformComponent>();
 

--- a/Content.Shared/_AU14/CCVar/AU14CCVars.cs
+++ b/Content.Shared/_AU14/CCVar/AU14CCVars.cs
@@ -17,7 +17,7 @@ public sealed partial class AU14CCVars : CVars
 
     // master switch for the AU14 comms overhaul, off = stock radio behavior
     public static readonly CVarDef<bool> NewCommsSystem =
-        CVarDef.Create("au14.new_comms_system", false, CVar.SERVERONLY);
+        CVarDef.Create("au14.new_comms_system", true, CVar.SERVERONLY);
         
     /// <summary>
     /// With the "Separated" HUD layout the chat panel sits to the right of the viewport, which pushes the

--- a/Content.Shared/_AU14/Callsigns/AU14CallsignConsoleUI.cs
+++ b/Content.Shared/_AU14/Callsigns/AU14CallsignConsoleUI.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Radio;
 using Robust.Shared.Serialization;
 
 namespace Content.Shared._AU14.Callsigns;
@@ -88,4 +89,16 @@ public static class AU14Callsigns
 {
     public const int MaxWordLength = 10;
     public const int MaxSuffixLength = 8;
+
+    // factions that run callsigns at all
+    public static readonly HashSet<string> Factions =
+        new(StringComparer.OrdinalIgnoreCase) { "govfor", "opfor", "clf" };
+
+    // where a callsign actually applies. a callsign is net procedure, not an
+    // identity: it holds on the callsign factions' nets, but on an open channel -
+    // colony, WEYU, CMB - the speaker goes out under their own name like anyone else
+    public static bool IsCallsignChannel(RadioChannelPrototype channel)
+    {
+        return !string.IsNullOrEmpty(channel.Faction) && Factions.Contains(channel.Faction);
+    }
 }

--- a/Content.Shared/_AU14/Insurgency/InsurgencyBuiltinFactions.cs
+++ b/Content.Shared/_AU14/Insurgency/InsurgencyBuiltinFactions.cs
@@ -107,6 +107,8 @@ public static class InsurgencyBuiltinFactions
 
     private static FactionVendorDefinition ToolVendor() => Vendor("CLF tool cache",
         Section("Field Tools",
+            Entry("ANPRC117GRadioCLFFilled", 1),
+            Entry("AU14CLFBaseStation", 1),
             Entry("AU14GunCaseRifleMar30"),
             Entry("RMCGunCasePistolZHNK72", 1),
             Entry("RMCGunCasePistolMK80", 1),

--- a/Content.Shared/_AU14/Radio/ANPRCRadioComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCRadioComponent.cs
@@ -117,4 +117,95 @@ public sealed partial class ANPRCRadioComponent : Component
     public const int MaxNetLogEntries = 50;
 
     public HashSet<string> GrantedChannels = new();
+
+    // slots the set ships with, seeded at map init. a base station has to be usable
+    // the moment it is set up - the cell leader manning it is not a trained operator
+    // and cannot open the panel to tune it
+    [DataField]
+    public List<ANPRCDefaultSlot> DefaultSlots = new();
+
+    #region Band sweep
+
+    // search receiver. walking the band ties up the set: no transmit, no traffic on
+    // your own nets. finding somebody else's net is a job, not a passive perk
+    [DataField, AutoNetworkedField]
+    public bool SweepEnabled;
+
+    // where the sweep head currently sits, in raw frequency units
+    [DataField, AutoNetworkedField]
+    public int SweepPosition = SweepBandMin;
+
+    public const int SweepBandMin = 1000;
+    public const int SweepBandMax = 2999;
+
+    // the colonist softwave band, where handhelds and tunable headsets live. FREQ
+    // accepts it so a set can bridge a headset direct net, but the search receiver
+    // does not cover it
+    public const int SoftwaveBandMin = 30000;
+    public const int SoftwaveBandMax = 87999;
+
+    // frequency -> how much of a fix the operator has built on it. what that buys is
+    // set by SweepTierThresholds: the number falls in one digit at a time
+    public Dictionary<int, float> SweepContacts = new();
+
+    // frequencies the operator has fixed exactly. these become tunable by name
+    [DataField]
+    public HashSet<int> DiscoveredFrequencies = new();
+
+    // band units the head advances per second. the full band takes
+    // (SweepBandMax - SweepBandMin) / this seconds to cover once
+    [DataField("sweepStepPerSecond")]
+    public float SweepStepPerSecond = 100f;
+
+    // how recently a frequency must have carried traffic for the passing head to
+    // catch it. short window plus a slow head means most passes come up empty
+    [DataField("sweepActivityWindow")]
+    public TimeSpan SweepActivityWindow = TimeSpan.FromSeconds(20);
+
+    // how far away a transmitter can be and still be intercepted
+    [DataField("sweepInterceptRange")]
+    public float SweepInterceptRange = 60f;
+
+    [DataField("sweepConfidencePerHit")]
+    public float SweepConfidencePerHit = 0.25f;
+
+    // contacts rot, but slower than a caught pass builds them, so progress survives
+    // between flybys and a net that goes quiet loses its fix over a few minutes
+    [DataField("sweepConfidenceDecayPerSecond")]
+    public float SweepConfidenceDecayPerSecond = 0.005f;
+
+    // a busy net is easier to fix than a disciplined one. traffic caught in the
+    // window multiplies the hit up to this ceiling, so chatter is what gets you found
+    [DataField("sweepTrafficBonusPerEmission")]
+    public float SweepTrafficBonusPerEmission = 0.5f;
+
+    [DataField("sweepTrafficMultiplierMax")]
+    public float SweepTrafficMultiplierMax = 2f;
+
+    // confidence gates for each step of the fix. the head gives the number up a digit
+    // at a time - band half, hundreds, tens, then the exact frequency and the net's
+    // name. below the first entry a contact is not shown at all. one entry per digit,
+    // so a shorter or longer ladder just changes how many steps there are
+    [DataField("sweepTierThresholds")]
+    public List<float> SweepTierThresholds = new() { 0.25f, 0.75f, 1.25f, 2f };
+
+    public float SweepResolveThreshold =>
+        SweepTierThresholds.Count > 0 ? SweepTierThresholds[^1] : 1f;
+
+    [DataField("sweepChargeCostPerSecond")]
+    public float SweepChargeCostPerSecond = 3f;
+
+    public TimeSpan SweepLastUpdate;
+
+    #endregion
+}
+
+[DataDefinition]
+public sealed partial class ANPRCDefaultSlot
+{
+    [DataField(required: true)]
+    public string Label = string.Empty;
+
+    [DataField(required: true)]
+    public ProtoId<RadioChannelPrototype> Channel;
 }

--- a/Content.Shared/_AU14/Radio/ANPRCRadioUI.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCRadioUI.cs
@@ -71,12 +71,70 @@ public static class RadioTxPowerExtensions
 }
 
 [Serializable, NetSerializable]
-public sealed class ANPRCNetLogEntry(float timestamp, string senderName, string channelDisplay, string message)
+public sealed class ANPRCNetLogEntry(
+    float timestamp,
+    string senderName,
+    string channelDisplay,
+    string message,
+    bool intercepted = false)
 {
     public readonly float Timestamp = timestamp;
     public readonly string SenderName = senderName;
     public readonly string ChannelDisplay = channelDisplay;
     public readonly string Message = message;
+
+    // traffic on a net belonging to somebody else's faction. worth writing down,
+    // worth carrying to whoever can act on it
+    public readonly bool Intercepted = intercepted;
+}
+
+// a contact the search receiver has built up but not necessarily fixed. Resolved
+// contacts carry their exact frequency, unresolved ones only the digits earned so far
+[Serializable, NetSerializable]
+public sealed class ANPRCSweepContact(
+    int frequency,
+    float confidence,
+    bool resolved,
+    string channelName,
+    int tier,
+    int tierMax,
+    bool known)
+{
+    public readonly int Frequency = frequency;
+    public readonly float Confidence = confidence;
+    public readonly bool Resolved = resolved;
+
+    // only populated once resolved, the net's name is part of the prize
+    public readonly string ChannelName = channelName;
+
+    // digits of the frequency earned so far, out of TierMax for a full fix
+    public readonly int Tier = tier;
+    public readonly int TierMax = tierMax;
+
+    // one of the operator's own nets, surfaced for free rather than fixed. shown so
+    // the band reads honestly, but never something they had to spend time on
+    public readonly bool Known = known;
+}
+
+[Serializable, NetSerializable]
+public sealed class ANPRCSetSweepMsg(bool enabled) : BoundUserInterfaceMessage
+{
+    public readonly bool Enabled = enabled;
+}
+
+// tune a resolved sweep contact straight into a slot without retyping the number
+[Serializable, NetSerializable]
+public sealed class ANPRCTuneContactMsg(int slot, int frequency) : BoundUserInterfaceMessage
+{
+    public readonly int Slot = slot;
+    public readonly int Frequency = frequency;
+}
+
+// dumps the net log to paper so an intercept can leave the radio
+[Serializable, NetSerializable]
+public sealed class ANPRCPrintLogMsg(bool interceptsOnly) : BoundUserInterfaceMessage
+{
+    public readonly bool InterceptsOnly = interceptsOnly;
 }
 
 [Serializable, NetSerializable]
@@ -200,9 +258,16 @@ public sealed class ANPRCRadioState(
     float batteryFraction,
     bool hasBattery,
     string antennaLabel,
-    Dictionary<string, int> channelFrequencies)
+    Dictionary<string, int> channelFrequencies,
+    bool sweepEnabled,
+    int sweepPosition,
+    List<ANPRCSweepContact> sweepContacts)
     : BoundUserInterfaceState
 {
+    public readonly bool SweepEnabled = sweepEnabled;
+    public readonly int SweepPosition = sweepPosition;
+    public readonly List<ANPRCSweepContact> SweepContacts = sweepContacts;
+
     public readonly Dictionary<int, ProtoId<RadioChannelPrototype>> Presets = presets;
     public readonly Dictionary<int, int> FrequencyOverrides = frequencyOverrides;
     public readonly Dictionary<int, string> SlotLabels = slotLabels;

--- a/Resources/Locale/en-US/_AU14/anprc-radio.ftl
+++ b/Resources/Locale/en-US/_AU14/anprc-radio.ftl
@@ -24,6 +24,7 @@ anprc-verb-open = Open Radio Panel
 anprc-out-of-range = Static. No relay in range on { $channel }.
 
 anprc-frequency-invalid = Invalid frequency format. Enter a number such as 1606 or 1.606.
+anprc-frequency-out-of-band = No net can live there. Direct frequencies sit in 1.000-2.999 MHz or the 30.000-87.999 softwave band.
 anprc-frequency-not-found = No channel found at frequency { $freq }.
 anprc-frequency-set = [{ $slot }] tuned to { $freq } MHz.
 anprc-frequency-set-dynamic = [{ $slot }] set to { $freq } MHz (direct frequency). Transmit with :r.
@@ -85,3 +86,17 @@ anprc-handset-hands-full = You need a free hand to take the handset.
 anprc-handset-cord = The handset cord yanks out of your hand as you move away.
 anprc-handset-radio-gone = The handset goes dead.
 anprc-handset-hint = Speaking transmits on the pack's active net while you hold the handset. Whisper to stay off the air.
+
+# search receiver
+anprc-sweep-started = The set drops off the net and starts walking the band. You will hear nothing and send nothing until you stop.
+anprc-sweep-needs-online = The set has to be on and worn to search.
+anprc-sweep-aborted = The search stops as the set goes down.
+anprc-sweep-aborted-power = The battery gives out and the search stops.
+anprc-sweep-tx-blocked = The set is searching the band. Stop the search before you transmit.
+anprc-sweep-contact = The search narrows. Something is transmitting on { $freq } MHz.
+anprc-sweep-resolved = FIX: { $freq } MHz - { $net }.
+anprc-sweep-unknown-net = UNIDENTIFIED NET
+
+# net log to paper
+anprc-log-print-empty = Nothing in the log worth writing down.
+anprc-log-printed = You transcribe { $count } log entries onto paper.

--- a/Resources/Locale/en-US/_AU14/radio-channels.ftl
+++ b/Resources/Locale/en-US/_AU14/radio-channels.ftl
@@ -21,6 +21,7 @@ chat-radio-alert = ALRT
 chat-radio-WEYU = WEYU
 chat-radio-CMB = CMB
 chat-radio-CLF = CLF
+chat-radio-CLFCommand = CLF Command
 chat-radio-mob = FAMLY
 
 chat-radio-hivemind = HIVE

--- a/Resources/Prototypes/_CMU14/Economy/Misc/clfstuff.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Misc/clfstuff.yml
@@ -347,6 +347,9 @@
       - id: ANPRC117GRadioCLFFilled
         amount: 1
         points: 15
+      - id: AU14CLFBaseStation
+        amount: 1
+        points: 18
       - id: ANPRCFillCardCLF
         amount: 3
         points: 4
@@ -481,6 +484,8 @@
   - type: StorageFill
     contents:
     - id: ANPRC117GRadioCLFFilled
+      amount: 1
+    - id: AU14CLFBaseStation
       amount: 1
     - id:  AU14GunCaseRifleMar30
       amount: 2

--- a/Resources/Prototypes/_CMU14/Entities/Objects/Guidebook/comms.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Guidebook/comms.yml
@@ -5,6 +5,7 @@
   text: "/ServerInfo/Guidebook/_AU14/Comms/AU14CommsIndex.xml"
   priority: 2
   children:
+  - AU14CommsFirstNet
   - AU14CommsANPRC
   - AU14CommsHeadsets
   - AU14CommsVoiceProcedure
@@ -12,28 +13,35 @@
 
 - type: guideEntry
   parent: RMC
+  id: AU14CommsFirstNet
+  name: Getting On The Net
+  priority: 0
+  text: "/ServerInfo/Guidebook/_AU14/Comms/AU14CommsFirstNet.xml"
+
+- type: guideEntry
+  parent: RMC
   id: AU14CommsANPRC
   name: "AN/PRC-117G Radio"
-  priority: 0
+  priority: 1
   text: "/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml"
 
 - type: guideEntry
   parent: RMC
   id: AU14CommsHeadsets
   name: Field Headsets
-  priority: 1
+  priority: 2
   text: "/ServerInfo/Guidebook/_AU14/Comms/AU14CommsHeadsets.xml"
 
 - type: guideEntry
   parent: RMC
   id: AU14CommsVoiceProcedure
   name: Voice Procedure
-  priority: 2
+  priority: 3
   text: "/ServerInfo/Guidebook/_AU14/Comms/AU14CommsVoiceProcedure.xml"
 
 - type: guideEntry
   parent: RMC
   id: AU14CommsQuickRef
   name: Comms Quick Reference
-  priority: 3
+  priority: 4
   text: "/ServerInfo/Guidebook/_AU14/Comms/AU14CommsQuickRef.xml"

--- a/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
@@ -147,6 +147,7 @@
   - type: RTORelay
     bridgedChannels:
     - radioCLF
+    - radioCLFCommand
 
 - type: entity
   parent: BaseItem
@@ -193,3 +194,68 @@
     containers:
       fill_card:
       - ANPRCFillCardCLF
+
+# the cell's fixed end of the net. cannot be worn - it only works set up - so the
+# operator takes the manpack forward while whoever stays behind mans this one on the
+# handset. gives the CLF command net an actual station on the other end, and makes the
+# place they hide it worth defending and worth raiding
+- type: entity
+  parent: ANPRC117GRadioCLFFilled
+  id: AU14CLFBaseStation
+  name: clandestine base station
+  suffix: CLF, Base Station
+  description: >-
+    A base station cannibalised from colony survey gear and a stolen military set,
+    bolted into a crate that does not travel well. Too heavy to carry on your back,
+    long-legged enough to hold the cell together from wherever it is hidden.
+  components:
+  # no wearable slots: this only ever works planted, so it can be carried in hand to
+  # a hiding spot and set up, but never worn as a manpack the way the RTO's set is
+  - type: Clothing
+    slots:
+    - NONE
+  - type: Item
+    size: Ginormous
+  - type: ANPRCRadio
+    operatorFaction: clf
+    requiredSlot: none
+    callsignPresets:
+    - CELL ACTUAL
+    - BASE
+    - FIREBRAND
+    - MAGPIE
+    dfReportFactions:
+    - GOVFOR
+    # comes up tuned so the leader can work it without a trained operator present
+    defaultSlots:
+    - label: CELL
+      channel: radioCLF
+    - label: CMD
+      channel: radioCLFCommand
+  - type: ItemSlots
+    slots:
+      fill_card:
+        name: COMSEC fill card
+        whitelist:
+          components:
+          - ANPRCFillCard
+      antenna:
+        name: antenna
+        whitelist:
+          components:
+          - ANPRCAntenna
+        startingItem: ANPRCMastAntenna
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: RMCPowerCellHigh
+
+- type: entity
+  parent: CMPaperWritten
+  id: ANPRCNetLogPrintout
+  name: AN/PRC-117G net log printout
+  description: A strip of thermal paper spat out of a radio's log printer. Smudges if you handle it too much.
+  components:
+  - type: Item
+    size: Small
+  # content is written by ANPRCRadioSystem when the log is printed
+  - type: Paper

--- a/Resources/Prototypes/_CMU14/Roles/radio_channels.yml
+++ b/Resources/Prototypes/_CMU14/Roles/radio_channels.yml
@@ -199,6 +199,20 @@
   longRange: true
   tower: true
   faction: "clf"
+  anchorGated: true
+
+# cell command net. lives on the RTO pack only - no earpiece carries it, so the cell
+# leader talks to command through the operator's handset the same way GOVFOR does
+- type: radioChannel
+  id: radioCLFCommand
+  name: chat-radio-CLFCommand
+  keycode: "n"
+  frequency: 1887
+  color: "#0b7a3d"
+  longRange: true
+  tower: true
+  faction: "clf"
+  anchorGated: true
 
 - type: radioChannel
   id: radioMobFamily

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml
@@ -35,17 +35,26 @@
 
   A worn radio relays traffic only when it is carried by a trained operator. A deployed retransmission station continues relaying without a wearer.
 
-  ### GOVFOR trained roles
+  ### GOVFOR and OPFOR trained roles
 
-  - Radio Traffic Operator
+  Both regular factions field the same set of trained roles.
+
   - Commander
-  - Officer Adjutant
-  - Advisor
-  - Platoon Sergeant
+  - Adjutant
+  - Staff officers
+  - Engineering officers
+  - Intelligence officers
+  - Synthetics
+  - Squad leaders
+  - Fireteam Leaders
+  - Radio Traffic Operators
 
   ### CLF trained roles
 
   - Cell Leader
+  - Radio Operator
+
+  An untrained character can also be trained in the field by reading a [bold]field radio operator's pamphlet[/bold]. This is permanent and works regardless of role.
 
   Nearby headset users do not need radio training. They only need to be within range of a powered radio carrying their net.
 
@@ -64,7 +73,7 @@
 
   Alt-click again to return the handset.
 
-  A squad leader can use an attached RTO's handset to reach a command net that is not available through the squad leader's headset.
+  A squad leader can use an attached Fireteam Leader's handset to reach a command net that is not available through the squad leader's headset.
 
   ## Slots
 
@@ -570,6 +579,26 @@
 
   If all available relays are disabled or removed, the affected net loses coverage.
 
+  ## CLF Nets and Base Station
+
+  The CLF have two combat nets:
+
+  - [bold]CLF[/bold] - the cell net, carried by every CLF earpiece.
+  - [bold]CLF Command[/bold] - carried only on AN/PRC sets, not on any earpiece. The cell leader reaches it through a set's handset or panel.
+
+  Both nets are relay-gated. The CLF have no fixed array or command-post mast, so coverage comes from CLF AN/PRC sets: the operator's manpack in the field and the cell's base station at the safehouse.
+
+  Losing all coverage does not silence the cell. The [bold]Colony[/bold] channel on every CLF earpiece is not gated, so a cell cut off its own nets drops back to colony chatter - which is unencrypted and can be found and read by anyone sweeping the band.
+
+  ### Clandestine base station
+
+  The base station is a CLF AN/PRC set too heavy to wear. It only works set up, so it is carried by hand to a hiding place and deployed there.
+
+  - It comes tuned to both CLF nets, so it works the moment it is set up without opening the panel.
+  - Fitted with a mast antenna, a deployed station anchors both CLF nets across a wide radius - enough to cover a safehouse and its approaches.
+  - The cell leader mans it on the handset while the operator takes the manpack forward. The two sets hold the cell together across the map.
+  - It is the cell's only fixed coverage. Destroying or capturing it collapses the cell onto whatever the forward manpack still reaches.
+
   ## Battery and Antenna
 
   The radio uses a battery in its internal battery slot.
@@ -589,9 +618,35 @@
   - Provides less range than the whip while moving.
   - Is intended for command posts and retransmission sites.
 
+  ## SEARCH (Band Sweep)
+
+  Intercepting a net requires knowing its frequency. Frequencies are reassigned every operation, so a captured frequency card is one way to learn them and the search receiver is the other.
+
+  [bold]START SEARCH[/bold] walks the radio's receiver across the band hunting for anyone transmitting.
+
+  Searching takes the set out of service entirely:
+
+  - The radio drops off [bold]every[/bold] loaded net. You hear nothing.
+  - Transmit is inhibited. You cannot answer traffic while searching.
+  - Battery drain continues for as long as the search runs.
+
+  A single pass rarely finds anything. The receiver only registers a frequency if somebody transmitted on it very recently at the moment the sweep head happened to pass over it, and the contact must be within intercept range.
+
+  Contacts build up over repeated catches:
+
+  - Below half confidence a contact is not shown at all.
+  - Above half confidence the panel shows an approximate frequency only, as [bold]~1.60X MHz[/bold].
+  - At full confidence the contact resolves to an exact frequency and net name, and can be tuned into the active slot with [bold]TUNE[/bold].
+
+  Partial contacts decay. A fix requires a net that keeps talking and an operator willing to stay deaf and silent nearby while it does. Sitting near the enemy is not enough on its own.
+
+  A resolved fix is permanent for the operation.
+
+  Custom direct frequencies are found the same way. A squad net that is off the published plan is not hidden from a search receiver: the set only accepts direct frequencies inside the searchable [bold]1.000-2.999 MHz[/bold] military band or in the colonist softwave band ([bold]30.000+ MHz[/bold]). Softwave sits outside the search receiver's coverage, but it is short-ranged, unencrypted and shared with every handheld on the colony.
+
   ## Intercepting Enemy Traffic
 
-  Enter another faction's frequency with [bold]FREQ[/bold].
+  Enter another faction's frequency with [bold]FREQ[/bold], or tune a resolved [bold]SEARCH[/bold] contact directly.
 
   When the signal reaches the radio, intercepted traffic appears in [color=#FF6B6B]red[/color] and is recorded in the net log.
 
@@ -666,6 +721,16 @@
   - Incoming traffic on all loaded nets while MON or SCAN is enabled.
 
   The log can be used to review missed traffic or confirm that a message was transmitted.
+
+  Traffic on another faction's net is flagged [bold]INTERCEPT[/bold] in the log.
+
+  ### Printing the log
+
+  The log rolls over at 50 entries and dies with the radio. [bold]PRINT LOG[/bold] transcribes it onto paper so it can be carried, handed over or cached.
+
+  [bold]PRINT INTERCEPTS[/bold] prints only the intercepted traffic, which is usually what command actually wants.
+
+  Printing is how a radio operator turns listening into something the rest of the cell can act on.
 
   ## Status Display
 

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsFirstNet.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsFirstNet.xml
@@ -1,0 +1,304 @@
+<Document>
+  # Getting On The Net
+
+  This page takes you from spawning in to holding a working conversation on a radio net. It assumes you have never touched the comms system before and explains every step as you take it.
+
+  If something does not work, the last section of this page lists what usually causes it.
+
+  <Box>
+    <GuideEntityEmbed Entity="AU14HeadsetGovforMarineFTL" Caption="Field Headset"/>
+    <GuideEntityEmbed Entity="ANPRC117GRadio" Caption="AN/PRC-117G"/>
+  </Box>
+
+  ## Step 1: Work out what you are carrying
+
+  Almost everybody spawns with a [bold]field headset[/bold] in their ears slot. This is your personal radio and it is all most roles ever need.
+
+  A small number of roles also spawn with an [bold]AN/PRC-117G[/bold] manpack radio in their back slot. It is large, it is obvious in your inventory, and it is the thing that makes everyone else's headset work.
+
+  Open your inventory and check both slots before you do anything else.
+
+  - [bold]Headset only[/bold] - read step 2, then step 3, then skip to the handset section.
+  - [bold]Headset and manpack[/bold] - read the whole page. You are the reason your squad has comms.
+
+  ## Step 2: Understand why radios go dead
+
+  This is the single thing that confuses new players most, so read it before you try to transmit.
+
+  Your headset is not a phone. It does not reach across the map on its own. Combat nets are [bold]relay-gated[/bold]: your headset only works if it is standing near something that anchors the net.
+
+  Anything on this list will anchor a net:
+
+  - A powered AN/PRC worn by a trained operator.
+  - A deployed retransmission station.
+  - A command-post antenna mast.
+  - A powered shipboard communications array.
+  - A vehicle radio aboard a dropship or vehicle, covering little more than the hull.
+  - A field antenna mast raised from ten metal sheets by engineering-trained personnel.
+
+  If none of those are within range of you, your squad net is dead. Not degraded. Dead. You will speak and nothing will happen.
+
+  This is why the radio operator matters, and it is why walking away from the person carrying the pack cuts you off. In a squad that is usually your [bold]Fireteam Leader[/bold].
+
+  Colony and civilian channels are the exception. They are not gated and work anywhere, which is also why anyone can listen to them.
+
+  ### How far is "near"
+
+  <Table Columns="2" MinForcedColumnWidth="120">
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Distance from the anchor[/bold]</Box>
+    </ColorBox>
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]What you get[/bold]</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">0-30 tiles</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Clear traffic both ways.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">30-45 tiles</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Readable but degraded. Words go missing.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Beyond 45 tiles</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Nothing at all.</Box>
+    </ColorBox>
+  </Table>
+
+  Coverage reaches one level above or below the anchor, so a tunnel or a lower deck usually needs its own relay. Only a shipboard array covers a whole site vertically.
+
+  ## Step 3: Say something on your headset
+
+  With the headset worn in your ears slot, type a colon, the letter h, a space, and your message:
+
+  [color=#a4885c]:h Radio check, over.[/color]
+
+  If the net is anchored and somebody is listening, they will see your message with your callsign in front of it.
+
+  Your headset may carry more than one net. Examine the headset to see which prefixes it holds. Common ones:
+
+  - [color=#a4885c]:v[/color] for command, if your headset has the command key.
+  - [color=#a4885c]:a[/color] for Alpha, if your headset has the Alpha key.
+
+  A headset cannot use a net it does not have the key for. There is no way to add one in the field.
+
+  Note that your [bold]name is never transmitted[/bold]. Everyone on the net sees your callsign instead, friendly or hostile. Face to face speech is unaffected, so people standing next to you still hear you normally.
+
+  ## Step 4: Open the radio panel
+
+  Everything from here needs an AN/PRC on your back and the training to use it.
+
+  Only these roles can open the panel and transmit through the radio:
+
+  <Table Columns="2" MinForcedColumnWidth="110">
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Faction[/bold]</Box>
+    </ColorBox>
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Trained roles[/bold]</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">[bold]GOVFOR and OPFOR[/bold]</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Commander, Adjutant, staff officers, engineering officers, intelligence officers, synthetics, squad leaders, Fireteam Leaders, and Radio Traffic Operators.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">[bold]CLF[/bold]</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Cell Leader and Radio Operator.</Box>
+    </ColorBox>
+  </Table>
+
+  Both regular factions field the same set of trained roles, so a captured enemy pack is useful to the same people on your side.
+
+  If you are not on that list the panel will not open for you. You have two ways round it: use somebody else's handset, covered further down, or read a [bold]field radio operator's pamphlet[/bold] if one is available, which trains you permanently.
+
+  To open it:
+
+  - Wear the radio in your [bold]back slot[/bold]. It does nothing in a bag or on the floor.
+  - Alt-click the radio, or open its verb menu.
+  - Select [bold]Open Radio Panel[/bold].
+
+  The panel opens with a status line across the top. Read it now, because it tells you what is wrong before you waste time hunting.
+
+  - [bold]READY[/bold] means the radio is worn and has an active net. This is what you want.
+  - [bold]NOT WORN[/bold] means it is not in your back slot.
+  - [bold]NO NET[/bold] means you have not set up a slot yet. That is normal on a fresh radio.
+  - [bold]STBY[/bold] means part of the setup is still incomplete.
+
+  ## Step 5: Add your first net
+
+  A fresh radio has no nets loaded. You build them yourself, into what the panel calls slots. The radio holds up to [bold]four[/bold].
+
+  Work through this in order:
+
+  - Select [bold]+ ADD NET[/bold]. An empty slot appears.
+  - Give it a short label, something like [bold]CMD[/bold] or [bold]ALPHA[/bold]. The label is cosmetic. It is only shown on your own radio and it does not pick the net for you.
+  - Select [bold]TUNE[/bold] on that slot.
+  - Open the [bold]NET[/bold] tab and pick a named faction net from the list.
+  - Select the slot row itself so it becomes the [bold]active[/bold] slot.
+
+  That last step catches people out constantly. Adding a net does not select it. The active slot is the one you actually transmit on, and it is the row that is highlighted.
+
+  Instead of a named net you can enter a raw frequency in the [bold]FREQ[/bold] tab. Frequencies work with or without the decimal point, so [color=#a4885c]1606[/color] and [color=#a4885c]1.606[/color] are the same thing. Use this for tuning to somebody else's net, which is covered in the AN/PRC guide.
+
+  Two more buttons on each slot:
+
+  - [bold]CLEAR[/bold] empties the slot but keeps it and its label.
+  - [bold]DEL[/bold] removes the slot entirely.
+
+  ## Step 6: Load your COMSEC fill
+
+  Most faction nets are meant to be encrypted, and the AN/PRC does not carry its own keys. It reads them off a physical card.
+
+  - Find your issued [bold]fill card[/bold] in your kit.
+  - Insert it into the radio's fill card slot.
+  - Check the COMSEC panel. It should read [bold]SECURED[/bold].
+
+  If you transmit on a secured faction net with no matching fill, the radio warns you and [bold]sends the message anyway, in the clear[/bold]. It does not stop you. Anyone listening on that frequency reads it, and you light up enemy direction finding while you do it.
+
+  Treat a fill warning as a mistake to fix, not a message to click past.
+
+  ## Step 7: Transmit
+
+  With a slot active, transmit through the radio the same way you use a headset, but with [color=#a4885c]:r[/color]:
+
+  [color=#a4885c]:r HAVOC 6, this is ALPHA ROMEO, radio check, over.[/color]
+
+  [color=#a4885c]:r[/color] always goes out on whichever slot is currently active. If you have four nets loaded and speak on the wrong one, that is almost always because you forgot to change the active slot first.
+
+  Your transmission goes out under your callsign. A worn radio follows the wearer's assigned callsign automatically, shown on the panel as [bold]AUTO[/bold]. If you have no callsign assigned you will transmit as [bold]UNKNOWN STATION[/bold], which is worth fixing before anyone needs you.
+
+  ## Step 8: Confirm it actually works
+
+  Do not assume. Select [bold]RADIO CHECK[/bold] on the panel.
+
+  The radio sends [bold]RADIO CHECK, HOW COPY, OVER[/bold] on the active net, then gives you a private report listing which stations hear you clearly and which hear you degraded.
+
+  This is the fastest way to answer "is my net working" without bothering anyone, and you should run it before you move somewhere new and after you set up.
+
+  If you run it while sitting inside enemy jamming, the report also gives you a bearing to the strongest jammer, which is useful intelligence on its own.
+
+  ## The handset: how everyone else uses your radio
+
+  The handset is how someone without radio training talks on a net they do not otherwise have. A squad leader reaching the command net through their Fireteam Leader is the standard case.
+
+  To take it:
+
+  - Stand within about [bold]two and a half tiles[/bold] of the radio or the person wearing it.
+  - Make sure you have a [bold]free hand[/bold]. You cannot take it with both hands full.
+  - Alt-click the wearer, or the deployed radio.
+  - Select [bold]Take Handset[/bold].
+
+  Now read this part carefully, because it surprises people and it has consequences.
+
+  [bold]While you are holding the handset, anything you say out loud goes out on the net.[/bold] You do not need a prefix. Talking normally to the person next to you transmits it to every station on that net.
+
+  To speak without transmitting, [bold]whisper[/bold]. Whispered speech stays off the air.
+
+  The rest of the handset's behaviour:
+
+  - It transmits on the radio's [bold]active slot[/bold], whatever the operator last selected.
+  - It uses [bold]your[/bold] callsign, not the radio operator's.
+  - Only one person can hold it at a time.
+  - Walk out of range and the cord yanks out of your hand and disconnects you.
+  - Select [bold]Hang Up Handset[/bold] to return it.
+
+  One exception: if you are wearing your own AN/PRC, holding someone else's handset does not open your mic. Your own pack takes priority and normal [color=#a4885c]:r[/color] discipline applies.
+
+  ## When it does not work
+
+  Work down this list in order. It is roughly ordered by how often each one is the real problem.
+
+  <Table Columns="2" MinForcedColumnWidth="120">
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Symptom[/bold]</Box>
+    </ColorBox>
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Check[/bold]</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Nobody answers on a squad or command net</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">There is no anchor in range. Find your Fireteam Leader, a mast, or an array. This is the answer most of the time.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">[color=#a4885c]:r[/color] goes out on the wrong net</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">The wrong slot is active. Select the row you want first.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">The panel will not open</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Your role is not radio trained, or the radio is not in your back slot.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Traffic arrives broken or full of static</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">You are at the edge of coverage, or you are being jammed. Move closer to the anchor.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">AN/PRC traffic arrives as pure static</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">One of the two radios does not have matching COMSEC fill.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">A net key is missing from your headset</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Examine it to confirm. You cannot add keys in the field. Use a handset instead.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">You transmit as UNKNOWN STATION</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">You have no callsign assigned. Command can assign one from the net directory.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">You said something private and it went out on the net</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">You are holding a handset. Hang it up, or whisper.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">The radio has gone completely dead</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Check the battery in its internal slot. Searching and high transmit power drain it quickly.</Box>
+    </ColorBox>
+  </Table>
+
+  ## Where to go next
+
+  - [textlink="AN/PRC-117G Radio" link="AU14CommsANPRC"] - everything else the manpack does: operating modes, transmit power, retransmission stations, band searching, and intercepting enemy traffic.
+  - [textlink="Field Headsets" link="AU14CommsHeadsets"] - direct frequencies, tuning, and headset-specific behaviour.
+  - [textlink="Voice Procedure" link="AU14CommsVoiceProcedure"] - how to actually word a transmission so it is understood the first time.
+  - [textlink="Comms Quick Reference" link="AU14CommsQuickRef"] - the tables on one page, for when you know what you are doing and just need a number.
+</Document>

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsHeadsets.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsHeadsets.xml
@@ -86,9 +86,9 @@
 
   Squad leader headsets contain the squad and JTAC nets, but not the command net.
 
-  A squad leader can use an RTO's AN/PRC handset to communicate on command:
+  A squad leader can use a Fireteam Leader's AN/PRC handset to communicate on command:
 
-  - Stand near the RTO or a deployed radio.
+  - Stand near the Fireteam Leader or a deployed radio.
   - Alt-click the wearer or radio.
   - Select [bold]Take Handset[/bold].
   - Transmit with [color=#a4885c]:r[/color].

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsQuickRef.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsQuickRef.xml
@@ -46,14 +46,11 @@
 
   The AN/PRC panel can be operated by:
 
-  - Radio Traffic Operators
-  - Commanders
-  - Officer Adjutants
-  - Advisors
-  - Platoon Sergeants
-  - CLF Cell Leaders
+  - [bold]GOVFOR and OPFOR[/bold] - Commander, Adjutant, staff officers, engineering officers, intelligence officers, synthetics, squad leaders, Fireteam Leaders, and Radio Traffic Operators.
+  - [bold]CLF[/bold] - Cell Leader and Radio Operator.
+  - Anyone who has read a [bold]field radio operator's pamphlet[/bold].
 
-  The handset can be used by anyone within range.
+  The handset can be used by anyone within range, trained or not.
 
   ## Signal Range
 
@@ -422,4 +419,69 @@
   [bold]RADIO CHECK[/bold] reports which stations receive the active net clearly or with degradation.
 
   When used inside a jammer field, it also reports a bearing to the strongest jammer.
+
+  ## SEARCH
+
+  [bold]START SEARCH[/bold] walks the band hunting for other factions' frequencies.
+
+  While searching:
+
+  <Table Columns="2" MinForcedColumnWidth="110">
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Effect[/bold]</Box>
+    </ColorBox>
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Value[/bold]</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Loaded nets</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">All dropped. You hear nothing.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Transmit</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Inhibited.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Full band pass</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Approximately 80 seconds.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Catches a frequency if</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">It carried traffic within the last 20 seconds, within 60 tiles, on the same level.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Catches to resolve</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">4.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Partial contact decay</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Full decay in roughly 50 seconds without another catch.</Box>
+    </ColorBox>
+  </Table>
+
+  Contacts below half confidence are hidden, above it show an approximate frequency, and at full confidence resolve to an exact frequency and net name.
+
+  ## Net Log
+
+  Stores the last [bold]50[/bold] entries. Other factions' traffic is flagged [bold]INTERCEPT[/bold].
+
+  [bold]PRINT LOG[/bold] and [bold]PRINT INTERCEPTS[/bold] transcribe it to paper.
 </Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Builds on the AN/PRC-117G comms system to give the **CLF radio operator an actual job loop** and give the cell leader someone to talk to

### Nets
- **`radioCLF` is now anchor-gated** like the conventional-force combat nets, so it needs a live CLF AN/PRC on the map to carry it. Colony stays ungated as the fallback: a cell that loses its own relay coverage drops to unencrypted colony chatter rather than going silent
- **New `radioCLFCommand` net**, carried only on AN/PRC sets (no earpiece). The cell leader reaches it through a set's handset or panel, not from a headset

### Base station (`AU14CLFBaseStation`)
- A CLF set too heavy to wear, it works only when planted. Carried by hand to a hiding spot and set up, it anchors both CLF nets across a mast-antenna radius
- Comes **pre-tuned to both nets** via a new `ANPRCRadio.defaultSlots` datafield, seeded at map init, so it is usable the moment it is deployed without opening the panel. The leader mans it on the handset while the operator takes the manpack forward
- Spawns in the safehouse tool cache and is buyable from the CLF vendor

### Band sweep (`ANPRCSweepSystem`)
- **SEARCH** walks the receiver across the band hunting for other factions' frequencies. Searching takes the set out of service, so it drops every net and inhibits transmit. A contact only registers if the frequency carried traffic within a short window, in range, at the moment the head passed. **Four catches resolve a contact**; partial contacts decay. Unresolved contacts are blurred server-side so the exact frequency is only known once earned. Resolved contacts can be tuned straight into a slot
- The client is now only shipped own-faction, faction-less, and resolved frequencies instead of the entire signal plan
- **FREQ** now rejects raw frequencies outside the searchable military band and the softwave band, so a custom net cannot hide where no receiver could ever find it. Published channel frequencies stay tunable by number regardless of band

### Net log
- Traffic on another faction's net is flagged as an **intercept** and colour-coded
- **PRINT LOG / PRINT INTERCEPTS** transcribe the log to paper, so an intercept can outlive the 50-entry rollover and be physically carried off the radio

### Callsigns drop on open channels
Callsigns are net procedure, not identity. Speaking on a channel that does not belong to a callsign faction (colony comms, WEYU, CMB, the third-party nets) now goes out under the speaker's **own name and rank**, exactly as it would without the comms overhaul. The callsign mask, the job-prefix strip, and the net-log sender name all follow that rule, on the headset path and through an AN/PRC pack or handset alike. The two raw-frequency sentinel paths (AN/PRC FREQ overrides and tunable direct frequencies) keep the mask: the audience there is whoever tuned in, not the public

### Guidebook
Updated for the CLF nets, base station, sweep, and print features, plus a fix to the trained-roles list which omitted the CLF Radio Operator

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The base comms PR gave GOVFOR/OPFOR RTOs a real field role, but the CLF operator had little to actually do. This closes that gap:

- **Anchor-gating `radioCLF`** makes the CLF set worth protecting
- The **command net** and **base station** split the CLF radio picture into a forward manpack (operator) and a rear command post (leader on the handset), so the two roles need each other rather than duplicating one radio
- **Band sweep** turns interception into an active minigame with a cost (the set is off the net while searching) and a real reward (enemy frequencies you can tune and log), instead of a passive "you hear static." The four-catch resolve and blurred contacts stop it from being a free frequency dump
- **Print log** gives intercepted intel physical persistence

## Technical details
<!-- Summary of code changes for easier review. -->

- **`ANPRCSweepSystem`** (new): drives the SEARCH state. Band walk, per-tick contact detection (traffic-in-window + in-range gating), four-catch resolution, partial-contact decay, and server-side blurring of unresolved frequencies. BuildChannelFrequencies` now filters to own-faction / faction-less / resolved before it reaches the client; `FREQ` validates against the searchable military and softwave bands
- **`ANPRCRadioComponent`** gains `defaultSlots` Presets seeded at map init so the base station is deployable without opening the panel
- **`AU14CLFBaseStation`** is a plant-only set anchoring both CLF nets at mast-antenna radius, pre-tuned via `defaultSlots`
- **`radioCLFCommand`** channel added (AN/PRC-only, no earpiece key); **`radioCLF`** flagged `AnchorGated`
- **Callsign masking** now keys off the shared callsign-faction set, moved into the `AU14Callsigns` statics so the callsign system and the radio system agree on which nets carry callsigns. The mask, job-prefix strip, and net-log sender name all consult it uniformly across the headset, pack, and handset paths; the FREQ and tunable-direct sentinel paths deliberately keep the mask
- **Net log** flags cross-faction traffic as intercepts (colour-coded); **PRINT LOG / PRINT INTERCEPTS** render the log to paper
- Prototypes: base station entity, CLF command channel, `defaultSlots` on the CLF sets, safehouse cache + vendor entries. Guidebook XML and locale updated (CLF nets, base station, sweep, print, trained-roles fix)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

<!-- TODO: add clips of the band sweep resolving a contact, the base station deployed and manned on the handset, and a printed intercept log. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay. -->
:cl:
- add: The CLF combat net now needs a live CLF AN/PRC on the map to carry it
- add: Added a CLF command net carried only on AN/PRC sets, so the cell leader reaches it through a set's handset or panel
- add: Added the CLF base station: a plant-only AN/PRC that anchors both CLF nets across a wide radius, comes pre-tuned to both, and spawns in the safehouse cache and CLF vendor
- add: Added band sweep (SEARCH) to the AN/PRC, letting operators hunt for other factions' frequencies. Searching takes the set off the net, and a frequency is only revealed after repeated catches on live traffic
- add: Intercepted traffic on other factions' nets is now flagged and colour-coded in the net log, and can be printed to paper with PRINT LOG / PRINT INTERCEPTS
- tweak: Radio callsigns now only mask names on faction nets. Speaking on colony, WEYU, CMB, or third-party channels goes out under your own name and rank
- fix: Added the CLF Radio Operator to the trained-roles list in the comms guidebook
- fix: Restored the AN/PRC-117G manpack and CLF base station to the CLF tool cache, which the new insurgency cell kit had dropped
