### PR TITLE
Queen can no longer rest in ovi + plasma trees work in ovi

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/PlasmaTree/PlasmaTreeSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Plasma;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Rest;
@@ -57,7 +58,7 @@ public sealed partial class PlasmaTreeSystem : EntitySystem
         {
             if (!_hive.FromSameHive(ent, nearbyEntity) ||
                 !HasComp<XenoComponent>(nearbyEntity) ||
-                !HasComp<XenoRestingComponent>(nearbyEntity) ||
+                !(HasComp<XenoRestingComponent>(nearbyEntity) || HasComp<XenoAttachedOvipositorComponent>(nearbyEntity)) ||
                 !TryComp<XenoPlasmaComponent>(nearbyEntity, out var plasmaComp) ||
                 plasmaComp.Plasma == plasmaComp.MaxPlasma ||
                 !HasComp<MobStateComponent>(nearbyEntity) ||
@@ -85,7 +86,7 @@ public sealed partial class PlasmaTreeSystem : EntitySystem
             BreakOnMove = true,
             MovementThreshold = 0.5f,
             DuplicateCondition = DuplicateConditions.SameEvent,
-            TargetEffect = "RMCEffectHealBusy",
+            TargetEffect = "RMCEffectHealPlasma",
         };
 
         if (_doafter.TryStartDoAfter(recover, out var id))

--- a/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Egg/XenoEggSystem.cs
@@ -8,6 +8,7 @@ using Content.Shared._RMC14.Xenonids.Egg.EggRetriever;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Plasma;
+using Content.Shared._RMC14.Xenonids.Rest;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Actions;
 using Content.Shared.Buckle.Components;
@@ -101,6 +102,7 @@ public sealed partial class XenoEggSystem : EntitySystem
         SubscribeLocalEvent<XenoAttachedOvipositorComponent, ComponentRemove>(OnXenoAttachedRemove);
         SubscribeLocalEvent<XenoAttachedOvipositorComponent, MobStateChangedEvent>(OnXenoMobStateChanged);
         SubscribeLocalEvent<XenoAttachedOvipositorComponent, XenoConstructionRangeEvent>(OnXenoConstructionRange);
+        SubscribeLocalEvent<XenoAttachedOvipositorComponent, XenoRestAttemptEvent>(OnXenoRest);
 
         SubscribeLocalEvent<XenoEggComponent, AfterAutoHandleStateEvent>(OnXenoEggAfterState);
         SubscribeLocalEvent<XenoEggComponent, GettingPickedUpAttemptEvent>(OnXenoEggPickedUpAttempt);
@@ -221,6 +223,11 @@ public sealed partial class XenoEggSystem : EntitySystem
     private void OnXenoConstructionRange(Entity<XenoAttachedOvipositorComponent> ent, ref XenoConstructionRangeEvent args)
     {
         args.Range = 0;
+    }
+
+    private void OnXenoRest(Entity<XenoAttachedOvipositorComponent> ent, ref XenoRestAttemptEvent args)
+    {
+        args.Cancelled = true;
     }
 
     private void OnXenoEggAfterState(Entity<XenoEggComponent> egg, ref AfterAutoHandleStateEvent args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Direct port of two RMC prs.
Makes plasma tree use more streamlined, and changes the visual effect. Queen was never intended to rest in ovi anyway so that is partially a bug fix
Simply checks for ovi component for both tweaks.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Queen can no longer rest in ovi, and plasma trees work properly in ovi now.