### PR TITLE
Tile Movement (Sorta)

### DIFF
--- a/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.Smites.cs
@@ -17,6 +17,7 @@ using Content.Server.Storage.Components;
 using Content.Server.Storage.EntitySystems;
 using Content.Server.Tabletop;
 using Content.Server.Tabletop.Components;
+using Content.Shared._CMU14.TileMovement;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared.Administration;
 using Content.Shared.Administration.Components;
@@ -804,6 +805,24 @@ public sealed partial class AdminVerbSystem
             Message = string.Join(": ", runWalkSwapName, Loc.GetString("admin-smite-run-walk-swap-description"))
         };
         args.Verbs.Add(runWalkSwap);
+
+        var tileMovementName = Loc.GetString("admin-smite-tile-movement-name").ToLowerInvariant();
+        Verb tileMovement = new()
+        {
+            Text = tileMovementName,
+            Category = VerbCategory.Smite,
+            Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/smite.svg.192dpi.png")),
+            Act = () =>
+            {
+                EnsureComp<CMUTileMovementComponent>(args.Target);
+
+                _popupSystem.PopupEntity(Loc.GetString("admin-smite-tile-movement-prompt"), args.Target,
+                    args.Target, PopupType.LargeCaution);
+            },
+            Impact = LogImpact.Extreme,
+            Message = string.Join(": ", tileMovementName, Loc.GetString("admin-smite-tile-movement-description"))
+        };
+        args.Verbs.Add(tileMovement);
 
         var backwardsAccentName = Loc.GetString("admin-smite-speak-backwards-name").ToLowerInvariant();
         Verb backwardsAccent = new()

--- a/Content.Server/Administration/Systems/AdminVerbSystem.cs
+++ b/Content.Server/Administration/Systems/AdminVerbSystem.cs
@@ -10,6 +10,7 @@ using Content.Server.Mind.Commands;
 using Content.Server.Prayer;
 using Content.Server.Silicons.Laws;
 using Content.Server.Station.Systems;
+using Content.Server._RMC14.Mentor;
 using Content.Shared._RMC14.Admin;
 using Content.Shared._RMC14.Dialog;
 using Content.Shared._RMC14.Prototypes;
@@ -72,6 +73,7 @@ namespace Content.Server.Administration.Systems
         [Dependency] private AdminFrozenSystem _freeze = default!;
         [Dependency] private IPlayerManager _playerManager = default!;
         [Dependency] private SiliconLawSystem _siliconLawSystem = default!;
+        [Dependency] private MentorManager _mentorManager = default!;
 
         // RMC14
         [Dependency] private DialogSystem _dialog = default!;
@@ -139,54 +141,59 @@ namespace Content.Server.Administration.Systems
                     args.Verbs.Add(prayerVerb);
 
                     // Spawn - Like respawn but on the spot.
-                    args.Verbs.Add(new Verb()
+                    // Mentors are excluded even if their admin data otherwise counts as IsAdmin (e.g. via
+                    // the MentorHelp flag alone) - spawning players is not part of what mentors should do.
+                    if (!_mentorManager.IsMentor(player.UserId))
                     {
-                        Text = Loc.GetString("admin-player-actions-spawn"),
-                        Category = VerbCategory.Admin,
-                        Act = () =>
+                        args.Verbs.Add(new Verb()
                         {
-                            if (!_transformSystem.TryGetMapOrGridCoordinates(args.Target, out var coords))
+                            Text = Loc.GetString("admin-player-actions-spawn"),
+                            Category = VerbCategory.Admin,
+                            Act = () =>
                             {
-                                _popup.PopupEntity(Loc.GetString("admin-player-spawn-failed"), args.User, args.User);
-                                return;
-                            }
+                                if (!_transformSystem.TryGetMapOrGridCoordinates(args.Target, out var coords))
+                                {
+                                    _popup.PopupEntity(Loc.GetString("admin-player-spawn-failed"), args.User, args.User);
+                                    return;
+                                }
 
-                            var stationUid = _stations.GetOwningStation(args.Target);
+                                var stationUid = _stations.GetOwningStation(args.Target);
 
-                            var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
-                            var mobUid = _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid);
+                                var profile = _gameTicker.GetPlayerProfile(targetActor.PlayerSession);
+                                var mobUid = _spawning.SpawnPlayerMob(coords.Value, null, profile, stationUid);
 
-                            if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp))
-                                _mindSystem.TransferTo(mindId, mobUid, true, mind: mindComp);
+                                if (_mindSystem.TryGetMind(args.Target, out var mindId, out var mindComp))
+                                    _mindSystem.TransferTo(mindId, mobUid, true, mind: mindComp);
 
-                        },
-                        ConfirmationPopup = true,
-                        Impact = LogImpact.High,
-                    });
+                            },
+                            ConfirmationPopup = true,
+                            Impact = LogImpact.High,
+                        });
 
