### PR TITLE
revert scout to release

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -234,17 +234,6 @@
       Snow: _RMC14/Objects/Clothing/Back/Backpacks/Marines/sniper_smock/snow-urban-desert.rsi
       Classic: _RMC14/Objects/Clothing/Back/Backpacks/Marines/sniper_smock/jungle-classic.rsi
       Urban: _RMC14/Objects/Clothing/Back/Backpacks/Marines/sniper_smock/snow-urban-desert.rsi
-  - type: Clothing
-    equipSound:
-      collection: storageRustle
-    unequipSound:
-      collection: RMCEquipArmor
-    quickEquip: false
-    slots:
-    - back
-    - belt
-  - type: Corrodible
-    isCorrodible: false
 
 - type: entity
   parent: CMSatchel
@@ -256,7 +245,13 @@
     sprite: _RMC14/Objects/Clothing/Back/Backpacks/Marines/scout_cloak.rsi
   - type: Storage
     grid:
-    - 0,0,15,1
+    - 0,0,14,1 # 15 slots
+  - type: ClothingRequireEquipped
+    autoUnequip: true
+    whitelist:
+      tags:
+      - RMCScoutArmor
+    denyReason: rmc-wear-scout-armor-required
   - type: ThermalCloak
     opacity: 0.035 # Put to 0.03 for testing
     restrictWeapons: true

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -2,7 +2,7 @@
   parent: RMCBaseEquipmentCase
   id: CMSniperEquipmentCase
   name: sniper equipment case
-  description: "A large case containing your very own long-range M96S sniper rifle, M45 ghillie armor and helmet, M42 scout sight, ammunition, spotter equipment, and additional pieces of equipment.\n\nNOTE: You cannot put items back inside this case."
+  description: "A large case containing your very own long-range M96S sniper rifle, M42 scout sight, ammunition, spotter equipment, and additional pieces of equipment.\n\nNOTE: You cannot put items back inside this case."
   components:
   - type: Storage
     maxItemSize: Huge
@@ -21,7 +21,6 @@
     - id: CMM96SSniperRifle
     - id: AU14KitSpotter
 #    - id: CMFacepaintSniper
-    - id: AU14ScoutWebbing
   - type: CMChangeUserOnVend
     addComponents:
     - type: SniperWhitelist
@@ -34,7 +33,7 @@
   parent: CMSniperEquipmentCase
   id: RMCAntiMaterielEquipmentCase
   name: anti-materiel sniper equipment case
-  description: "A large case containing your very own long-range XM43E1 anti-materiel sniper rifle, M45 ghillie armor and helmet, M42 scout sight, ammunition, spotter equipment, and additional pieces of equipment.\n\nNOTE: You cannot put items back inside this case."
+  description: "A large case containing your very own long-range XM43E1 anti-materiel sniper rifle, M42 scout sight, ammunition, spotter equipment, and additional pieces of equipment.\n\nNOTE: You cannot put items back inside this case."
   components:
   - type: Storage
     maxItemSize: Huge
@@ -49,7 +48,6 @@
     - id: RMCScoutShoes
     - id: CMBackpackSniper
     - id: AU14KitSpotter
-    - id: AU14ScoutWebbing
   - type: IgnoreContentsSize
     items:
       tags:
@@ -196,15 +194,15 @@
     - id: RMCMagazineRifleM4SPRA19Impact
       amount: 4
     - id: RMCBackpackScout
-    - id: CMBackpackSniper
     - id: WeaponRifleM4SPRCustom
     - id: RMCThermalTarpFolded
       amount: 2
     - id: RMCExplosivePlastic
       amount: 2
     - id: RMCLaserDesignatorScout
+    - id: RMCArmorM3Scout
+    - id: RMCArmorHelmetM3Scout
     - id: RMCScoutShoes
-    - id: AU14ScoutWebbing
   - type: CMChangeUserOnVend
     addComponents:
     - type: ScoutWhitelist
@@ -237,15 +235,15 @@
     - id: RMCAttachmentFlashlightGrip
     - id: RMCAttachmentS5RedDotSight
     - id: RMCBackpackScout
-    - id: CMBackpackSniper
     - id: WeaponRifleM5SPR2
     - id: RMCThermalTarpFolded
       amount: 2
     - id: RMCExplosivePlastic
       amount: 2
     - id: RMCLaserDesignatorScout
+    - id: RMCArmorM3Scout
+    - id: RMCArmorHelmetM3Scout
     - id: RMCScoutShoes
-    - id: AU14ScoutWebbing
   - type: CMChangeUserOnVend
     addComponents:
     - type: ScoutWhitelist
@@ -477,7 +475,6 @@
     sprite: _RMC14/Objects/Storage/procase_mini.rsi
   - type: StorageFill
     contents:
-    - id: AU14ScoutWebbing
     - id: CMArmorHelmetM45
     - id: RMCVisorNightVision
     - id: CMBackpackSniper


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed the sniper spec backpack from scout's kit, removed the ability to wear it on belt (partial revert of #1397)
Gives scout their armor back, remove their webbing (partial revert of #1443)
Scout requires their armor to become invisible (partial revert of #1300)
Changed the description of sniper cases as they still don't have M45 ghille armor

## Why / Balance
All of these changes were made week 1 of specialist being in the game, before it was even really tested. Scout will be just as effective at their role as before, and scout will still be picked every round just as it is on RMC.

The webbing is not needed for a scout to do their job of trailing people and doing recon, as they have binoculars, NVGs that function with active binoculars, and near full invisibility. The webbing itself had no reason to be as armored as light armor while moving as quick as someone unarmored, while also invisible, and really just encouraged a fragging playstyle. They are already plenty combat viable by having the single best gun in the game with a very quick CAS designator, and their old armor having medium armor stats but with light speed. 

Giving the scout a 2x sized specialist satchel with no open doafter and making it fit in the belt slot was a very questionable change that just let specs fit endless ammo, also just promoting a solo fragging playstyle.

## Media

invisibility still works 
<img width="320" height="180" alt="Screenshot (1291)" src="https://github.com/user-attachments/assets/5c7c8673-e4ee-472c-9804-0c2a7b22d1ac" />

the new scout kits
<img width="320" height="180" alt="Screenshot (1289)" src="https://github.com/user-attachments/assets/eb0aa2a4-dc2f-477f-845b-bd6b7694ddbf" />
<img width="320" height="180" alt="Screenshot (1290)" src="https://github.com/user-attachments/assets/4f3e5617-3fe3-40cb-9e22-cf27fb63353f" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: shibechef
- add: Adds the scout armor back to their kit.
- remove: Removes webbing from scout kit.
- tweak: Scouts must wear their armor to become invisible.
- remove: Sniper backpacks can no longer be worn on the belt slot.