### PR TITLE
Remove Marine Orders yaml noise (collection specifiers)

### DIFF
--- a/Content.Shared/_RMC14/Marines/Orders/MarineOrdersComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/MarineOrdersComponent.cs
@@ -67,35 +67,22 @@ public sealed partial class MarineOrdersComponent : Component
 
     // Gender-based "Move!" Voicelines.
     [DataField, AutoNetworkedField]
-    public SoundSpecifier? MoveOrderSoundMale;
+    public SoundSpecifier? MoveOrderSoundMale = new SoundCollectionSpecifier("AU14MaleMoveOrder");
 
     [DataField, AutoNetworkedField]
-    public SoundSpecifier? MoveOrderSoundFemale;
-
-    // Fallback for backwards compatibility
-    [DataField, AutoNetworkedField]
-    public SoundSpecifier? MoveOrderSound;
+    public SoundSpecifier? MoveOrderSoundFemale = new SoundCollectionSpecifier("AU14FemaleMoveOrder");
 
     // Gender-based "Focus!" Voicelines.
     [DataField, AutoNetworkedField]
-    public SoundSpecifier? FocusOrderSoundMale;
+    public SoundSpecifier? FocusOrderSoundMale = new SoundCollectionSpecifier("AU14MaleFocusOrder");
 
     [DataField, AutoNetworkedField]
-    public SoundSpecifier? FocusOrderSoundFemale;
-
-    // Fallback for backwards compatibility
-    [DataField, AutoNetworkedField]
-    public SoundSpecifier? FocusOrderSound;
+    public SoundSpecifier? FocusOrderSoundFemale = new SoundCollectionSpecifier("AU14FemaleFocusOrder");
 
     // Gender-based "Hold!" Voicelines.
     [DataField, AutoNetworkedField]
-    public SoundSpecifier? HoldOrderSoundMale;
+    public SoundSpecifier? HoldOrderSoundMale = new SoundCollectionSpecifier("AU14MaleHoldOrder");
 
     [DataField, AutoNetworkedField]
-    public SoundSpecifier? HoldOrderSoundFemale;
-
-    // Fallback for backwards compatibility
-    [DataField, AutoNetworkedField]
-    public SoundSpecifier? HoldOrderSound;
-
+    public SoundSpecifier? HoldOrderSoundFemale = new SoundCollectionSpecifier("AU14FemaleHoldOrder");
 }

--- a/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Orders/SharedMarineOrdersSystem.cs
@@ -270,50 +270,35 @@ public abstract partial class SharedMarineOrdersSystem : EntitySystem
 
     private SoundSpecifier? GetMoveSound(Entity<MarineOrdersComponent> orders)
     {
-        // Check entity's gender from HumanoidAppearanceComponent
         if (TryComp<HumanoidAppearanceComponent>(orders.Owner, out var appearance))
         {
-            if (appearance.Sex == Sex.Male && orders.Comp.MoveOrderSoundMale != null)
-                return orders.Comp.MoveOrderSoundMale;
-
             if (appearance.Sex == Sex.Female && orders.Comp.MoveOrderSoundFemale != null)
                 return orders.Comp.MoveOrderSoundFemale;
         }
 
-        // Fallback to male sound
-        return orders.Comp.MoveOrderSound ?? orders.Comp.MoveOrderSoundMale;
+        return orders.Comp.MoveOrderSoundMale;
     }
 
     private SoundSpecifier? GetFocusSound(Entity<MarineOrdersComponent> orders)
     {
-        // Check entity's gender from HumanoidAppearanceComponent
         if (TryComp<HumanoidAppearanceComponent>(orders.Owner, out var appearance))
         {
-            if (appearance.Sex == Sex.Male && orders.Comp.FocusOrderSoundMale != null)
-                return orders.Comp.FocusOrderSoundMale;
-
             if (appearance.Sex == Sex.Female && orders.Comp.FocusOrderSoundFemale != null)
                 return orders.Comp.FocusOrderSoundFemale;
         }
 
-        // Fallback to male sound
-        return orders.Comp.FocusOrderSound ?? orders.Comp.FocusOrderSoundMale;
+        return orders.Comp.FocusOrderSoundMale;
     }
 
     private SoundSpecifier? GetHoldSound(Entity<MarineOrdersComponent> orders)
     {
-        // Check entity's gender from HumanoidAppearanceComponent
         if (TryComp<HumanoidAppearanceComponent>(orders.Owner, out var appearance))
         {
-            if (appearance.Sex == Sex.Male && orders.Comp.HoldOrderSoundMale != null)
-                return orders.Comp.HoldOrderSoundMale;
-
             if (appearance.Sex == Sex.Female && orders.Comp.HoldOrderSoundFemale != null)
                 return orders.Comp.HoldOrderSoundFemale;
         }
 
-        // Fallback to male sound
-        return orders.Comp.HoldOrderSound ?? orders.Comp.HoldOrderSoundMale;
+        return orders.Comp.HoldOrderSoundMale;
     }
 
     /// <summary>