-                    // RMC14
-                    args.Verbs.Add(new Verb
-                    {
-                        Text = Loc.GetString("rmc-admin-player-actions-spawn-here-as-job"),
-                        Category = VerbCategory.Admin,
-                        Act = () =>
+                        // RMC14
+                        args.Verbs.Add(new Verb
                         {
-                            var jobs = new List<DialogOption>();
-                            foreach (var job in _prototypeManager.EnumerateCM<JobPrototype>())
+                            Text = Loc.GetString("rmc-admin-player-actions-spawn-here-as-job"),
+                            Category = VerbCategory.Admin,
+                            Act = () =>
                             {
-                                var ev = new SpawnAsJobDialogEvent(GetNetEntity(args.User), GetNetEntity(args.Target), job.ID);
-                                var roleName = job.SpawnMenuRoleName is { } raw
-                                    ? (Loc.TryGetString(raw, out var loc) ? loc : raw)
-                                    : job.LocalizedName;
-                                jobs.Add(new DialogOption(roleName, ev));
-                            }
+                                var jobs = new List<DialogOption>();
+                                foreach (var job in _prototypeManager.EnumerateCM<JobPrototype>())
+                                {
+                                    var ev = new SpawnAsJobDialogEvent(GetNetEntity(args.User), GetNetEntity(args.Target), job.ID);
+                                    var roleName = job.SpawnMenuRoleName is { } raw
+                                        ? (Loc.TryGetString(raw, out var loc) ? loc : raw)
+                                        : job.LocalizedName;
+                                    jobs.Add(new DialogOption(roleName, ev));
+                                }
 
-                            jobs.Sort((a, b) => string.Compare(a.Text, b.Text, StringComparison.Ordinal));
-                            _dialog.OpenOptions(args.User, "Choose a job", jobs);
-                        },
-                        ConfirmationPopup = true,
-                        Impact = LogImpact.High,
-                    });
+                                jobs.Sort((a, b) => string.Compare(a.Text, b.Text, StringComparison.Ordinal));
+                                _dialog.OpenOptions(args.User, "Choose a job", jobs);
+                            },
+                            ConfirmationPopup = true,
+                            Impact = LogImpact.High,
+                        });
+                    }
 
                     if (TryComp(args.Target, out HumanoidAppearanceComponent? appearance))
                     {

--- a/Content.Server/_CMU14/TileMovement/CMUForceTileMovementCommand.cs
+++ b/Content.Server/_CMU14/TileMovement/CMUForceTileMovementCommand.cs
@@ -1,0 +1,28 @@
+using Content.Server.Administration;
+using Content.Server.Administration.Commands;
+using Content.Shared.Administration;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+
+namespace Content.Server._CMU14.TileMovement;
+
+[AdminCommand(AdminFlags.Server)]
+public sealed partial class CMUForceTileMovementCommand : LocalizedCommands
+{
+    [Dependency] private IConfigurationManager _cfg = default!;
+
+    public override string Command => "cmuforcetilemovement";
+
+    public override void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var toggle = PanicBunkerCommand.Toggle(CCVars.CMUTileMovementForcedForAll, shell, args, _cfg, LocalizationManager);
+        if (toggle == null)
+            return;
+
+        shell.WriteLine(Loc.GetString(toggle.Value
+            ? "cmuforcetilemovement-command-enabled"
+            : "cmuforcetilemovement-command-disabled"
+        ));
+    }
+}

--- a/Content.Server/_CMU14/TileMovement/CMUGlobalTileMovementSystem.cs
+++ b/Content.Server/_CMU14/TileMovement/CMUGlobalTileMovementSystem.cs
@@ -1,0 +1,75 @@
+using Content.Shared._CMU14.TileMovement;
+using Content.Shared.CCVar;
+using Content.Shared.Movement.Components;
+using Robust.Shared.Configuration;
+
+namespace Content.Server._CMU14.TileMovement;
+
+/// <summary>
+/// Lets an admin force tile-based movement onto every player mob at once via the "cmuforcetilemovement"
+/// command (backed by <see cref="CCVars.CMUTileMovementForcedForAll"/>). Applies retroactively to
+/// everyone already moving around, and (via <see cref="Update"/>) to anyone who spawns/attaches to a
+/// mover while it's enabled. Never touches entities that already had <see cref="CMUTileMovementComponent"/>
+/// before the toggle (e.g. via the trait), so turning the toggle back off doesn't strip those.
+/// </summary>
+public sealed class CMUGlobalTileMovementSystem : EntitySystem
+{
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+
+    private bool _forcedForAll;
+
+    /// <summary>Entities we added CMUTileMovementComponent to ourselves, so we know what to clean up.</summary>
+    private readonly HashSet<EntityUid> _forced = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        Subs.CVar(_cfg, CCVars.CMUTileMovementForcedForAll, OnForcedChanged, true);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // ComponentStartup on InputMoverComponent is an exclusive lifecycle event already claimed by
+        // ActionBlockerSystem, so newly-spawned/attached movers are picked up here instead.
+        if (!_forcedForAll)
+            return;
+
+        var query = EntityQueryEnumerator<InputMoverComponent>();
+        while (query.MoveNext(out var uid, out _))
+            Force(uid);
+    }
+
+    private void OnForcedChanged(bool enabled)
+    {
+        _forcedForAll = enabled;
+
+        if (enabled)
+        {
+            var query = EntityQueryEnumerator<InputMoverComponent>();
+            while (query.MoveNext(out var uid, out _))
+                Force(uid);
+
+            return;
+        }
+
+        foreach (var uid in _forced)
+        {
+            if (Exists(uid))
+                RemComp<CMUTileMovementComponent>(uid);
+        }
+
+        _forced.Clear();
+    }
+
+    private void Force(EntityUid uid)
+    {
+        if (HasComp<CMUTileMovementComponent>(uid))
+            return;
+
+        AddComp<CMUTileMovementComponent>(uid);
+        _forced.Add(uid);
+    }
+}

--- a/Content.Shared/CCVar/CCVars.CMU.TileMovement.cs
+++ b/Content.Shared/CCVar/CCVars.CMU.TileMovement.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Administration;
+using Content.Shared.CCVar.CVarAccess;
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// When enabled, forces tile-based movement (see CMUTileMovementComponent) onto every mob with an
+    /// InputMoverComponent, regardless of whether they have the trait. Toggled via the
+    /// "cmuforcetilemovement" admin command.
+    /// </summary>
+    [CVarControl(AdminFlags.VarEdit)]
+    public static readonly CVarDef<bool> CMUTileMovementForcedForAll =
+        CVarDef.Create("cmu.tile_movement.forced_for_all", false, CVar.SERVERONLY);
+}

