### PR TITLE
🩹 revert #1654 Cassette audio is owned by and follows the cassette player instead of playing globally

### DIFF
--- a/Content.Client/_RMC14/Cassette/CassetteSystem.cs
+++ b/Content.Client/_RMC14/Cassette/CassetteSystem.cs
@@ -98,7 +98,7 @@ public sealed partial class CassetteSystem : SharedCassetteSystem
             return null;
 
         var audioParams = player.Comp.AudioParams.WithVolume(SharedAudioSystem.GainToVolume(_gain));
-        return _audio.PlayEntity(stream, player, new ResolvedPathSpecifier(name), audioParams)?.Entity;
+        return _audio.PlayGlobal(stream, player, new ResolvedPathSpecifier(name), audioParams)?.Entity;
     }
 
     protected override async void ChooseCustomTrack(Entity<CassetteTapeComponent> tape)

--- a/Content.Shared/_RMC14/Cassette/SharedCassetteSystem.cs
+++ b/Content.Shared/_RMC14/Cassette/SharedCassetteSystem.cs
@@ -184,7 +184,7 @@ public abstract partial class SharedCassetteSystem : EntitySystem
                 audioParams = audioParams.WithVolume(SharedAudioSystem.GainToVolume(gain));
             }
 
-            player.Comp.AudioStream = _audio.PlayEntity(song, actor, player, audioParams)?.Entity;
+            player.Comp.AudioStream = _audio.PlayGlobal(song, actor, audioParams)?.Entity;
         }
 
         player.Comp.Tape = tape.Value;


### PR DESCRIPTION
## About the PR
- Blackfoot integrated cassette player may need some love
- The PlayGlobal -> PlayEntity introduced in this PR does not work

## Technical details
- PlayPvs would be better, but PlayEntity breaks Mono channel audio (which is required for local audio)
- Stereo channels don't have this issue as they are bypassing local audio anyways

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- fix: Fixed Cassettes not working for Mono channel audio files