--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFCellLeader.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFCellLeader.yml
@@ -48,18 +48,6 @@
   - type: FactionLanguageLeader
     factionTag: CLF
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
 
   name: au14-job-name-clfcellleader
   description: au14-job-description-clfcellleader

--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFRadioOperator.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFRadioOperator.yml
@@ -38,18 +38,6 @@
   - type: FactionLanguageMember
     factionTag: CLF
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
 
   name: au14-job-name-clfradiooperator
   description: au14-job-description-clfradiooperator

--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFSurgeon.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFSurgeon.yml
@@ -36,18 +36,6 @@
   - type: FactionLanguageMember
     factionTag: CLF
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
 
   name: au14-job-name-clfsurgeon
   description: au14-job-description-clfsurgeon

--- a/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/Base/AU14JobLEOLeaderBase.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/LawEnforcement/Base/AU14JobLEOLeaderBase.yml
@@ -24,18 +24,6 @@
     - NoEnglish
   roundComponents:
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
 
 - type: playTimeTracker
   id: AU14JobCivilianCMBMarshal

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Base/round_job_profiles.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Base/round_job_profiles.yml
@@ -4,18 +4,6 @@
   id: AU14RoundJobProfileMilitaryBase
   components:
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   sideComponents:
     Govfor:
     - type: Marine

--- a/Resources/Prototypes/_CMU14/Roles/Military/IndFor/Provost/base_provost.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/IndFor/Provost/base_provost.yml
@@ -24,18 +24,6 @@
   - type: SniperWhitelist
   - type: PyroWhitelist
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: TacticalMapIcon
     icon:
       sprite: /Textures/_RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/Base/Roles/BaseTeamLeader.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/Base/Roles/BaseTeamLeader.yml
@@ -31,18 +31,6 @@
   - type: JobPrefix
     prefix: au14-job-prefix-vai-teamleader
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: SquadLeader
   - type: RMCTrackable
   - type: RMCPointing

--- a/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/VAISO/Roles/VAISOTeamLeader.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Corporate/VAI/VAISO/Roles/VAISOTeamLeader.yml
@@ -31,18 +31,6 @@
   - type: JobPrefix
     prefix: au14-job-prefix-vai-teamleader
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: SquadLeader
   - type: RMCTrackable
   - type: RMCPointing

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Survivors/Roles/FORECONCommander.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Survivors/Roles/FORECONCommander.yml
@@ -25,18 +25,6 @@
   - type: JobPrefix
     prefix: rmc-job-prefix-forecon-co
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: RMCTrackable
   - type: RMCPointing
   - type: LanguagePreset

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Survivors/Roles/FORECONSquadLeader.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Survivors/Roles/FORECONSquadLeader.yml
@@ -6,18 +6,6 @@
   roundRole: AU14FORECONSquadleaderBase
   roundComponents:
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   name: cm-job-name-squad-leader
   description: au14-job-description-govforadvisor
   playTimeTracker: AU14JobFORECONSquadLeader

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/RMC/RapidResponseTeam/Roles/RRTCommander.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/RMC/RapidResponseTeam/Roles/RRTCommander.yml
@@ -24,18 +24,6 @@
         RMCSkillSurgery: 1
         RMCSkillVehicles: 1
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: SquadLeader
   - type: RMCTrackable
   - type: RMCPointing

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/UACG/LostTeam/Roles/UACGSquadLeader.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/UACG/LostTeam/Roles/UACGSquadLeader.yml
@@ -24,18 +24,6 @@
   - type: JobPrefix
     prefix: au-14-job-prefix-uacg-squadleader
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder # No Russian/UPP voicelines yet, its gonna have to use normal english accent (Not sure if this is UPP, but just in case)
   - type: RMCPointing
 
   name: au-14-job-name-uacg-squadleader

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/GROM/Team/Roles/GromCommander.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/GROM/Team/Roles/GromCommander.yml
@@ -18,18 +18,6 @@
   - type: JobPrefix
     prefix: au-14-job-prefix-rmcrrt-commander
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: RMCTrackable
   - type: RMCPointing
   - type: Language

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/GROM/Team/Roles/GromSquadLeader.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/GROM/Team/Roles/GromSquadLeader.yml
@@ -18,18 +18,6 @@
   - type: JobPrefix
     prefix: au-14-job-prefix-uppgrom-squadleader
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder # No Russian/UPP voicelines yet, its gonna have to use normal english accent
   - type: RMCTrackable
   - type: SquadLeader
   - type: RMCPointing

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/TerritorialDefense/LostTeam/Roles/TDSquadLeader.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/UPP/TerritorialDefense/LostTeam/Roles/TDSquadLeader.yml
@@ -7,18 +7,6 @@
   roundComponents:
   - type: SquadLeader
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder # No Russian/UPP voicelines yet, its gonna have to use normal english accent
   - type: RMCTrackable
   - type: TacticalMapIcon
     icon:
