### PR TITLE
Role leadership component fix

### DIFF
--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFCellLeader.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFCellLeader.yml
@@ -47,6 +47,19 @@
     - CLF
   - type: FactionLanguageLeader
     factionTag: CLF
+  - type: MarineOrders
+    moveOrderSoundMale:
+      collection: AU14MaleMoveOrder
+    moveOrderSoundFemale:
+      collection: AU14FemaleMoveOrder
+    focusOrderSoundMale:
+      collection: AU14MaleFocusOrder
+    focusOrderSoundFemale:
+      collection: AU14FemaleFocusOrder
+    holdOrderSoundMale:
+      collection: AU14MaleHoldOrder
+    holdOrderSoundFemale:
+      collection: AU14FemaleHoldOrder
 
   name: au14-job-name-clfcellleader
   description: au14-job-description-clfcellleader

--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFRadioOperator.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFRadioOperator.yml
@@ -37,6 +37,19 @@
     - CLF
   - type: FactionLanguageMember
     factionTag: CLF
+  - type: MarineOrders
+    moveOrderSoundMale:
+      collection: AU14MaleMoveOrder
+    moveOrderSoundFemale:
+      collection: AU14FemaleMoveOrder
+    focusOrderSoundMale:
+      collection: AU14MaleFocusOrder
+    focusOrderSoundFemale:
+      collection: AU14FemaleFocusOrder
+    holdOrderSoundMale:
+      collection: AU14MaleHoldOrder
+    holdOrderSoundFemale:
+      collection: AU14FemaleHoldOrder
 
   name: au14-job-name-clfradiooperator
   description: au14-job-description-clfradiooperator

--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFSurgeon.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFSurgeon.yml
@@ -35,6 +35,19 @@
     - CLF
   - type: FactionLanguageMember
     factionTag: CLF
+  - type: MarineOrders
+    moveOrderSoundMale:
+      collection: AU14MaleMoveOrder
+    moveOrderSoundFemale:
+      collection: AU14FemaleMoveOrder
+    focusOrderSoundMale:
+      collection: AU14MaleFocusOrder
+    focusOrderSoundFemale:
+      collection: AU14FemaleFocusOrder
+    holdOrderSoundMale:
+      collection: AU14MaleHoldOrder
+    holdOrderSoundFemale:
+      collection: AU14FemaleHoldOrder
 
   name: au14-job-name-clfsurgeon
   description: au14-job-description-clfsurgeon

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/Base/AU14JobLEOLeaderBase.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/Base/AU14JobLEOLeaderBase.yml
@@ -22,6 +22,20 @@
     traits:
     - Epilepsy
     - NoEnglish
+  roundComponents:
+  - type: MarineOrders
+    moveOrderSoundMale:
+      collection: AU14MaleMoveOrder
+    moveOrderSoundFemale:
+      collection: AU14FemaleMoveOrder
+    focusOrderSoundMale:
+      collection: AU14MaleFocusOrder
+    focusOrderSoundFemale:
+      collection: AU14FemaleFocusOrder
+    holdOrderSoundMale:
+      collection: AU14MaleHoldOrder
+    holdOrderSoundFemale:
+      collection: AU14FemaleHoldOrder
 
 - type: playTimeTracker
   id: AU14JobCivilianCMBMarshal


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
A large amount of leading roles, that HAD high leadership skill, lacked the actual component that let them use it. This lets them.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I'm pretty sure these roles were always intended to be able to give orders, the component was just never actually given to them.
## Technical details
<!-- Summary of code changes for easier review. -->
Adds the proper component to a few roles:
  - type: MarineOrders
      moveOrderSoundMale:
        collection: AU14MaleMoveOrder
      moveOrderSoundFemale:
        collection: AU14FemaleMoveOrder
      focusOrderSoundMale:
        collection: AU14MaleFocusOrder
      focusOrderSoundFemale:
        collection: AU14FemaleFocusOrder
      holdOrderSoundMale:
        collection: AU14MaleHoldOrder
      holdOrderSoundFemale:
        collection: AU14FemaleHoldOrder

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
- [x ] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x ] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed multiple roles lacking proper leadership component