### PR TITLE
fix(radio): comms playtest fixes

### DIFF
--- a/Content.Client/_AU14/Radio/ANPRCRadioWindow.xaml.cs
+++ b/Content.Client/_AU14/Radio/ANPRCRadioWindow.xaml.cs
@@ -592,7 +592,17 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
 
             string freqText;
             if (state.FrequencyOverrides.TryGetValue(slot, out var dynFreq))
-                freqText = $"{FormatFreq(dynFreq)} MHz · DIRECT";
+            {
+                // a raw frequency the sweep fixed but could not name reads as an
+                // unknown net rather than a plain direct entry, so an operator can
+                // tell a tuned intercept from a number they punched in themselves
+                var unknownNet = state.SweepContacts.Any(contact =>
+                    contact.Resolved && !contact.Known && contact.Frequency == dynFreq);
+
+                freqText = unknownNet
+                    ? $"{FormatFreq(dynFreq)} MHz · UNKNOWN NET"
+                    : $"{FormatFreq(dynFreq)} MHz · DIRECT";
+            }
             else if (state.Presets.TryGetValue(slot, out var ch) && _prototype.TryIndex(ch, out var proto))
                 freqText = $"{FormatFreq(PlanFreq(proto))} MHz · {proto.LocalizedName.ToUpperInvariant()}";
             else
@@ -682,15 +692,26 @@ public sealed partial class ANPRCRadioWindow : DefaultWindow
             if (proto.Frequency <= 0)
                 continue;
 
-            // only list the radio's own faction nets. faction-less channels (colony,
-            // civilian) get tuned by raw frequency instead
-            if (!string.IsNullOrEmpty(opFaction) && proto.Faction != opFaction)
+            // own-faction nets always list. a foreign net lists once the search
+            // receiver has fixed it - the server only puts a foreign channel's
+            // frequency in the state after it lands in DiscoveredFrequencies.
+            // faction-less channels (colony, civilian) get tuned by raw frequency
+            var ownNet = string.IsNullOrEmpty(opFaction) ||
+                         string.Equals(proto.Faction, opFaction, StringComparison.OrdinalIgnoreCase);
+
+            var discovered = !ownNet &&
+                             !string.IsNullOrEmpty(proto.Faction) &&
+                             state.ChannelFrequencies.ContainsKey(proto.ID);
+
+            if (!ownNet && !discovered)
                 continue;
 
             var capturedProto = proto;
             var btn = new Button
             {
-                Text = $"{proto.LocalizedName.ToUpperInvariant()}  -  {FormatFreq(PlanFreq(proto))} MHz",
+                Text = discovered
+                    ? $"{proto.LocalizedName.ToUpperInvariant()}  -  {FormatFreq(PlanFreq(proto))} MHz · INTERCEPT"
+                    : $"{proto.LocalizedName.ToUpperInvariant()}  -  {FormatFreq(PlanFreq(proto))} MHz",
                 HorizontalExpand = true,
             };
             btn.OnPressed += _ =>

--- a/Content.Server/_AU14/Callsigns/AU14CallsignSystem.cs
+++ b/Content.Server/_AU14/Callsigns/AU14CallsignSystem.cs
@@ -330,6 +330,11 @@ public sealed partial class AU14CallsignSystem : EntitySystem
         if (_squadWords.TryGetValue(squad, out var word))
             return word;
 
+        // squads carry a color word (RED, YELLOW, PURPLE) so callsigns never collide
+        // with the phonetic alphabet used for everything else on the net
+        if (CompOrNull<AU14SquadCallsignComponent>(squad)?.Word is { Length: > 0 } squadWord)
+            return squadWord.ToUpperInvariant();
+
         return Name(squad).ToUpperInvariant();
     }
 

--- a/Content.Server/_AU14/Radio/ANPRCFrequencyPlanSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCFrequencyPlanSystem.cs
@@ -45,10 +45,77 @@ public sealed partial class ANPRCFrequencyPlanSystem : EntitySystem
         _channelsByFrequency = null;
     }
 