@@ -61,7 +49,7 @@
     RMCRankCivilian: []
   chevrons:
     UPP_Plutonowy:
-      entity: AU14ChevronUPPNIPlutonowy 
+      entity: AU14ChevronUPPNIPlutonowy
       requirements: []
   spawnMenuRoleName: UPP TD Squad Leader (3rd party)
   startingGear: AU14GearUPPTerritorialDefenseSquadLeader

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/ArmoredResponse/Roles/USArmyArmoredSquadLeader.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/ArmoredResponse/Roles/USArmyArmoredSquadLeader.yml
@@ -31,18 +31,6 @@
   - type: JobPrefix
     prefix: cm-job-prefix-squad-leader
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: SquadLeader
   - type: RMCTrackable
   - type: RMCPointing

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/LostTankers/Roles/USArmyTankCommander.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/LostTankers/Roles/USArmyTankCommander.yml
@@ -22,18 +22,6 @@
   - type: JobPrefix
     prefix: au14-job-prefix-usarmy-tankcommander
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: RMCTrackable
   - type: RMCPointing
 

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/Survivors/Roles/USArmyCommander.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/Survivors/Roles/USArmyCommander.yml
@@ -22,18 +22,6 @@
   - type: JobPrefix
     prefix: rmc-job-prefix-forecon-co
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: RMCTrackable
   - type: RMCPointing
 

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/Survivors/Roles/USArmySquadLeader.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/USArmy/Survivors/Roles/USArmySquadLeader.yml
@@ -22,18 +22,6 @@
   - type: JobPrefix
     prefix: cm-job-prefix-squad-leader
   - type: MarineOrders
-    moveOrderSoundMale:
-      collection: AU14MaleMoveOrder
-    moveOrderSoundFemale:
-      collection: AU14FemaleMoveOrder
-    focusOrderSoundMale:
-      collection: AU14MaleFocusOrder
-    focusOrderSoundFemale:
-      collection: AU14FemaleFocusOrder
-    holdOrderSoundMale:
-      collection: AU14MaleHoldOrder
-    holdOrderSoundFemale:
-      collection: AU14FemaleHoldOrder
   - type: RMCTrackable
   - type: SquadLeader
   - type: RMCPointing

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/AuxiliarySupport/auxiliary_support_officer.yml
@@ -63,18 +63,6 @@
         RMCSkillSurgery: 1
         RMCSkillVehicles: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: JobPrefix
       prefix: cm-job-prefix-aso

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/commanding_officer.yml
@@ -34,18 +34,6 @@
     - type: Skills
       preset: RMCSkillPresetCommander
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: CMVendorUser
       id: CMCommandingOfficer
       points: 120

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/executive_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/executive_officer.yml
@@ -1,4 +1,4 @@
-﻿- type: job
+- type: job
   parent: CMJobBase
   id: CMExecutiveOfficer
   name: cm-job-name-executive-officer