--- a/Content.Shared/Movement/Systems/SharedMoverController.cs
+++ b/Content.Shared/Movement/Systems/SharedMoverController.cs
@@ -10,6 +10,7 @@ using Content.Shared.Mobs.Systems;
 using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Tag;
+using Content.Shared._CMU14.TileMovement;
 using Robust.Shared.Audio;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Configuration;
@@ -59,6 +60,7 @@ public abstract partial class SharedMoverController : VirtualController
     protected EntityQuery<RelayInputMoverComponent> RelayQuery;
     protected EntityQuery<PullableComponent> PullableQuery;
     protected EntityQuery<TransformComponent> XformQuery;
+    protected EntityQuery<CMUTileMovementComponent> TileMovementQuery;
 
     private static readonly ProtoId<TagPrototype> FootstepSoundTag = "FootstepSound";
 
@@ -67,6 +69,11 @@ public abstract partial class SharedMoverController : VirtualController
     private float _airDamping;
     private float _offGridDamping;
     private readonly HashSet<EntityUid> _aroundColliderIntersecting = new();
+
+    /// <summary>
+    /// Substep-accurate current time, used by tile movement so slides stay smooth across a single physics tick.
+    /// </summary>
+    private TimeSpan CurrentTime => PhysicsSystem.EffectiveCurTime ?? Timing.CurTime;
 
     /// <summary>
     /// Cache the mob movement calculation to re-use elsewhere.
@@ -91,6 +98,7 @@ public abstract partial class SharedMoverController : VirtualController
         FootstepModifierQuery = GetEntityQuery<FootstepModifierComponent>();
         MapGridQuery = GetEntityQuery<MapGridComponent>();
         MapQuery = GetEntityQuery<MapComponent>();
+        TileMovementQuery = GetEntityQuery<CMUTileMovementComponent>();
 
         SubscribeLocalEvent<MovementSpeedModifierComponent, TileFrictionEvent>(OnTileFriction);
 