+    // prototype reloads happen mid-round: the chem generator reloads reagent
+    // prototypes on every generated chem, and admins can reload after hotfixes.
+    // throwing the plan away here re-rolled every net frequency behind the backs of
+    // all the printed cards, tuned slots and sweep fixes. keep the plan, reconcile
+    // it against the channel list, and only reprint if something actually moved
     private void OnPrototypesReloaded(PrototypesReloadedEventArgs args)
     {
-        _plan = null;
+        if (!args.WasModified<RadioChannelPrototype>())
+            return;
+
         _channelsByFrequency = null;
+
+        if (_plan == null)
+            return;
+
+        var changed = false;
+
+        // channels that no longer exist or no longer qualify drop out of the plan
+        foreach (var id in _plan.Keys.ToArray())
+        {
+            if (!_prototype.TryIndex<RadioChannelPrototype>(id, out var proto) ||
+                proto.Frequency <= 0 ||
+                string.IsNullOrEmpty(proto.Faction))
+            {
+                _plan.Remove(id);
+                changed = true;
+            }
+        }
+
+        // new channels get a frequency without disturbing the assignments everyone
+        // already has written down
+        var taken = new HashSet<int>(_plan.Values);
+
+        foreach (var proto in _prototype.EnumeratePrototypes<RadioChannelPrototype>())
+        {
+            if (proto.Frequency > 0)
+                taken.Add(proto.Frequency);
+        }
+
+        var added = _prototype.EnumeratePrototypes<RadioChannelPrototype>()
+            .Where(proto => proto.Frequency > 0 &&
+                            !string.IsNullOrEmpty(proto.Faction) &&
+                            !_plan.ContainsKey(proto.ID))
+            .OrderBy(proto => proto.ID, StringComparer.Ordinal);
+
+        foreach (var proto in added)
+        {
+            int frequency;
+
+            do
+            {
+                frequency = _random.Next(FrequencyMin, FrequencyMax + 1);
+            }
+            while (!taken.Add(frequency));
+
+            _plan[proto.ID] = frequency;
+            changed = true;
+        }
+
+        if (changed)
+            ReprintCards();
+    }
+
+    private void ReprintCards()
+    {
+        var query = EntityQueryEnumerator<ANPRCFreqCardComponent, PaperComponent>();
+
+        while (query.MoveNext(out var uid, out var card, out var paper))
+        {
+            _paper.SetContent((uid, paper), GenerateSoi(card.Faction));
+        }
     }
 
     private void OnCommsToggled(bool enabled)
@@ -57,12 +124,7 @@ public sealed partial class ANPRCFrequencyPlanSystem : EntitySystem
         _channelsByFrequency = null;
 
         // cards printed before the toggle carry the wrong numbers, reprint them
-        var query = EntityQueryEnumerator<ANPRCFreqCardComponent, PaperComponent>();
-
-        while (query.MoveNext(out var uid, out var card, out var paper))
-        {
-            _paper.SetContent((uid, paper), GenerateSoi(card.Faction));
-        }
+        ReprintCards();
     }
 
     public int GetFrequency(RadioChannelPrototype channel)

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
@@ -181,7 +181,9 @@ public sealed partial class ANPRCRadioSystem
             return;
         }
 
-        if (_freqPlan.TryGetChannelByFrequency(frequency, out var channel))
+        var onNet = _freqPlan.TryGetChannelByFrequency(frequency, out var channel);
+
+        if (onNet)
         {
             ent.Comp.FrequencyOverrides.Remove(args.Slot);
             ent.Comp.Presets[args.Slot] = channel;
@@ -207,11 +209,20 @@ public sealed partial class ANPRCRadioSystem
             ? slotLabel
             : $"P{args.Slot + 1}";
 
+        // say what the number landed on. a frequency that matches no net used to get
+        // the same confirmation as one that does, and operators walked away thinking
+        // they were on a net when they were keying dead air
         _cmChat.ChatMessageToOne(
-            Loc.GetString(
-                "anprc-frequency-set",
-                ("slot", label),
-                ("freq", TunableFrequencySystem.FormatFreq(frequency))),
+            onNet && _prototype.TryIndex(channel, out var channelProto)
+                ? Loc.GetString(
+                    "anprc-frequency-set-net",
+                    ("slot", label),
+                    ("freq", TunableFrequencySystem.FormatFreq(frequency)),
+                    ("channel", channelProto.LocalizedName))
+                : Loc.GetString(
+                    "anprc-frequency-set-dynamic",
+                    ("slot", label),
+                    ("freq", TunableFrequencySystem.FormatFreq(frequency))),
             args.Actor);
     }
 
@@ -317,7 +328,9 @@ public sealed partial class ANPRCRadioSystem
         if (!ent.Comp.DiscoveredFrequencies.Contains(args.Frequency))
             return;
 