@@ -40,18 +40,6 @@
         RMCSkillSurgery: 1
         RMCSkillVehicles: 2
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: CMVendorUser
       points: 120
     - type: RMCPointing

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Command/staff_officer.yml
@@ -43,18 +43,6 @@
         RMCSkillSurgery: 1
         RMCSkillVehicles: 2
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: CMVendorUser
       id: CMStaffOfficer
       points: 45

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Marines/squad_leader.yml
@@ -42,18 +42,6 @@
       id: CMSquadLeader
       points: 45
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: SquadArmorWearer
       leader: true
     - type: SquadLeader

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -47,18 +47,6 @@
     - type: CMVendorUser
       points: 45
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: JobPrefix
       prefix: rmc-job-prefix-cmo

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CMB/bureau_marshal.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/CMB/bureau_marshal.yml
@@ -46,18 +46,6 @@
       prefix: rmc-job-prefix-bureau-marshal
     - type: RMCPointing
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCAllowSuitStorage
     - type: TacticalMapIcon
       icon:

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/Freelancers/leader.yml
@@ -48,18 +48,6 @@
         RMCSkillPolice: 1 # RMC14 disallow use of flashbangs
       # TODO RMC14 add English, russian, Chinese and Japanese languages
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: SquadArmorWearer
       leader: true
     - type: JobPrefix

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/High_Command/high_command_brigadier_general.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/High_Command/high_command_brigadier_general.yml
@@ -35,18 +35,6 @@
         RMCSkillSurgery: 1
         RMCSkillVehicles: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
   hidden: true
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/CLF/commander.yml
@@ -26,18 +26,6 @@
     - type: JobPrefix
       prefix: rmc-job-prefix-clf-pve-commander
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/assisstantsquadlead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/assisstantsquadlead.yml
@@ -44,18 +44,6 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: tl
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/squadlead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/FORECON/squadlead.yml
@@ -47,18 +47,6 @@
         sprite: /Textures/_RMC14/Interface/map_blips.rsi
         state: leader
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/force_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/force_lead.yml
@@ -30,18 +30,6 @@
         sprite: _RMC14/Interface/cm_job_icons.rsi
         state: pmc_ld
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/overwatch.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/overwatch.yml
@@ -28,18 +28,6 @@
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-pve-force-command
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/team_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/PMC/team_lead.yml
@@ -24,18 +24,6 @@
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-pve-team-leader
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/section_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/section_leader.yml
@@ -44,18 +44,6 @@
         RMCSkillPilot: 1
         RMCSkillLeadership: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/team_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/team_leader.yml
@@ -44,18 +44,6 @@
         RMCSkillPilot: 1
         RMCSkillLeadership: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/troop_commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/troop_commander.yml
@@ -45,18 +45,6 @@
         RMCSkillOverwatch: 1
         RMCSkillLeadership: 2
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/troop_sergeant.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/RCM/troop_sergeant.yml
@@ -45,18 +45,6 @@
         RMCSkillOverwatch: 1
         RMCSkillLeadership: 2
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: SquadLeader

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/SPPoverwatch.yml
@@ -44,18 +44,6 @@
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-overwatch
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/section_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/section_lead.yml
@@ -39,18 +39,6 @@
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-sectionsergeant
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/squad_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/SPP/squad_lead.yml
@@ -38,18 +38,6 @@
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-squadlead
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: DemoSpecWhitelist

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/platoon_commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/platoon_commander.yml
@@ -46,18 +46,6 @@
     - type: SniperWhitelist
     - type: PyroWhitelist
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: JobPrefix
       prefix: cm-job-prefix-platoon-commander

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/section_sergeant.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/section_sergeant.yml
@@ -42,18 +42,6 @@
     - type: SniperWhitelist
     - type: PyroWhitelist
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: JobPrefix
       prefix: cm-job-prefix-section-sergeant

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/PVE/UNMC/squad_leader.yml
@@ -37,18 +37,6 @@
     - type: SniperWhitelist
     - type: PyroWhitelist
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: SquadArmorWearer
     - type: JobPrefix
       prefix: cm-job-prefix-squad-leader

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SOF/sof_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SOF/sof_leader.yml
@@ -44,18 +44,6 @@
     - type: SniperWhitelist
     - type: PyroWhitelist
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: SquadLeader
       icon:
         sprite: _RMC14/Interface/cm_job_icons.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/commando_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/commando_leader.yml