@@ -171,6 +179,11 @@ public abstract partial class SharedMoverController : VirtualController
         // If we're not the target of a relay then handle lerp data.
         if (relaySource == null)
         {
+            // Tile movement needs the relative data to be current every tick, not just after a LerpTarget delay,
+            // since a slide can carry us across a grid boundary mid-tile.
+            if (TileMovementQuery.HasComponent(uid))
+                TryUpdateRelative(uid, mover, xform);
+
             // Update relative movement
             if (mover.LerpTarget < Timing.CurTime)
             {
@@ -215,6 +228,32 @@ public abstract partial class SharedMoverController : VirtualController
 
         // Get current tile def for things like speed/friction mods
         ContentTileDefinition? tileDef = null;
+
+        // Try doing tile movement instead of the usual analog movement, if this entity has it enabled.
+        if (TileMovementQuery.TryComp(uid, out var tileMovement))
+        {
+            if (!weightless && !inAirHelpless)
+            {
+                var didTileMovement = HandleTileMovement(uid,
+                    uid,
+                    tileMovement,
+                    physicsComponent,
+                    xform,
+                    mover,
+                    tileDef,
+                    relayTarget,
+                    frameTime);
+                tileMovement.WasWeightlessLastTick = weightless;
+                if (didTileMovement)
+                    return;
+            }
+            else
+            {
+                tileMovement.WasWeightlessLastTick = weightless;
+                tileMovement.SlideActive = false;
+                tileMovement.FailureSlideActive = false;
+            }
+        }
 
         var touching = false;
         // Whether we use tilefriction or not
@@ -633,5 +672,377 @@ public abstract partial class SharedMoverController : VirtualController
             args.Modifier *= ent.Comp.BaseWeightlessFriction;
         else
             args.Modifier *= ent.Comp.BaseFriction;
+    }
+
+    // Tile movement.
+    // Uses a physics-based implementation: rather than teleporting between tiles, we set velocity towards the
+    // center of the destination tile and let the normal physics/collision solver carry us there (or stop us
+    // early if something's in the way). This gives smooth, collidable movement while still snapping to tiles.
+
+    /// <summary>
+    /// Runs one tick of tile-based movement on the given inputs.
+    /// </summary>
+    /// <param name="uid">UID of the entity doing the move.</param>
+    /// <param name="physicsUid">UID of the physics entity doing the move. Usually the same as uid.</param>
+    /// <param name="tileMovement">CMUTileMovementComponent on the entity doing the move.</param>
+    /// <param name="physicsComponent">PhysicsComponent on the entity doing the move.</param>
+    /// <param name="targetTransform">TransformComponent on the entity doing the move.</param>
+    /// <param name="inputMover">InputMoverComponent on the entity doing the move.</param>
+    /// <param name="tileDef">ContentTileDefinition of the tile underneath the entity doing the move, if there is one.</param>
+    /// <param name="relayTarget">MovementRelayTargetComponent on the relay target, if any.</param>
+    /// <param name="frameTime">Time in seconds since the last tick of the physics system.</param>
+    /// <returns>True if tile movement handled this tick's movement (i.e. the caller should not also apply analog movement).</returns>
+    public bool HandleTileMovement(
+        EntityUid uid,
+        EntityUid physicsUid,
+        CMUTileMovementComponent tileMovement,
+        PhysicsComponent physicsComponent,
+        TransformComponent targetTransform,
+        InputMoverComponent inputMover,
+        ContentTileDefinition? tileDef,
+        MovementRelayTargetComponent? relayTarget,
+        float frameTime
+    )
+    {
+        // For smoothness' sake, if we just arrived on a grid after pixel moving in space then initiate a slide
+        // towards the center of the tile we're on and continue. It feels much nicer this way.
+        if (tileMovement.WasWeightlessLastTick)
+        {
+            InitializeSlideToCenter(physicsUid, tileMovement);
+            UpdateSlide(physicsUid, physicsUid, tileMovement, inputMover);
+        }
+        // If we're not moving, apply friction to existing velocity and then continue.
+        else if (StripWalk(inputMover.HeldMoveButtons) == MoveButtons.None && !tileMovement.SlideActive)
+        {
+            var movementVelocity = physicsComponent.LinearVelocity;
+
+            var movementSpeedComponent = ModifierQuery.CompOrNull(uid);
+            var friction = GetEntityFriction(inputMover, movementSpeedComponent, tileDef);
+            var minimumFrictionSpeed = movementSpeedComponent?.MinimumFrictionSpeed ??
+                MovementSpeedModifierComponent.DefaultMinimumFrictionSpeed;
+            Friction(minimumFrictionSpeed, frameTime, friction, ref movementVelocity);
+
+            PhysicsSystem.SetLinearVelocity(physicsUid, movementVelocity, body: physicsComponent);
+            PhysicsSystem.SetAngularVelocity(physicsUid, 0, body: physicsComponent);
+        }
+        // Otherwise, handle typical tile movement.
+        else
+        {
+            // Play step sound.
+            if (MobMoverQuery.TryGetComponent(uid, out var mobMover) &&
+                TryGetSound(false, uid, inputMover, mobMover, targetTransform, out var sound, tileDef: tileDef))
+            {
+                var soundModifier = inputMover.Sprinting ? 3.5f : 1.5f;
+                var volume = sound.Params.Volume + soundModifier;
+
+                var audioParams = sound.Params
+                    .WithVolume(volume)
+                    .WithVariation(sound.Params.Variation ?? mobMover.FootstepVariation);
+
+                // If we're a relay target then predict the sound for all relays.
+                if (relayTarget != null)
+                {
+                    _audio.PlayPredicted(sound, uid, relayTarget.Source, audioParams);
+                }
+                else
+                {
+                    _audio.PlayPredicted(sound, uid, uid, audioParams);
+                }
+            }
+
+            // If we're sliding...
+            if (tileMovement.SlideActive)
+            {
+                var movementSpeed = GetEntityMoveSpeed(uid, inputMover.Sprinting);
+
+                // Check whether we should end the slide.
+                if (CheckForSlideEnd(
+                    StripWalk(inputMover.HeldMoveButtons),
+                    targetTransform,
+                    tileMovement,
+                    movementSpeed))
+                {
+                    EndSlide(uid, tileMovement);
+
+                    // After ending the slide, check for immediately starting a new slide.
+                    if (StripWalk(inputMover.HeldMoveButtons) != MoveButtons.None)
+                    {
+                        InitializeSlide(physicsUid, tileMovement, inputMover);
+                        UpdateSlide(physicsUid, physicsUid, tileMovement, inputMover);
+                        tileMovement.FailureSlideActive = false;
+                    }
+                    // Otherwise if we failed to reach the destination, begin a "failure slide" back to the
+                    // original position.
+                    else if (!tileMovement.FailureSlideActive && !targetTransform.LocalPosition.EqualsApprox(tileMovement.Destination, 0.04))
+                    {
+                        InitializeSlideToTarget(physicsUid, tileMovement, targetTransform.LocalPosition, MoveButtons.None);
+                        UpdateSlide(physicsUid, physicsUid, tileMovement, inputMover);
+                        tileMovement.FailureSlideActive = true;
+                    }
+                    // If we reached proper destination or have already done a "failure slide", snap to tile forcefully.
+                    else
+                    {
+                        ForceSnapToTile(uid, inputMover);
+                        tileMovement.FailureSlideActive = false;
+                    }
+                }
+                // Special case: tile movement takes us between two fully adjacent grids seamlessly.
+                // Since we perform tile movement in local coordinates, stop and start the movement
+                // again to realign to new grid.
+                else if (tileMovement.Origin.EntityId != targetTransform.ParentUid)
+                {
+                    var previousButtons = tileMovement.CurrentSlideMoveButtons;
+                    var previousInitialKeyDownTime = tileMovement.MovementKeyInitialDownTime;
+                    InitializeSlideToCenter(physicsUid, tileMovement);
+                    tileMovement.CurrentSlideMoveButtons = previousButtons;
+                    tileMovement.MovementKeyInitialDownTime = previousInitialKeyDownTime;
+                    UpdateSlide(physicsUid, physicsUid, tileMovement, inputMover);
+                }
+                // Otherwise, continue slide.
+                else
+                {
+                    UpdateSlide(physicsUid, physicsUid, tileMovement, inputMover);
+                }
+            }
+            // If we're not sliding, start slide.
+            else
+            {
+                InitializeSlide(physicsUid, tileMovement, inputMover);
+                UpdateSlide(physicsUid, physicsUid, tileMovement, inputMover);
+            }
+
+            // Set WorldRotation so that our character is facing the way we're walking.
+            if (!NoRotateQuery.HasComponent(uid) && !tileMovement.FailureSlideActive)
+            {
+                if (tileMovement.SlideActive && TryComp(
+                    inputMover.RelativeEntity,
+                    out TransformComponent? parentTransform))
+                {
+                    var delta = tileMovement.Destination - tileMovement.Origin.Position;
+                    var worldRot = _transform.GetWorldRotation(parentTransform).RotateVec(delta).ToWorldAngle();
+                    _transform.SetWorldRotation(targetTransform, worldRot);
+                }
+            }
+        }
+
+        tileMovement.LastTickLocalCoordinates = targetTransform.LocalPosition;
+        Dirty(uid, tileMovement);
+        return true;
+    }
+
+    private bool CheckForSlideEnd(
+        MoveButtons pressedButtons,
+        TransformComponent transform,
+        CMUTileMovementComponent tileMovement,
+        float movementSpeed
+    )
+    {
+        // minPressedTime will be 1.05x the time it should take for you to go from 1 tile to another. Need to
+        // account for diagonals being sqrt(2) length as well. Max of 10 seconds just in case.
+        var distanceToDestination = (tileMovement.Destination - tileMovement.Origin.Position).Length();
+        var minPressedTime = Math.Min((1.05f / movementSpeed) * distanceToDestination, 20);
+
+        // We need to stop the move once we are close enough. This isn't perfect, since it technically ends the move
+        // 1 tick early in some cases. This is because there's a fundamental issue where because this is a physics-based
+        // tile movement system, we sometimes find scenarios where on each tick of the physics system, the player is moved
+        // back and forth across the destination in a loop. Thus, the tolerance needs to be set overly high so that it
+        // reaches the distance one the physics body can move in a single tick.
+        float destinationTolerance = movementSpeed / 100f;
+
+        var reachedDestination =
+            transform.LocalPosition.EqualsApprox(tileMovement.Destination, destinationTolerance);
+        var stoppedPressing = pressedButtons != tileMovement.CurrentSlideMoveButtons;
+        var minDurationPassed = CurrentTime - tileMovement.MovementKeyInitialDownTime >= TimeSpan.FromSeconds(minPressedTime);
+        var noProgress = tileMovement.LastTickLocalCoordinates != null && transform.LocalPosition.EqualsApprox(tileMovement.LastTickLocalCoordinates.Value, destinationTolerance/3);
+        var hardDurationLimitPassed = CurrentTime - tileMovement.MovementKeyInitialDownTime >= TimeSpan.FromSeconds(minPressedTime) * 3;
+        return reachedDestination || (stoppedPressing && (minDurationPassed || noProgress)) || hardDurationLimitPassed;
+    }
+
+    /// <summary>
+    /// Initializes a slide, setting destination and other variables needed to start a slide to the given
+    /// position (which is a local coordinate relative to the parent of the given uid).
+    /// </summary>
+    /// <param name="uid">UID of the entity that will be performing the slide.</param>
+    /// <param name="tileMovement">CMUTileMovementComponent on the entity represented by UID.</param>
+    /// <param name="localPositionTarget">Target of the slide coordinates local to the parent entity of uid.</param>
+    /// <param name="heldMoveButtons">Buttons used to initiate this slide.</param>
+    private void InitializeSlideToTarget(
+        EntityUid uid,
+        CMUTileMovementComponent tileMovement,
+        Vector2 localPositionTarget,
+        MoveButtons heldMoveButtons)
+    {
+        var transform = Transform(uid);
+        var localPosition = transform.LocalPosition;
+
+        tileMovement.SlideActive = true;
+        tileMovement.Origin = new EntityCoordinates(transform.ParentUid, localPosition);
+        tileMovement.Destination = SnapCoordinatesToTile(localPositionTarget);
+        tileMovement.MovementKeyInitialDownTime = CurrentTime;
+        tileMovement.CurrentSlideMoveButtons = heldMoveButtons;
+    }
+
+    /// <summary>
+    /// Initializes a slide, setting destination and other variables needed to start a slide to the center of the
+    /// tile the entity is currently on.
+    /// </summary>
+    /// <param name="uid">UID of the entity that will be performing the slide.</param>
+    /// <param name="tileMovement">CMUTileMovementComponent on the entity represented by UID.</param>
+    private void InitializeSlideToCenter(EntityUid uid, CMUTileMovementComponent tileMovement)
+    {
+        var localPosition = Transform(uid).LocalPosition;
+        InitializeSlideToTarget(uid, tileMovement, SnapCoordinatesToTile(localPosition), MoveButtons.None);
+    }
+
+    /// <summary>
+    /// Initializes a slide, setting destination and other variables needed to move in the direction currently given by
+    /// the InputMoverComponent.
+    /// </summary>
+    /// <param name="uid">UID of the entity that will be performing the slide.</param>
+    /// <param name="tileMovement">CMUTileMovementComponent on the entity represented by UID.</param>
+    /// <param name="inputMover">InputMoverComponent on the entity represented by UID.</param>
+    private void InitializeSlide(EntityUid uid, CMUTileMovementComponent tileMovement, InputMoverComponent inputMover)
+    {
+        var transform = Transform(uid);
+        var localPosition = transform.LocalPosition;
+        var offset = DirVecForButtons(inputMover.HeldMoveButtons);
+        offset = inputMover.TargetRelativeRotation.RotateVec(offset);
+
+        InitializeSlideToTarget(uid, tileMovement, localPosition + offset, StripWalk(inputMover.HeldMoveButtons));
+    }
+
+    /// <summary>
+    /// Updates the velocity of the current physics-based tile movement slide on the given entity.
+    /// </summary>
+    /// <param name="uid">UID of the entity being moved.</param>
+    /// <param name="physicsUid">UID of the entity with the physics body being moved. Usually the same as uid.</param>
+    /// <param name="tileMovement">CMUTileMovementComponent on the entity that's being moved.</param>
+    /// <param name="inputMover">InputMoverComponent of the person controlling the move.</param>
+    private void UpdateSlide(
+        EntityUid uid,
+        EntityUid physicsUid,
+        CMUTileMovementComponent tileMovement,
+        InputMoverComponent inputMover
+    )
+    {
+        var targetTransform = Transform(uid);
+
+        if (PhysicsQuery.TryComp(physicsUid, out var physicsComponent))
+        {
+            // Gather some components and values.
+            var moveSpeedComponent = ModifierQuery.CompOrNull(uid);
+            var parentRotation = Angle.Zero;
+            if (XformQuery.TryGetComponent(targetTransform.GridUid, out var relativeTransform))
+            {
+                parentRotation = _transform.GetWorldRotation(relativeTransform);
+            }
+
+            // Determine velocity based on movespeed, and rotate it so that it's in the right direction.
+            var movementVelocity = (tileMovement.Destination) - (targetTransform.LocalPosition);
+            movementVelocity.Normalize();
+            if (inputMover.Sprinting)
+            {
+                movementVelocity *= moveSpeedComponent?.CurrentSprintSpeed ??
+                    MovementSpeedModifierComponent.DefaultBaseSprintSpeed;
+            }
+            else
+            {
+                movementVelocity *= moveSpeedComponent?.CurrentWalkSpeed ??
+                    MovementSpeedModifierComponent.DefaultBaseWalkSpeed;
+            }
+
+            movementVelocity = parentRotation.RotateVec(movementVelocity);
+
+            // Apply final velocity to physics body.
+            PhysicsSystem.SetLinearVelocity(physicsUid, movementVelocity, body: physicsComponent);
+            PhysicsSystem.SetAngularVelocity(physicsUid, 0, body: physicsComponent);
+        }
+    }
+
+    /// <summary>
+    /// Sets values on a CMUTileMovementComponent designating that the slide has ended and sets it velocity to zero.
+    /// </summary>
+    /// <param name="uid">UID of the entity whose slide is being ended.</param>
+    /// <param name="tileMovement">CMUTileMovementComponent on the entity represented by UID.</param>
+    private void EndSlide(EntityUid uid, CMUTileMovementComponent tileMovement)
+    {
+        tileMovement.SlideActive = false;
+        tileMovement.MovementKeyInitialDownTime = null;
+        var physicsComponent = PhysicsQuery.GetComponent(uid);
+        PhysicsSystem.SetLinearVelocity(uid, Vector2.Zero, body: physicsComponent);
+        PhysicsSystem.SetAngularVelocity(uid, 0, body: physicsComponent);
+    }
+
+    /// <summary>
+    /// Instantly snaps/teleports an entity to the center of the tile it is currently standing on based on the
+    /// given grid. Does not trigger collisions on the way there, but does trigger collisions after the snap.
+    /// </summary>
+    /// <param name="uid">UID of entity to be snapped.</param>
+    /// <param name="inputMover">InputMoverComponent on the entity to be snapped.</param>
+    private void ForceSnapToTile(EntityUid uid, InputMoverComponent inputMover)
+    {
+        if (TryComp(inputMover.RelativeEntity, out TransformComponent? rel))
+        {
+            var targetTransform = Transform(uid);
+
+            var localCoordinates = targetTransform.LocalPosition;
+            var snappedCoordinates = SnapCoordinatesToTile(localCoordinates);
+
+            if (!localCoordinates.EqualsApprox(snappedCoordinates) && targetTransform.ParentUid.IsValid())
+            {
+                _transform.SetLocalPosition(uid, snappedCoordinates);
+            }
+
+            PhysicsSystem.WakeBody(uid);
+        }
+    }
+
+    /// <summary>
+    /// Returns the movespeed of the given entity.
+    /// </summary>
+    /// <param name="uid">UID of the entity whose movespeed is being grabbed. May or may not have a MoveSpeedComponent.</param>
+    /// <param name="sprinting">Whether the speed of the entity while sprinting should be grabbed.</param>
+    private float GetEntityMoveSpeed(EntityUid uid, bool sprinting)
+    {
+        var moveSpeedComponent = ModifierQuery.CompOrNull(uid);
+        if (sprinting)
+        {
+            return moveSpeedComponent?.CurrentSprintSpeed ?? MovementSpeedModifierComponent.DefaultBaseSprintSpeed;
+        }
+
+        return moveSpeedComponent?.CurrentWalkSpeed ?? MovementSpeedModifierComponent.DefaultBaseWalkSpeed;
+    }
+
+    private float GetEntityFriction(
+        InputMoverComponent inputMover,
+        MovementSpeedModifierComponent? movementSpeedComponent,
+        ContentTileDefinition? tileDef
+    )
+    {
+        if (inputMover.HeldMoveButtons != MoveButtons.None || movementSpeedComponent?.FrictionNoInput == null)
+        {
+            return tileDef?.MobFriction ??
+                movementSpeedComponent?.Friction ?? MovementSpeedModifierComponent.DefaultFriction;
+        }
+
+        return movementSpeedComponent.FrictionNoInput;
+    }
+
+    /// <summary>
+    /// Sets the walk value on the given MoveButtons input to zero.
+    /// </summary>
+    private MoveButtons StripWalk(MoveButtons input)
+    {
+        return input & ~MoveButtons.Walk;
+    }
+
+    /// <summary>
+    /// Returns the given local coordinates snapped to the center of the tile it is currently on.
+    /// </summary>
+    /// <param name="input">Given coordinates to snap.</param>
+    /// <returns>The closest tile center to the input.</returns>
+    public static Vector2 SnapCoordinatesToTile(Vector2 input)
+    {
+        return new Vector2((int) Math.Floor(input.X) + 0.5f, (int) Math.Floor(input.Y) + 0.5f);
     }
 }

