### PR TITLE
WYGuard Backpack update (Food for the hungry!!)

### DIFF
--- a/Resources/Prototypes/_CMU14/Roles/WeYu/WYGuard.yml
+++ b/Resources/Prototypes/_CMU14/Roles/WeYu/WYGuard.yml
@@ -89,6 +89,12 @@
     ears: AU14ColonyWeylandHeadset
     ears2: RMCM5CameraGear
     suitstorage: RMCM77BeltPMCFilled
+  storage:
+    back:
+    - RMCMREWeYa
+    - CMCanteen
+    - CMU14TearGasGrenade
+    - RMCGrenadeFlashBang
 
 - type: entity
   parent: CMSpawnPointJobBase


### PR DESCRIPTION
## Description:
Added MRE and Canteen to the backpack to prevent guards dying on the job! Also added a tear gas grenade and flashbang to make them more capable of dealing with prisoners (1 each since I know you don't always get mapped vendors)
 
🆑 
- add: 1 WY MRE, 1 Canteen, 1 Tear Gas, 1 Flash Bang