@@ -53,18 +53,6 @@
     - type: SniperWhitelist
     - type: PyroWhitelist
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-commando-leader

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/SPP/leader.yml
@@ -46,18 +46,6 @@
         RMCSkillVehicles: 1
         RMCSkillPolice: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: SquadArmorWearer
       leader: true
     - type: SquadLeader

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/Royal/royal_captain.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/Royal/royal_captain.yml
@@ -37,18 +37,6 @@
         RMCSkillPowerLoader: 1
         RMCSkillOverwatch: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: ViewIntelObjectives

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/Royal/royal_lieutenant.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/Royal/royal_lieutenant.yml
@@ -37,18 +37,6 @@
         RMCSkillIntel: 1
         RMCSkillPowerLoader: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: ViewIntelObjectives

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/Royal/royal_major.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/Royal/royal_major.yml
@@ -39,18 +39,6 @@
         RMCSkillSmartGun: 1
         RMCSkillExecution: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/Royal/royal_teamlead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/Royal/royal_teamlead.yml
@@ -35,18 +35,6 @@
         RMCSkillPilot: 1
         RMCSkillIntel: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: ViewIntelObjectives

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/TSEPA/tsepa_inspector.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/TSE/TSEPA/tsepa_inspector.yml
@@ -28,18 +28,6 @@
         RMCSkillFireman: 2
         RMCSkillLeadership: 2
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: NpcFactionMember
       factions:
       - TSE

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/goon_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/goon_leader.yml
@@ -30,18 +30,6 @@
       currentLanguage: English
       defaultLanguage: English
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: Skills
       skills:
         RMCSkillCqc: 2

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/leader.yml
@@ -44,18 +44,6 @@
         RMCSkillJtac: 2
         RMCSkillVehicles: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: SquadLeader
       icon:
         sprite: _RMC14/Interface/cm_job_icons.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/site_director.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/WeYa/site_director.yml
@@ -45,18 +45,6 @@
         RMCSkillJtac: 4
         RMCSkillExecution: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: JobPrefix
       prefix: rmc-job-prefix-pmc-director
     - type: TacticalMapIcon

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/Kommissar.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/Kommissar.yml
@@ -28,18 +28,6 @@
         RMCSkillVehicles: 1
         RMCSkillPolice: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-kommissar
   hidden: true
@@ -128,18 +116,6 @@
         RMCSkillVehicles: 1
         RMCSkillPolice: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-battalion-kommissar
   hidden: true
@@ -211,18 +187,6 @@
         RMCSkillVehicles: 1
         RMCSkillPolice: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-sr-battalion-kommissar
   hidden: true
@@ -294,18 +258,6 @@
         RMCSkillVehicles: 1
         RMCSkillPolice: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-regimental-kommissar
   hidden: true
@@ -377,18 +329,6 @@
         RMCSkillVehicles: 1
         RMCSkillPolice: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-brigade-kommissar
   hidden: true
@@ -463,18 +403,6 @@
         RMCSkillOverwatch: 1
         RMCSkillEndurance: 2
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: JobPrefix
       prefix: rmc-job-prefix-spp-division-kommissar
   hidden: true

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/sppco.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/sppco.yml
@@ -55,18 +55,6 @@
         RMCSkillSurgery: 1
         RMCSkillVehicles: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/sppso.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/sppso.yml
@@ -53,18 +53,6 @@
         RMCSkillSurgery: 1
         RMCSkillVehicles: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/sppxo.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Other/spp_command/sppxo.yml