-        if (_freqPlan.TryGetChannelByFrequency(args.Frequency, out var channel))
+        var onNet = _freqPlan.TryGetChannelByFrequency(args.Frequency, out var channel);
+
+        if (onNet)
         {
             ent.Comp.FrequencyOverrides.Remove(args.Slot);
             ent.Comp.Presets[args.Slot] = channel;
@@ -335,10 +348,16 @@ public sealed partial class ANPRCRadioSystem
         UpdateBuiState(ent);
 
         _cmChat.ChatMessageToOne(
-            Loc.GetString(
-                "anprc-frequency-set",
-                ("slot", ent.Comp.SlotLabels[args.Slot]),
-                ("freq", TunableFrequencySystem.FormatFreq(args.Frequency))),
+            onNet && _prototype.TryIndex(channel, out var channelProto)
+                ? Loc.GetString(
+                    "anprc-frequency-set-net",
+                    ("slot", ent.Comp.SlotLabels[args.Slot]),
+                    ("freq", TunableFrequencySystem.FormatFreq(args.Frequency)),
+                    ("channel", channelProto.LocalizedName))
+                : Loc.GetString(
+                    "anprc-frequency-set-unknown",
+                    ("slot", ent.Comp.SlotLabels[args.Slot]),
+                    ("freq", TunableFrequencySystem.FormatFreq(args.Frequency))),
             args.Actor);
     }
 

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Content.Server.Chat.Systems;
 using Content.Server.Radio.Components;
 using Content.Shared._AU14.Callsigns;
@@ -428,6 +429,11 @@ public sealed partial class ANPRCRadioSystem
         var clear = new List<string>();
         var degraded = new List<string>();
 
+        // gated nets carry traffic wherever any anchor covers, not just around this
+        // pack. the check has to grade stations the same way the traffic gate does or
+        // it reports dead air to a platoon that can hear the operator fine
+        var gated = channel.AnchorGated;
+
         var query = EntityQueryEnumerator<ANPRCRadioComponent, TransformComponent>();
 
         while (query.MoveNext(out var otherUid, out var other, out var otherXform))
@@ -441,9 +447,8 @@ public sealed partial class ANPRCRadioSystem
             if (!HasPreset(other, channelId.Id))
                 continue;
 
-            var distance = (senderPos - _transform.GetWorldPosition(otherXform)).Length();
-
-            AddByRange(distance, fullRange, partialRange, GetOnAirName((otherUid, other)), clear, degraded);
+            AddStation(ent.Owner, otherUid, gated, channelId.Id, senderPos, fullRange, partialRange,
+                GetOnAirName((otherUid, other)), clear, degraded);
         }
 
         var headsetQuery = EntityQueryEnumerator<WearingHeadsetComponent, TransformComponent>();
@@ -462,14 +467,13 @@ public sealed partial class ANPRCRadioSystem
                 continue;
             }
 
-            var distance = (senderPos - _transform.GetWorldPosition(wearerXform)).Length();
-
             var label = TryComp(wearerUid, out AU14CallsignComponent? wearerCallsign) &&
                         !string.IsNullOrEmpty(wearerCallsign.Callsign)
                 ? wearerCallsign.Callsign
                 : Name(wearerUid);
 
-            AddByRange(distance, fullRange, partialRange, label, clear, degraded);
+            AddStation(ent.Owner, wearerUid, gated, channelId.Id, senderPos, fullRange, partialRange,
+                label, clear, degraded);
         }
 
         var nothingHeard = Loc.GetString("anprc-radio-check-nothing-heard");
@@ -506,14 +510,37 @@ public sealed partial class ANPRCRadioSystem
         };
     }
 