--- a/Content.Shared/_CMU14/TileMovement/CMUTileMovementComponent.cs
+++ b/Content.Shared/_CMU14/TileMovement/CMUTileMovementComponent.cs
@@ -1,0 +1,66 @@
+using System.Numerics;
+using Content.Shared.Movement.Systems;
+using Robust.Shared.GameStates;
+using Robust.Shared.Map;
+
+namespace Content.Shared._CMU14.TileMovement;
+
+/// <summary>
+/// When attached to an entity with an <see cref="InputMoverComponent"/>, all mob movement on that entity will
+/// be tile-based instead of the usual free/analog movement: WASD slides the entity one tile at a time.
+/// Contains the state used by <see cref="SharedMoverController"/> to drive that sliding motion.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class CMUTileMovementComponent : Component
+{
+    /// <summary>
+    /// Whether a tile movement slide is currently in progress.
+    /// </summary>
+    [AutoNetworkedField]
+    public bool SlideActive;
+
+    /// <summary>
+    /// Local coordinates from which the current slide first began.
+    /// </summary>
+    [AutoNetworkedField]
+    public EntityCoordinates Origin;
+
+    /// <summary>
+    /// Local coordinates of the target of the current slide.
+    /// </summary>
+    [AutoNetworkedField]
+    public Vector2 Destination;
+
+    /// <summary>
+    /// This helps determine how long a slide should last. A slide will continue so long
+    /// as a movement key (WASD) is being held down, but if it was held down for less than
+    /// a certain time period then it will continue for a minimum period.
+    /// </summary>
+    [AutoNetworkedField]
+    public TimeSpan? MovementKeyInitialDownTime;
+
+    /// <summary>
+    /// Move buttons used to initiate the current slide.
+    /// </summary>
+    [AutoNetworkedField]
+    public MoveButtons CurrentSlideMoveButtons;
+
+    /// <summary>
+    /// Whether this entity was weightless last physics tick.
+    /// </summary>
+    [AutoNetworkedField]
+    public bool WasWeightlessLastTick;
+
+    /// <summary>
+    /// Whether the current ongoing slide was initiated due to a failed slide.
+    /// </summary>
+    [AutoNetworkedField]
+    public bool FailureSlideActive;
+
+    /// <summary>
+    /// Coordinates of the moving entity on the last physics tick. Null if the entity was not
+    /// parented to the same entity last tick.
+    /// </summary>
+    [AutoNetworkedField]
+    public Vector2? LastTickLocalCoordinates;
+}