@@ -53,18 +53,6 @@
         RMCSkillSurgery: 1
         RMCSkillVehicles: 1
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/commander.yml
@@ -19,18 +19,6 @@
     - type: Skills
       preset: RMCSkillPresetCommander
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: RMCTrackable
     - type: JobPrefix

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/ForceRecon/squad_leader.yml
@@ -32,18 +32,6 @@
         RMCSkillLeadership: 1
         RMCSkillVehicles: 0
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: SquadLeader
     - type: RMCPointing
     - type: TacticalMapIcon

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/pilot.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Hybrisa_Prospera/pilot.yml
@@ -35,18 +35,6 @@
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
   useLoadoutOfJob: CMSurvivorCorporate # for inheritance
 
 - type: startingGear

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Kutjevo/kutjevo_chaplain.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Kutjevo/kutjevo_chaplain.yml
@@ -18,18 +18,6 @@
     - type: EquipEntityPreset
       preset: RMCGearSurvivorPresetKutjevoChaplain
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_cl.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_cl.yml
@@ -24,18 +24,6 @@
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: TacticalMapIcon
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_lead.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/LV624/corporate_dome_goon_lead.yml
@@ -23,18 +23,6 @@
     - type: IntelRescueSurvivorObjective
     - type: RMCAllowSuitStorage
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: TacticalMapIcon
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Misc/gang_leader_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Misc/gang_leader_survivor.yml
@@ -21,18 +21,6 @@
     - type: EquipEntityPreset
       preset: RMCGearSurvivorPresetGangLeader
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Multi_Map/priest_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Multi_Map/priest_survivor.yml
@@ -20,18 +20,6 @@
     - type: EquipEntityPreset
       preset: RMCGearSurvivorPresetPriest
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/commander_survivor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/New_Varadero/commander_survivor.yml
@@ -18,18 +18,6 @@
     - type: Skills
       preset: RMCSkillPresetCommander
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_assistant_manager.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Shivas/Panic_Room/shivas_panic_room_assistant_manager.yml
@@ -27,18 +27,6 @@
     - type: EquipEntityPreset
       preset: RMCSurvivorPresetCorporate
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: TacticalMapIcon
       icon:
         sprite: /Textures/_RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/corporate_supervisor.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/corporate_supervisor.yml
@@ -18,18 +18,6 @@
     - type: Skills
       preset: RMCSkillPresetSurvivorWeYaManager
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/field_opertaions_leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/field_opertaions_leader.yml
@@ -19,18 +19,6 @@
     - type: Skills
       preset: RMCSkillPresetSurvivorWeYaPMCCommander
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/leader.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/Crashlanding_Offices/leader.yml
@@ -18,18 +18,6 @@
     - type: Skills
       preset: RMCSkillPresetSurvivorWeYaPMCLeader
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/solaris_chaplain.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/solaris_chaplain.yml
@@ -18,18 +18,6 @@
     - type: EquipEntityPreset
       preset: RMCGearSurvivorPresetPriest
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/solaris_cmb_marshal.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/solaris_cmb_marshal.yml
@@ -32,18 +32,6 @@
         RMCSkillEndurance: 2
         RMCSkillJtac: 3
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCPointing
     - type: CommandAccent
     - type: InnateCommandSpeech

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/solaris_unmc_recruiter.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Solaris/solaris_unmc_recruiter.yml
@@ -22,18 +22,6 @@
         RMCSkillFireman: 2
         RMCSkillFirearms: 2
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: EquipEntityPreset
       preset: RMCSurvivorPresetCivilian
     - type: RMCSurvivor

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/trijent_chaplain.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/Survivor/Trijent_Dam/trijent_chaplain.yml
@@ -18,18 +18,6 @@
     - type: EquipEntityPreset
       preset: RMCGearSurvivorPresetTrijentChaplain
     - type: MarineOrders
-      moveOrderSoundMale:
-        collection: AU14MaleMoveOrder
-      moveOrderSoundFemale:
-        collection: AU14FemaleMoveOrder
-      focusOrderSoundMale:
-        collection: AU14MaleFocusOrder
-      focusOrderSoundFemale:
-        collection: AU14FemaleFocusOrder
-      holdOrderSoundMale:
-        collection: AU14MaleHoldOrder
-      holdOrderSoundFemale:
-        collection: AU14FemaleHoldOrder
     - type: RMCSurvivor
     - type: MotionDetectorTracked
     - type: NpcFactionMember


### PR DESCRIPTION
- **✨ Update Marine Orders to hold new CMU sound collections**
- **📋 remove MarineOrders collection noise from yaml**

## About the PR
- Annoying me to keep specifying a default value everywhere

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- code: Removes the MarineOrders collection specifier in yaml