-    private static void AddByRange(
-        float distance,
+    private void AddStation(
+        EntityUid pack,
+        EntityUid station,
+        bool gated,
+        string channelId,
+        Vector2 senderPos,
         float fullRange,
         float partialRange,
         string label,
         List<string> clear,
         List<string> degraded)
     {
+        if (gated)
+        {
+            // the worn pack is itself an anchor for its presets, so stations standing
+            // next to the operator still grade through this path
+            switch (_range.GetRangeTier(station, channelId, out _))
+            {
+                case ANPRCRangeTier.Full:
+                    clear.Add(label);
+                    return;
+                case ANPRCRangeTier.Partial:
+                    degraded.Add(label);
+                    return;
+                default:
+                    return;
+            }
+        }
+
+        var distance = (senderPos - _transform.GetWorldPosition(station)).Length();
+
         if (distance <= fullRange)
             clear.Add(label);
         else if (distance <= partialRange)

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
@@ -142,6 +142,7 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         SubscribeLocalEvent<PropCallerComponent, MapInitEvent>(OnAdminObserverMapInit);
 
         SubscribeLocalEvent<ANPRCRadioComponent, ANPRCDirectScanSwitchedEvent>(OnDirectScanSwitched);
+        SubscribeLocalEvent<ANPRCRadioComponent, ANPRCDirectTrafficReceivedEvent>(OnDirectTrafficReceived);
         SubscribeLocalEvent<ANPRCRadioComponent, ANPRCSweepStoppedEvent>(OnSweepStopped);
         SubscribeLocalEvent<ANPRCRadioComponent, ANPRCSweepUpdatedEvent>(OnSweepUpdated);
         SubscribeLocalEvent<ANPRCRadioComponent, ANPRCCryptoChangedEvent>(OnCryptoChanged);
@@ -656,6 +657,46 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
     private void OnDirectScanSwitched(Entity<ANPRCRadioComponent> ent, ref ANPRCDirectScanSwitchedEvent args)
     {
         UpdateBuiState(ent);
+    }
+
+    // direct-frequency traffic lands in the net log like channel traffic does. anyone
+    // the set cannot place as friendly - enemy operators, colony handhelds, private
+    // squad freqs of the other side - gets the intercept flag so the print filter and
+    // the red log line pick it up
+    private void OnDirectTrafficReceived(Entity<ANPRCRadioComponent> ent, ref ANPRCDirectTrafficReceivedEvent args)
+    {
+        if (!_commsEnabled)
+            return;
+
+        var senderFaction = GetSenderFaction(args.Sender);
+
+        var intercepted = string.IsNullOrEmpty(senderFaction) ||
+                          !string.Equals(senderFaction, ent.Comp.OperatorFaction, StringComparison.OrdinalIgnoreCase);
+
+        AppendNetLog(
+            ent.Comp,
+            _timing.CurTime.TotalSeconds,
+            args.SenderName,
+            $"{TunableFrequencySystem.FormatFreq(args.Frequency)} MHz",
+            args.Message,
+            intercepted);
+
+        UpdateBuiState(ent);
+    }
+
+    private string? GetSenderFaction(EntityUid sender)
+    {
+        if (TryComp(sender, out ANPRCRadioComponent? sourceRadio))
+            return sourceRadio.OperatorFaction;
+
+        if (TryComp(sender, out WearingANPRCComponent? wearing) &&
+            TryComp(wearing.Radio, out ANPRCRadioComponent? wornRadio))
+        {
+            return wornRadio.OperatorFaction;
+        }
+
+        // every faction member carries an assigned callsign, which knows its faction
+        return CompOrNull<AU14CallsignComponent>(sender)?.Faction;
     }
 
     private void OnSweepStopped(Entity<ANPRCRadioComponent> ent, ref ANPRCSweepStoppedEvent args)

--- a/Content.Server/_AU14/Radio/ANPRCRangeSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRangeSystem.cs
@@ -154,7 +154,10 @@ public sealed partial class ANPRCRangeSystem : EntitySystem
         }
     }
 
-    private ANPRCRangeTier GetRangeTier(EntityUid entity, string channelId, out float quality)
+    // best coverage tier any live anchor gives this entity on the channel. public so
+    // the radio check can report reachability the same way real traffic is gated,
+    // instead of pretending the pack's own radius is the whole net
+    public ANPRCRangeTier GetRangeTier(EntityUid entity, string channelId, out float quality)
     {
         var entityPos = _transform.GetWorldPosition(entity);
         var entityMap = Transform(entity).MapID;

--- a/Content.Server/_AU14/Radio/TunableFrequencySystem.cs
+++ b/Content.Server/_AU14/Radio/TunableFrequencySystem.cs
@@ -196,6 +196,20 @@ public sealed partial class TunableFrequencySystem : EntitySystem
             if (wearer == sender)
                 continue;
 
+            var anprcPos = _transform.GetWorldPosition(xform);
+
+            if (!TryGetLinkIntensity(
+                    sender,
+                    senderPos,
+                    anprc,
+                    anprcPos,
+                    frequency,
+                    anprc,
+                    out var intensity))
+            {
+                continue;
+            }
+
             if (radio.ScanEnabled &&
                 (!radio.FrequencyOverrides.TryGetValue(radio.ActiveSlot, out var activeSlotFrequency) ||
                  activeSlotFrequency != frequency))
@@ -222,27 +236,33 @@ public sealed partial class TunableFrequencySystem : EntitySystem
                 }
             }
 
+            // what this set actually hears, garble and all, is what lands in its log -
+            // this is how direct-frequency traffic (enemy squad nets, colony softwave)
+            // becomes an intercept the operator can print and carry off the radio
+            var jam = MaxIntensity(senderJam, _garble.GetJamIntensity(anprc));
+            var totalIntensity = MaxIntensity(intensity, jam);
+
+            var heard = totalIntensity != RadioJamIntensity.None
+                ? _garble.GarbleMessage(message, totalIntensity)
+                : message;
+
+            var logEv = new ANPRCDirectTrafficReceivedEvent(
+                sender,
+                senderName ?? Name(sender),
+                frequency,
+                heard);
+
+            RaiseLocalEvent(anprc, ref logEv);
+
+            // the wearer's own tuned headset already delivers this to chat, the pack
+            // only logs it instead of doubling the line up
             if (TryComp(wearer, out TunedFrequencyComponent? wearerTuned) &&
                 wearerTuned.Frequency == frequency)
             {
                 continue;
             }
 