--- a/Resources/Locale/en-US/_CMU14/tile-movement.ftl
+++ b/Resources/Locale/en-US/_CMU14/tile-movement.ftl
@@ -1,0 +1,4 @@
+cmd-cmuforcetilemovement-desc = Toggles tile-based movement for every player, regardless of whether they have the trait.
+cmd-cmuforcetilemovement-help = Usage: cmuforcetilemovement [true/false]
+cmuforcetilemovement-command-enabled = Tile movement has been forced on for everyone.
+cmuforcetilemovement-command-disabled = Tile movement is no longer forced on for everyone.

--- a/Resources/Locale/en-US/_CMU14/traits/traits.ftl
+++ b/Resources/Locale/en-US/_CMU14/traits/traits.ftl
@@ -9,3 +9,6 @@ trait-cmu-prosthetic-left-leg-desc = Your left leg has been replaced with a robo
 
 trait-cmu-prosthetic-right-leg-name = Right leg prosthesis
 trait-cmu-prosthetic-right-leg-desc = Your right leg has been replaced with a robotic prosthesis.
+
+trait-cmu-tile-movement-name = Tile Movement
+trait-cmu-tile-movement-desc = You move from tile to tile instead of walking freely, just like the forebears who came before you.

--- a/Resources/Locale/en-US/administration/smites.ftl
+++ b/Resources/Locale/en-US/administration/smites.ftl
@@ -12,6 +12,7 @@ admin-smite-turned-ash-other = {CAPITALIZE($name)} turns into a pile of ash!
 admin-smite-stomach-removal-self = Your stomach feels hollow...
 admin-smite-run-walk-swap-prompt = You have to press shift to run!
 admin-smite-super-speed-prompt = You move at mach 0.8!
