### PR TITLE
Removes xeno ability miss cds, reverts tail stab sprite click

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Numerics;
 using Content.Shared._RMC14.Barricade;
 using Content.Shared._RMC14.CameraShake;
+using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Stun;
 using Content.Shared._RMC14.Xenonids.GasToggle;
 using Content.Shared._RMC14.Xenonids.Neurotoxin;
@@ -24,11 +25,9 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
-using Content.Shared._RMC14.CCVar;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Physics;
-using Robust.Shared.Configuration;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
 
@@ -54,7 +53,6 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
     [Dependency] private RMCDazedSystem _daze = default!;
     [Dependency] private RMCCameraShakeSystem _cameraShake = default!;
     [Dependency] private RMCSizeStunSystem _size = default!;
-    [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private SharedPhysicsSystem _physics = default!;
     [Dependency] private SharedXenoHiveSystem _hive = default!;
 
@@ -127,6 +125,9 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
             if (uid == stab.Owner)
                 return true;
 
+            if (HasComp<BarricadeComponent>(uid))
+                return false;
+
             if (!HasComp<MobStateComponent>(uid))
                 return true;
 
@@ -140,10 +141,15 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
         // but have you seen these allocations either way
         var intersect = _physics.IntersectRayWithPredicate(transform.MapID, leftRay, tailRange, Ignored, false);
         intersect = intersect.Concat(_physics.IntersectRayWithPredicate(transform.MapID, rightRay, tailRange, Ignored, false));
-        var results = intersect.Select(r => r.HitEntity).ToHashSet();
+        var results = intersect
+            .Select(r => r.HitEntity)
+            .Distinct()
+            .OrderBy(x =>
+                (_transform.GetMapCoordinates(x).Position - userCoords.Position).LengthSquared())
+            .ToList();
 
         var actualResults = new List<EntityUid>();
-        var range = stab.Comp.TailRange.Float();
+        var range = tailRange;
         foreach (var result in results)
         {
             if (!_interaction.InRangeUnobstructed(stab.Owner, result, range: range))
@@ -180,6 +186,9 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
         {
             args.Handled = true;
 
+            var filter = Filter.Pvs(transform.Coordinates, entityMan: EntityManager)
+                .RemoveWhereAttachedEntity(o => o == stab.Owner);
+
             foreach (var originalHit in actualResults)
             {
                 var hit = originalHit;
@@ -191,19 +200,19 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
                         userPosition,
                         (targetPosition - userPosition).ToWorldAngle(),
                         0,
-                        stab.Comp.TailRange.Float(),
+                        tailRange,
                         _transform.GetMapId(stab.Owner),
                         stab))
                     .ToList();
 
-                foreach (var potentialTarget in entities)
+                foreach (var entity in entities)
                 {
-                    var target = GetEntity(potentialTarget);
+                    var blockingEntity = GetEntity(entity);
 
-                    if (!_directionBlock.IsAttackBlocked(stab, target))
+                    if (!_directionBlock.IsAttackBlocked(stab, blockingEntity))
                         continue;
 
-                    hit = target;
+                    hit = blockingEntity;
                     break;
                 }
 
@@ -215,12 +224,12 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
                     _interaction.DoContactInteraction(stab, stab);
                     _interaction.DoContactInteraction(stab, hit);
 
-                    var filter = Filter.Pvs(transform.Coordinates, entityMan: EntityManager).RemoveWhereAttachedEntity(o => o == stab.Owner);
-
-                    var attackedEv = new AttackedEvent(stab, stab, args.Target);
+                var attackedEv = new AttackedEvent(stab, stab, args.Target);
                     RaiseLocalEvent(hit, attackedEv);
 
-                var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEv.BonusDamage, hitEvent.ModifiersList);
+                var modifiedDamage = DamageSpecifier.ApplyModifierSets(
+                    damage + hitEvent.BonusDamage + attackedEv.BonusDamage,
+                    hitEvent.ModifiersList);
                 var finalDamage = _xeno.TryApplyXenoSlashDamageMultiplier(hit, modifiedDamage);
                 var change = _damageable.TryChangeDamage(
                     hit,
@@ -245,7 +254,7 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
             var length = localPos.Length();
             if (length > 0)
             {
-                localPos *= stab.Comp.TailRange.Float() / length;
+                localPos *= tailRange / length;
                 DoLunge((stab, stab, transform), localPos, "WeaponArcThrust");
             }
 

--- a/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Stab/SharedXenoTailStabSystem.cs
@@ -24,6 +24,13 @@ using Robust.Shared.Network;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
+using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Physics;
+using Robust.Shared.Configuration;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 
 namespace Content.Shared._RMC14.Xenonids.Stab;
 
@@ -47,6 +54,12 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
     [Dependency] private RMCDazedSystem _daze = default!;
     [Dependency] private RMCCameraShakeSystem _cameraShake = default!;
     [Dependency] private RMCSizeStunSystem _size = default!;
+    [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private SharedPhysicsSystem _physics = default!;
+    [Dependency] private SharedXenoHiveSystem _hive = default!;
+
+    private const int AttackMask = (int)(CollisionGroup.MobMask | CollisionGroup.Opaque);
+    private const int TailStabMaxTargets = 1;
 
     protected Box2Rotated LastTailAttack;
 
@@ -56,6 +69,7 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
 
         SubscribeLocalEvent<XenoTailStabComponent, XenoTailStabEvent>(OnXenoTailStab);
         SubscribeLocalEvent<XenoTailStabComponent, XenoGasToggleActionEvent>(OnXenoGasToggle);
+
     }
 
     private void OnXenoGasToggle(Entity<XenoTailStabComponent> stab, ref XenoGasToggleActionEvent args)
@@ -92,6 +106,55 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
             Dirty(stab, melee);
         }
 
+        var tailRange = stab.Comp.TailRange.Float();
+        var box = new Box2(userCoords.Position.X - 0.10f, userCoords.Position.Y, userCoords.Position.X + 0.10f, userCoords.Position.Y + tailRange);
+
+        var matrix = Vector2.Transform(targetCoords.Position, _transform.GetInvWorldMatrix(transform));
+        var rotation = _transform.GetWorldRotation(stab).RotateVec(-matrix).ToWorldAngle();
+        var boxRotated = new Box2Rotated(box, rotation, userCoords.Position);
+        LastTailAttack = boxRotated;
+
+        // ray on the left side of the box
+        var leftRay = new CollisionRay(boxRotated.BottomLeft, (boxRotated.TopLeft - boxRotated.BottomLeft).Normalized(), AttackMask);
+
+        // ray on the right side of the box
+        var rightRay = new CollisionRay(boxRotated.BottomRight, (boxRotated.TopRight - boxRotated.BottomRight).Normalized(), AttackMask);
+
+        var hive = _hive.GetHive(stab.Owner);
+
+        bool Ignored(EntityUid uid)
+        {
+            if (uid == stab.Owner)
+                return true;
+
+            if (!HasComp<MobStateComponent>(uid))
+                return true;
+
+            return _hive.IsMember(uid, hive);
+        }
+
+        // dont open allocations ahead
+        // entity lookups dont work properly with Box2Rotated
+        // so we do one ray cast on each side instead since its narrow enough
+        // im sure you could calculate the ray bounds more efficiently
+        // but have you seen these allocations either way
+        var intersect = _physics.IntersectRayWithPredicate(transform.MapID, leftRay, tailRange, Ignored, false);
+        intersect = intersect.Concat(_physics.IntersectRayWithPredicate(transform.MapID, rightRay, tailRange, Ignored, false));
+        var results = intersect.Select(r => r.HitEntity).ToHashSet();
+
+        var actualResults = new List<EntityUid>();
+        var range = stab.Comp.TailRange.Float();
+        foreach (var result in results)
+        {
+            if (!_interaction.InRangeUnobstructed(stab.Owner, result, range: range))
+                continue;
+
+            actualResults.Add(result);
+            if (actualResults.Count >= TailStabMaxTargets)
+                break;
+        }
+
+
         // TODO RMC14 sounds
         // TODO RMC14 lag compensation
         var damaged = false;
@@ -99,9 +162,10 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
         var eve = new RMCGetTailStabBonusDamageEvent(new DamageSpecifier());
         RaiseLocalEvent(stab, ref eve);
         damage += eve.Damage;
-        if (args.Entity == null ||
-            TerminatingOrDeleted(args.Entity) ||
-            !_xeno.CanAbilityAttackTarget(stab,args.Entity.Value, true))
+        actualResults.RemoveAll(uid =>
+            !_xeno.CanAbilityAttackTarget(stab, uid, true));
+
+        if (actualResults.Count == 0)
         {
             var missEvent = new MeleeHitEvent(new List<EntityUid>(), stab, stab, damage, null);
             RaiseLocalEvent(stab, missEvent);
@@ -116,29 +180,26 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
         {
             args.Handled = true;
 
-            var hit = args.Entity.Value;
-            var hitEvent = new MeleeHitEvent(new List<EntityUid>{hit}, stab, stab, damage, null);
-            RaiseLocalEvent(stab, hitEvent);
-
-            if (!hitEvent.Handled)
+            foreach (var originalHit in actualResults)
             {
-                _interaction.DoContactInteraction(stab, stab);
-                _interaction.DoContactInteraction(stab, hit);
+                var hit = originalHit;
 
                 var targetPosition = _transform.GetMoverCoordinates(hit).Position;
                 var userPosition = _transform.GetMoverCoordinates(stab).Position;
-                var entities = GetNetEntityList(_melee.ArcRayCast(userPosition,
-                        (targetPosition -
-                         userPosition).ToWorldAngle(),
+
+                var entities = GetNetEntityList(_melee.ArcRayCast(
+                        userPosition,
+                        (targetPosition - userPosition).ToWorldAngle(),
                         0,
                         stab.Comp.TailRange.Float(),
                         _transform.GetMapId(stab.Owner),
-                        stab)
-                    .ToList());
+                        stab))
+                    .ToList();
 
                 foreach (var potentialTarget in entities)
                 {
                     var target = GetEntity(potentialTarget);
+
                     if (!_directionBlock.IsAttackBlocked(stab, target))
                         continue;
 
@@ -146,10 +207,18 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
                     break;
                 }
 
-                var filter = Filter.Pvs(transform.Coordinates, entityMan: EntityManager).RemoveWhereAttachedEntity(o => o == stab.Owner);
+                var hitEvent = new MeleeHitEvent(new List<EntityUid> { hit }, stab, stab, damage, null);
+                RaiseLocalEvent(stab, hitEvent);
 
-                var attackedEv = new AttackedEvent(stab, stab, args.Target);
-                RaiseLocalEvent(hit, attackedEv);
+                if (!hitEvent.Handled)
+                {
+                    _interaction.DoContactInteraction(stab, stab);
+                    _interaction.DoContactInteraction(stab, hit);
+
+                    var filter = Filter.Pvs(transform.Coordinates, entityMan: EntityManager).RemoveWhereAttachedEntity(o => o == stab.Owner);
+
+                    var attackedEv = new AttackedEvent(stab, stab, args.Target);
+                    RaiseLocalEvent(hit, attackedEv);
 
                 var modifiedDamage = DamageSpecifier.ApplyModifierSets(damage + hitEvent.BonusDamage + attackedEv.BonusDamage, hitEvent.ModifiersList);
                 var finalDamage = _xeno.TryApplyXenoSlashDamageMultiplier(hit, modifiedDamage);
@@ -169,6 +238,16 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
                     damaged = true;
                     _colorFlash.RaiseEffect(Color.Red, new List<EntityUid> { hit }, filter);
                 }
+            }
+
+            var localPos = transform.LocalRotation.RotateVec(matrix);
+
+            var length = localPos.Length();
+            if (length > 0)
+            {
+                localPos *= stab.Comp.TailRange.Float() / length;
+                DoLunge((stab, stab, transform), localPos, "WeaponArcThrust");
+            }
 
                 if (_net.IsServer)
                 {
@@ -250,14 +329,16 @@ public abstract partial class SharedXenoTailStabSystem : EntitySystem
 
         if (_net.IsServer)
         {
-            if (args.Entity != null && !TerminatingOrDeleted(args.Entity))
+            if (damaged)
             {
                 var direction = _transform.GetWorldRotation(stab).GetDir();
                 var angle = direction.ToAngle() - Angle.FromDegrees(180);
                 _rotate.RotateXeno(stab, angle.GetDir());
             }
 
-            var sound = args.Entity != null && damaged && !TerminatingOrDeleted(args.Entity) && args.Entity != stab ? stab.Comp.SoundHit : stab.Comp.SoundMiss;
+            var sound = damaged
+                ? stab.Comp.SoundHit
+                : stab.Comp.SoundMiss;
             _audio.PlayPvs(sound, stab);
         }
 

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -752,7 +752,6 @@
     event: !type:XenoLungeActionEvent
   - type: XenoOffensiveAction
   - type: RMCDazeableAction
-  - type: RMCCooldownOnMiss
 
 - type: entity
   parent: CMGuidebookActionXenoBase
@@ -1069,8 +1068,6 @@
   - type: ActionBlockIfResting
   - type: XenoActionPlasma
     cost: 80
-  - type: RMCCooldownOnMiss
-    missCooldown: 0.7
 
 - type: entity
   parent: ActionXenoBase
@@ -1093,8 +1090,6 @@
   - type: XenoActionPlasma
     cost: 30
   - type: ActionBlockIfResting
-  - type: RMCCooldownOnMiss
-    missCooldown: 0.7
 
 - type: entity
   parent: ActionXenoBase


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Xeno QOL to make using some abilities easier.

## Why / Balance
These were parity ports from byond that translated into jank because surprisingly, we are no longer on a 30 year old engine and have pixel movement.
Both tail stab and dancer+warrior abilities relied on sprite clicking, which is much easier to do in byond as it is based on tile movement, but here it is much harder and more of an annoyance to use because we don't have tile movement, enough to be considered anti-QOL. They have been reverted.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Certain Dancer and Warrior abilities no longer have a cooldown upon missing. Tailstab has been reverted to its previous state as a thrust attack.