-            var anprcPos = _transform.GetWorldPosition(xform);
-
-            if (!TryGetLinkIntensity(
-                    sender,
-                    senderPos,
-                    anprc,
-                    anprcPos,
-                    frequency,
-                    anprc,
-                    out var intensity))
-            {
-                continue;
-            }
-
-            DeliverGarbled(sender, anprc, wearer, message, frequency, senderJam, intensity, senderName);
+            SendToEntity(sender, wearer, heard, frequency, senderName);
         }
 
         SendToEntity(sender, sender, message, frequency, senderName);
@@ -531,3 +551,12 @@ public sealed partial class TunableFrequencySystem : EntitySystem
 }
 
 public record struct ANPRCDirectScanSwitchedEvent;
+
+// a tuned-in ANPRC caught traffic on a raw frequency; the radio system writes it
+// into the set's net log, flagged as an intercept when the sender is not friendly
+[ByRefEvent]
+public readonly record struct ANPRCDirectTrafficReceivedEvent(
+    EntityUid Sender,
+    string SenderName,
+    int Frequency,
+    string Message);

--- a/Content.Shared/_AU14/Callsigns/AU14SquadCallsignComponent.cs
+++ b/Content.Shared/_AU14/Callsigns/AU14SquadCallsignComponent.cs
@@ -1,0 +1,11 @@
+namespace Content.Shared._AU14.Callsigns;
+
+// placed on a squad team entity to set the element word its members' callsigns use
+// on the radio. squads default to color words (RED 6, YELLOW 1-2) instead of their
+// phonetic names, so "ALPHA" in voice traffic can only ever mean another unit
+[RegisterComponent]
+public sealed partial class AU14SquadCallsignComponent : Component
+{
+    [DataField(required: true)]
+    public string Word = string.Empty;
+}

--- a/Resources/Locale/en-US/_AU14/anprc-radio.ftl
+++ b/Resources/Locale/en-US/_AU14/anprc-radio.ftl
@@ -27,7 +27,9 @@ anprc-frequency-invalid = Invalid frequency format. Enter a number such as 1606 
 anprc-frequency-out-of-band = No net can live there. Direct frequencies sit in 1.000-2.999 MHz or the 30.000-87.999 softwave band.
 anprc-frequency-not-found = No channel found at frequency { $freq }.
 anprc-frequency-set = [{ $slot }] tuned to { $freq } MHz.
-anprc-frequency-set-dynamic = [{ $slot }] set to { $freq } MHz (direct frequency). Transmit with :r.
+anprc-frequency-set-net = [{ $slot }] tuned to { $freq } MHz — on the { $channel } net.
+anprc-frequency-set-unknown = [{ $slot }] tuned to { $freq } MHz — unidentified net. Traffic will be logged.
+anprc-frequency-set-dynamic = [{ $slot }] set to { $freq } MHz (direct frequency) — no net assigned here. Transmit with :r.
 
 anprc-slot-max-reached = Maximum preset slots reached (4). Delete a slot first.
 

--- a/Resources/Prototypes/_CMU14/Economy/Misc/clfstuff.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Misc/clfstuff.yml
@@ -356,6 +356,19 @@
       - id: CMUGasMaskFilterHAZOPS
         amount: 3
         points: 5
+    # the cell's starting comms: one manpack and one base station on the house so a
+    # round-start cell is never without its net. gated to the radio operator; spares
+    # and replacements stay as the paid entries under Special Equipment
+    - name: Radio Operator Issue
+      jobs:
+      - AU14JobCLFRadioOperator
+      entries:
+      - id: ANPRC117GRadioCLFFilled
+        amount: 1
+        points: 0
+      - id: AU14CLFBaseStation
+        amount: 1
+        points: 0
     - name: Special Equipment
       entries:
       - id: CMUDeployableZLevelLadder

--- a/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
@@ -36,9 +36,9 @@
     callsignPresets:
     - PLT ACTUAL
     - PLT MAIN
-    - ALPHA ACTUAL
-    - BRAVO ACTUAL
-    - CHARLIE 6
+    - RED ACTUAL
+    - YELLOW ACTUAL
+    - PURPLE 6
     - SUNRAY
     - OVERLORD
     - DUSTOFF

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/squads.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/squads.yml
@@ -3,6 +3,8 @@
   id: SquadGovfor
   name: Alpha
   components:
+  - type: AU14SquadCallsign
+    word: RED
   - type: SquadTeam
     color: "#F0433E"
     radio: radioGovforAlpha
@@ -17,6 +19,8 @@
   id: SquadGovforBravo
   name: Bravo
   components:
+  - type: AU14SquadCallsign
+    word: YELLOW
   - type: SquadTeam
     roundStart: true
     color: "#c7b646"