+admin-smite-tile-movement-prompt = Your feet lock to the tiles beneath you!
 admin-smite-lung-removal-self = You can't breathe!
 
 ## Smite names
@@ -42,6 +43,7 @@ admin-smite-maid-name = Cat Maid
 admin-smite-zoom-in-name = Zoom In
 admin-smite-flip-eye-name = Flip Eye
 admin-smite-run-walk-swap-name = Run Walk Swap
+admin-smite-tile-movement-name = Tile Movement
 admin-smite-super-speed-name = Run Up
 admin-smite-stomach-removal-name = Stomach Removal
 admin-smite-speak-backwards-name = Speak Backwards
@@ -90,6 +92,7 @@ admin-smite-maid-description = Forcibly converts them into a janitorial cat maid
 admin-smite-zoom-in-description = Zooms in their view so that they can no longer see their surroundings.
 admin-smite-flip-eye-description = Flips their view, effectively reversing their controls and making the game annoying to play.
 admin-smite-run-walk-swap-description = Swaps running and walking, forcing them to hold shift to move fast.
+admin-smite-tile-movement-description = Forces them to move tile by tile, just like in SS13!
 admin-smite-super-speed-description = Makes them really fast, causing them to turn into gibs when hitting a wall.
 admin-smite-stomach-removal-description = Removes their stomach, rendering them unable to eat.
 admin-smite-speak-backwards-description = Forces them to speak backwards, so they can't call for help.

--- a/Resources/Prototypes/Entities/Mobs/Player/clone.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/clone.yml
@@ -27,6 +27,7 @@
   - Snoring
   - Unrevivable
   - SlowRunner
+  - CMUTileMovement
   - RespiratoryStrain
   - Anemic
   - DrugAllergy

--- a/Resources/Prototypes/Traits/disabilities.yml
+++ b/Resources/Prototypes/Traits/disabilities.yml
@@ -1,85 +1,85 @@
 # If you add a new trait, make sure to add the corresponding component to the whitelist in \Resources\Prototypes\Entities\Mobs\Player\clone.yml so it gets copied to clones correctly!
 
-- type: trait
-  id: Blindness
-  name: trait-blindness-name
-  description: trait-blindness-desc
-  traitGear: WhiteCane
-  category: Disabilities
-  whitelist:
-    components:
-      - Blindable
-  components:
-    - type: PermanentBlindness
-
-- type: trait
-  id: PoorVision
-  name: trait-poor-vision-name
-  description: trait-poor-vision-desc
-  traitGear: ClothingEyesGlasses
-  category: Disabilities
-  whitelist:
-    components:
-      - Blindable
-  components:
-    - type: PermanentBlindness
-      blindness: 4
-
-- type: trait
-  id: Narcolepsy
-  name: trait-narcolepsy-name
-  description: trait-narcolepsy-desc
-  category: Disabilities
-  components:
-    - type: Narcolepsy
-      timeBetweenIncidents: 300, 600
-      durationOfIncident: 10, 30
-
-- type: trait
-  id: Unrevivable
-  name: trait-unrevivable-name
-  description: trait-unrevivable-desc
-  category: Disabilities
-  components:
-    - type: Unrevivable
-      cloneable: true
-
-- type: trait
-  id: Monochromacy
-  name: trait-monochromacy-name
-  description: trait-monochromacy-desc
-  category: Disabilities
-  components:
-  - type: BlackAndWhiteOverlay
-
-- type: trait
-  id: Muted
-  name: trait-muted-name
-  description: trait-muted-desc
-  category: Disabilities
-  blacklist:
-    components:
-      - BorgChassis
-  components:
-    - type: Muted
-
-- type: trait
-  id: Paracusia
-  name: trait-paracusia-name
-  description: trait-paracusia-desc
-  category: Disabilities
-  components:
-    - type: Paracusia
-      minTimeBetweenIncidents: 0.1
-      maxTimeBetweenIncidents: 300
-      maxSoundDistance: 7
-      sounds:
-        collection: Paracusia
-
-- type: trait
-  id: PainNumbness
-  name: trait-painnumbness-name
-  description: trait-painnumbness-desc
-  category: Disabilities
-  components:
-  - type: PainNumbness
+#- type: trait
+#  id: Blindness
+#  name: trait-blindness-name
+#  description: trait-blindness-desc
+#  traitGear: WhiteCane
+#  category: Disabilities
+#  whitelist:
+#    components:
+#      - Blindable
+#  components:
+#    - type: PermanentBlindness
+#
+#- type: trait
+#  id: PoorVision
+#  name: trait-poor-vision-name
+#  description: trait-poor-vision-desc
+#  traitGear: ClothingEyesGlasses
+#  category: Disabilities
+#  whitelist:
+#    components:
+#      - Blindable
+#  components:
+#    - type: PermanentBlindness
+#      blindness: 4
+#
+#- type: trait
+#  id: Narcolepsy
+#  name: trait-narcolepsy-name
+#  description: trait-narcolepsy-desc
+#  category: Disabilities
+#  components:
+#    - type: Narcolepsy
+#      timeBetweenIncidents: 300, 600
+#      durationOfIncident: 10, 30
+#
+#- type: trait
+#  id: Unrevivable
+#  name: trait-unrevivable-name
+#  description: trait-unrevivable-desc
+#  category: Disabilities
+#  components:
+#    - type: Unrevivable
+#      cloneable: true
+#
+#- type: trait
+#  id: Monochromacy
+#  name: trait-monochromacy-name
+#  description: trait-monochromacy-desc
+#  category: Disabilities
+#  components:
+#  - type: BlackAndWhiteOverlay
+#
+#- type: trait
+#  id: Muted
+#  name: trait-muted-name
+#  description: trait-muted-desc
+#  category: Disabilities
+#  blacklist:
+#    components:
+#      - BorgChassis
+#  components:
+#    - type: Muted
+#
+#- type: trait
+#  id: Paracusia
+#  name: trait-paracusia-name
+#  description: trait-paracusia-desc
+#  category: Disabilities
+#  components:
+#    - type: Paracusia
+#      minTimeBetweenIncidents: 0.1
+#      maxTimeBetweenIncidents: 300
+#      maxSoundDistance: 7
+#      sounds:
+#        collection: Paracusia
+#
+#- type: trait
+#  id: PainNumbness
+#  name: trait-painnumbness-name
+#  description: trait-painnumbness-desc
+#  category: Disabilities
+#  components:
+#  - type: PainNumbness

--- a/Resources/Prototypes/_CMU14/Traits/quirks.yml
+++ b/Resources/Prototypes/_CMU14/Traits/quirks.yml
@@ -1,0 +1,7 @@
+- type: trait
+  id: CMUTileMovement
+  name: trait-cmu-tile-movement-name
+  description: trait-cmu-tile-movement-desc
+  category: Quirks
+  components:
+  - type: CMUTileMovement


### PR DESCRIPTION
Adds tile movement as an optional server toggle, smite and trait.
Mentors no longer can spawn themselves here as job.
General fixes, reference changelog.

**Changelog**
:cl:
- add: Added tile movement. Tile movement can be taken as a trait in character customization, toggled on by admins via a server command and used as a smite by admins.
- fix: Mentors can no longer spawn themselves as roles.
- fix: Old upstream traits no longer improperly show up as selectable.