@@ -31,6 +35,8 @@
   id: SquadGovforCharlie
   name: Charlie
   components:
+  - type: AU14SquadCallsign
+    word: PURPLE
   - type: SquadTeam
     roundStart: true
     group: GOVFOR
@@ -45,6 +51,8 @@
   id: SquadGovforIntel
   name: Auxiliary
   components:
+  - type: AU14SquadCallsign
+    word: GREEN
   - type: SquadTeam
     group: GOVFOR
     roundStart: true

--- a/Resources/Prototypes/_CMU14/Roles/Military/OpFor/squads.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/OpFor/squads.yml
@@ -3,6 +3,8 @@
   id: SquadOpfor
   name: Sierra
   components:
+  - type: AU14SquadCallsign
+    word: VIOLET
   - type: SquadTeam
     roundStart: true
     color: "#bb91d8"
@@ -17,6 +19,8 @@
   id: SquadOpforBravo
   name: Tango
   components:
+  - type: AU14SquadCallsign
+    word: TAN
   - type: SquadTeam
     roundStart: true
     color: "#c6c1a8"
@@ -31,6 +35,8 @@
   id: SquadOpforCharlie
   name:  Uniform
   components:
+  - type: AU14SquadCallsign
+    word: SAGE
   - type: SquadTeam
     roundStart: true
     color: "#7A967E"
@@ -45,6 +51,8 @@
   id: SquadOpforIntel
   name: Intel # this will cause confusion, but better than x2 Auxiliary
   components:
+  - type: AU14SquadCallsign
+    word: BLUE
   - type: SquadTeam
     roundStart: true
     color: "#1E90FF"

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml
@@ -193,30 +193,30 @@
     </ColorBox>
 
     <ColorBox>
-      <Box Margin="4">ALPHA ACTUAL</Box>
+      <Box Margin="4">RED ACTUAL</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Alpha squad leader</Box>
-    </ColorBox>
-
-    <ColorBox>
-      <Box Margin="4">ALPHA ROMEO</Box>
-    </ColorBox>
-    <ColorBox>
-      <Box Margin="4">Radio operator attached to Alpha</Box>
+      <Box Margin="4">Red (Alpha) squad leader</Box>
     </ColorBox>
 
     <ColorBox>
-      <Box Margin="4">ALPHA 1-1 ... 1-N</Box>
+      <Box Margin="4">RED ROMEO</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Alpha squad members</Box>
+      <Box Margin="4">Radio operator attached to Red (Alpha)</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">RED 1-1 ... 1-N</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Red (Alpha) squad members</Box>
     </ColorBox>
   </Table>
 
   [bold]ACTUAL[/bold] identifies the person in charge speaking personally rather than an operator transmitting on their behalf.
 
-  Squad leaders answer as their element's ACTUAL station, for example [bold]ALPHA ACTUAL[/bold]. At platoon level, [bold]HAVOC 6 ACTUAL[/bold] means the commander has taken the handset personally instead of the RTO.
+  Squad leaders answer as their element's ACTUAL station, for example [bold]RED ACTUAL[/bold]. At platoon level, [bold]HAVOC 6 ACTUAL[/bold] means the commander has taken the handset personally instead of the RTO.
 
   ### Comms Net Directory
 

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsVoiceProcedure.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsVoiceProcedure.xml
@@ -18,7 +18,7 @@
 
   Address the receiving station first, then identify the transmitting station.
 
-  [color=#a4885c]HAVOC 6, this is ALPHA ROMEO, message, over.[/color]
+  [color=#a4885c]HAVOC 6, this is RED ROMEO, message, over.[/color]
 
   A complete call normally contains:
 
@@ -30,11 +30,11 @@
 
   The receiving station answers using the same order:
 
-  [color=#a4885c]ALPHA ROMEO, this is HAVOC 6, send it, over.[/color]
+  [color=#a4885c]RED ROMEO, this is HAVOC 6, send it, over.[/color]
 
   After both stations have established contact, [bold]THIS IS[/bold] may be omitted:
 
-  [color=#a4885c]ALPHA ROMEO, HAVOC 6, send it, over.[/color]
+  [color=#a4885c]RED ROMEO, HAVOC 6, send it, over.[/color]
 
   ## Prowords
 
@@ -181,9 +181,9 @@
 
   A radio check confirms that two stations can hear each other.
 
-  [color=#a4885c]HAVOC ROMEO, this is ALPHA ROMEO, radio check, over.[/color]
+  [color=#a4885c]HAVOC ROMEO, this is RED ROMEO, radio check, over.[/color]
 
-  [color=#a4885c]ALPHA ROMEO, this is HAVOC ROMEO, Lima Charlie. How me? Over.[/color]
+  [color=#a4885c]RED ROMEO, this is HAVOC ROMEO, Lima Charlie. How me? Over.[/color]
 
   [color=#a4885c]Lima Charlie, out.[/color]
 
@@ -203,19 +203,19 @@
   - Approximate strength.
   - What the reporting element is doing.
 
-  [color=#a4885c]HAVOC 6, this is ALPHA ACTUAL, contact. Infantry, squad strength, east treeline near grid two-four-five. Engaging, over.[/color]
+  [color=#a4885c]HAVOC 6, this is RED ACTUAL, contact. Infantry, squad strength, east treeline near grid two-four-five. Engaging, over.[/color]
 
-  [color=#a4885c]ALPHA ACTUAL, HAVOC 6, roger. BRAVO is moving to your flank. Hold your position, over.[/color]
+  [color=#a4885c]RED ACTUAL, HAVOC 6, roger. YELLOW is moving to your flank. Hold your position, over.[/color]
 
-  [color=#a4885c]HAVOC 6, ALPHA ACTUAL, wilco, out.[/color]
+  [color=#a4885c]HAVOC 6, RED ACTUAL, wilco, out.[/color]
 
   ## Fire-Support Request
 
   Establish contact before sending the full request.
 
-  [color=#a4885c]HAVOC OPS, this is ALPHA ROMEO, fire mission, over.[/color]
+  [color=#a4885c]HAVOC OPS, this is RED ROMEO, fire mission, over.[/color]
 
-  [color=#a4885c]ALPHA ROMEO, HAVOC OPS, send it, over.[/color]
+  [color=#a4885c]RED ROMEO, HAVOC OPS, send it, over.[/color]
 
   The request should identify:
 
@@ -226,17 +226,17 @@
 
   [color=#a4885c]Enemy machine-gun position on the north ridge beside the communications tower. Friendlies are two-five-zero meters east, marked by smoke. Request suppression, over.[/color]
 
-  [color=#a4885c]ALPHA ROMEO, HAVOC OPS, roger. Rounds out, impact in three-zero seconds, over.[/color]
+  [color=#a4885c]RED ROMEO, HAVOC OPS, roger. Rounds out, impact in three-zero seconds, over.[/color]
 
-  [color=#a4885c]HAVOC OPS, ALPHA ROMEO, impact observed. Target suppressed. End of mission, out.[/color]
+  [color=#a4885c]HAVOC OPS, RED ROMEO, impact observed. Target suppressed. End of mission, out.[/color]
 
   ## Casualty Evacuation Request
 
   Establish contact before sending casualty details.
 
-  [color=#a4885c]HAVOC ROMEO, this is BRAVO ROMEO, casualty evacuation request, over.[/color]
+  [color=#a4885c]HAVOC ROMEO, this is YELLOW ROMEO, casualty evacuation request, over.[/color]
 
-  [color=#a4885c]BRAVO ROMEO, HAVOC ROMEO, send it, over.[/color]
+  [color=#a4885c]YELLOW ROMEO, HAVOC ROMEO, send it, over.[/color]
 
   Include:
 
@@ -248,15 +248,15 @@
 
   [color=#a4885c]Two casualties. One urgent surgical, one walking wounded. Pickup at the landing zone south of the bridge. Area is secure and marked with green smoke, over.[/color]
 
-  [color=#a4885c]BRAVO ROMEO, HAVOC ROMEO, good copy. Evacuation craft inbound in five minutes, out.[/color]
+  [color=#a4885c]YELLOW ROMEO, HAVOC ROMEO, good copy. Evacuation craft inbound in five minutes, out.[/color]
 
   ## Using ACTUAL
 
   [bold]ACTUAL[/bold] identifies the person in charge speaking personally rather than an RTO or other person speaking on their behalf.
 
-  Squad leaders carry it as their assigned station: [bold]ALPHA ACTUAL[/bold] is the Alpha squad leader. Command stations append it when the officer takes the handset personally.
+  Squad leaders carry it as their assigned station: [bold]RED ACTUAL[/bold] is the Red (Alpha) squad leader. Command stations append it when the officer takes the handset personally.
 
-  [color=#a4885c]ALPHA ACTUAL, this is HAVOC 6 ACTUAL. Move past phase line DODGE, over.[/color]
+  [color=#a4885c]RED ACTUAL, this is HAVOC 6 ACTUAL. Move past phase line DODGE, over.[/color]
 
   Without [bold]ACTUAL[/bold], [bold]HAVOC 6[/bold] traffic may be the RTO relaying for the commander. With it, the commander is speaking personally.
 


### PR DESCRIPTION
## About the PR

Follow-up fixes for the AN/PRC-117G comms system based on the playtest feedback from #1568 and #1681

The main fix is for the per-round frequency plan silently changing during normal gameplay. This caused printed SOI cards to show stale frequencies while the radios were using a newly generated plan

This also fixes radio checks under comms array coverage, direct-frequency intercept logging, sweep-discovered net tuning, and changes the default squad callsigns from phonetics to colors

## Why / Balance

The frequency plan was being discarded whenever `PrototypesReloadedEventArgs` fired

The chem research system calls `IPrototypeManager.ReloadPrototypes()` whenever it generates a chemical, so unrelated reagent reloads could reset the radio plan in the middle of a round. The next radio access generated a fresh plan

That meant:

- Printed SOI cards kept the old frequencies
- Entering a frequency from the card could tune the radio to dead air
- Sweep results and displayed frequencies could change mid-round
- Radio checks on the old frequencies returned nothing
- NET selection continued working because it stores the channel rather than the frequency number

The plan now ignores prototype reloads unless radio channel prototypes actually changed

When radio channels do change, the existing plan is reconciled rather than rerolled. Existing assignments stay where they are, new channels receive frequencies, removed channels are dropped, and frequency cards are reprinted if the plan actually changed

Radio checks also previously ignored comms array coverage. They only counted stations inside the pack's own 30/45-tile range, even when those stations could communicate normally through an array

Anchor-gated nets now use the same `ANPRCRangeSystem.GetRangeTier` coverage logic as real radio traffic. Ungated nets keep the normal distance check. This does not increase radio range, it just makes the radio check report the range players already have

Direct-frequency traffic was another gap. A tuned radio could hear traffic on a raw frequency, but the message was only sent to chat and never written to the net log. This made it impossible to print intercepts for traffic outside the known channel list

Direct-frequency traffic is now logged using the same garbled message the receiving set heard. It is marked as an `INTERCEPT` when the sender cannot be identified as friendly through either their AN/PRC operator faction or assigned callsign faction

A sender with no identifiable faction is deliberately treated as an intercept. A military set monitoring unauthenticated traffic should not assume it is friendly

Sweep-discovered foreign nets were already sent to the client, but the NET tab filtered them out because they did not belong to the pack's faction. Discovered foreign nets are now selectable and marked with `· INTERCEPT`

Tuning feedback now distinguishes between:

- A named net
- An unidentified net
- A direct frequency with no matching net

Resolved frequencies without a known name now appear as `UNKNOWN NET` instead of `DIRECT`

Squad callsigns now default to colors instead of phonetics. The phonetic squad names were easy to confuse with normal procedure

The defaults are:

- GOVFOR Alpha: `RED`
- GOVFOR Bravo: `YELLOW`
- GOVFOR Charlie: `PURPLE`
- GOVFOR Auxiliary: `GREEN`
- OPFOR Sierra: `VIOLET`
- OPFOR Tango: `TAN`
- OPFOR Uniform: `SAGE`
- OPFOR Intel: `BLUE`

This is data-driven through a new `AU14SquadCallsign` component on the squad prototypes. Directory console renames still override the default

Radio channel names such as ALFA, BRAV, and CHAR are unchanged

## Technical details

- Made `ANPRCFrequencyPlanSystem` ignore unrelated prototype reloads
- Added frequency-plan reconciliation when radio channel prototypes actually change
- Preserved existing channel-to-frequency assignments during reconciliation
- Added frequencies only for newly added channels
- Removed assignments for deleted channels
- Reprinted SOI frequency cards when reconciliation changes the plan
- Updated anchor-gated radio checks to use `ANPRCRangeSystem.GetRangeTier`
- Added net-log entries for received direct-frequency traffic
- Logged the garbled message as heard by the receiving set
- Added intercept detection using the sender's AN/PRC faction or assigned callsign faction
- Exposed sweep-discovered foreign nets in the NET tab
- Marked discovered foreign nets with `· INTERCEPT`
- Added separate tuning feedback for named nets, unidentified nets, and dead direct frequencies
- Changed resolved unnamed frequencies from `DIRECT` to `UNKNOWN NET`
- Added the data-driven `AU14SquadCallsign` component to the squad prototypes
- Updated pack callsign presets and guidebook examples to use the new color callsigns

## Media


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: AN/PRC-117G frequency assignments no longer change mid-round, so printed SOI cards stay accurate
- fix: Radio checks now include stations reachable through comms array coverage
- fix: Direct-frequency traffic heard by a tuned radio is now logged and marked as an intercept when unauthenticated
- fix: Nets discovered through a band sweep can now be selected from the NET tab
- tweak: Tuning feedback now distinguishes named nets, unidentified nets, and empty direct frequencies
- add: Squads now use color callsigns such as RED, YELLOW, PURPLE, and GREEN instead of phonetics
- tweak: The CLF Requisitions Rack now issues the cell's starting comms for free
