### PR TITLE
Metashield, WY APC, inapp tweak.

### DIFF
--- a/Content.Shared/Examine/ExamineSystemShared.cs
+++ b/Content.Shared/Examine/ExamineSystemShared.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Shared._RMC14.Examine;
 using Content.Shared._RMC14.Overwatch;
 using Content.Shared._RMC14.Xenonids.Eye;
 using Content.Shared._RMC14.Xenonids.Watch;
@@ -7,6 +8,7 @@ using Content.Shared.Ghost;
 using Content.Shared.Interaction;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Whitelist;
 using JetBrains.Annotations;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
@@ -26,6 +28,7 @@ namespace Content.Shared.Examine
 
         // RMC14
         [Dependency] private QueenEyeSystem _queenEye = default!;
+        [Dependency] private EntityWhitelistSystem _whitelist = default!;
 
         public const float MaxRaycastRange = 100;
 
@@ -305,11 +308,19 @@ namespace Content.Shared.Examine
 
             var hasDescription = false;
             var metadata = MetaData(entity);
+            var description = metadata.EntityDescription;
+
+            // RMC14
+            if (TryComp(entity, out FixedDescriptionComponent? fixedDescription) &&
+                _whitelist.IsWhitelistPass(fixedDescription.Whitelist, examiner.Value))
+            {
+                description = Loc.GetString(fixedDescription.Description);
+            }
 
             //Add an entity description if one is declared
-            if (!string.IsNullOrEmpty(metadata.EntityDescription))
+            if (!string.IsNullOrEmpty(description))
             {
-                message.AddText(metadata.EntityDescription);
+                message.AddText(description);
                 hasDescription = true;
             }
 

--- a/Content.Shared/_RMC14/Examine/FixedDescriptionComponent.cs
+++ b/Content.Shared/_RMC14/Examine/FixedDescriptionComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Whitelist;
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Examine;
+
+/// <summary>
+///     Overrides the entity's examine description for viewers that pass <see cref="Whitelist"/>.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class FixedDescriptionComponent : Component
+{
+    [DataField(required: true), AutoNetworkedField]
+    public LocId Description = string.Empty;
+
+    [DataField, AutoNetworkedField]
+    public EntityWhitelist? Whitelist;
+}

--- a/Resources/Locale/en-US/_AU14/job/colony.ftl
+++ b/Resources/Locale/en-US/_AU14/job/colony.ftl
@@ -210,9 +210,9 @@ au14-job-name-orbitallawyer = Orbital Counsel
 au14-job-description-orbitallawyer = Defend the innocent (and guilty), prosecute, or just argue until someone pays you.
 au14-job-prefix-orbitallawyer = Orb. Cnsl.
 
-au14-job-name-civiliancolonyadminasssistant = Administrative Assistant
+au14-job-name-civiliancolonyadminasssistant = Deputy Administrator
 au14-job-description-civiliancolonyadminassistant = Be the right hand of the Colony Administrator.
-au14-job-prefix-colonyadminassistant = Admin. Assist.
+au14-job-prefix-colonyadminassistant = Dep. Admin.
 
 au14-job-name-civiliancorporateassistant = Corporate Assistant
 au14-job-description-civiliancorporateassistant = Be the right hand of the Corporate Liaison.

--- a/Resources/Locale/en-US/_RMC14/rmc-xeno.ftl
+++ b/Resources/Locale/en-US/_RMC14/rmc-xeno.ftl
@@ -2,3 +2,4 @@
 rmc-rouny = Rouny
 rmc-wehny = Wehny
 rmc-lesser-carrier = Lesser Carrier
+rmc-xeno-unknown-description = What the hell is that?

--- a/Resources/Prototypes/_CMU14/Entities/Mobs/Xeno/bull.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Mobs/Xeno/bull.yml
@@ -11,7 +11,7 @@
   description: A heavy charging xeno with a brutal forward rush.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-bull
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _CMU14/Mobs/Xenonids/Bull/bull.rsi
   - type: MobState
@@ -101,7 +101,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
   - type: FixedIdentity
-    name: cm-job-name-xeno-bull
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT2
   - type: RMCActionOrder

--- a/Resources/Prototypes/_CMU14/Entities/Mobs/Xeno/warlock.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Mobs/Xeno/warlock.yml
@@ -11,7 +11,7 @@
   description: A psychic xeno that crushes minds and shields itself with plasma.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-warlock
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _CMU14/Mobs/Xenonids/Warlock/warlock.rsi
   - type: MobState
@@ -95,7 +95,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.5
   - type: FixedIdentity
-    name: cm-job-name-xeno-warlock
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT3
   - type: RMCActionOrder

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Administration/AU14JobCivilianColonyAdminAssistant.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Administration/AU14JobCivilianColonyAdminAssistant.yml
@@ -81,7 +81,7 @@
 - type: entity
   parent: CMSpawnPointJobBase
   id: AU14SpawnPointCivilianColonyAdminAssistant
-  name: Spawn Point Colony Administrative Assistant
+  name: Spawn Point Colony Deputy Administrator
   components:
   - type: SpawnPoint
     job_id: AU14JobCivilianColonyAdminAssistant

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Ranks/Civilian/Civilian.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Ranks/Civilian/Civilian.yml
@@ -11,13 +11,13 @@
 
 - type: rank
   id: AU14RankColonySeniorAdminAssistant
-  name: Senior Assistant
-  prefix: Sn. Assist.
+  name: Senior Deputy Administrator
+  prefix: Sr. Dep. Admin.
 
 - type: rank
   id: AU14RankColonyAdminAssistant
-  name: Assistant
-  prefix: Assist.
+  name: Deputy Administrator
+  prefix: Dep. Admin.
 
 # Diplomatic
 - type: rank

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/base_xeno.yml
@@ -249,7 +249,7 @@
     makeSentient: true
     allowSpeech: true
     allowMovement: true
-    name: cm-xeno-name
+    name: cmu-job-name-xeno-unknown
     description: cm-xeno-description
     raffle:
       settings: short
@@ -384,7 +384,12 @@
   - type: XenoRankNames
   - type: Blindable
   - type: FixedIdentity
-    name: cm-xeno-name
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
+  - type: FixedDescription
+    description: rmc-xeno-unknown-description
     whitelist:
       components:
       - Marine

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/boiler.yml
@@ -15,7 +15,7 @@
     guides:
     - RMCGuideRoleBoiler
   - type: GhostRole
-    name: cm-job-name-xeno-boiler
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Boiler/boiler.rsi # AU14-Edit
   - type: Fixtures
@@ -182,7 +182,7 @@
     enabled: false
   - type: XenoToggleChargingStop
   - type: FixedIdentity
-    name: cm-job-name-xeno-boiler
+    name: cmu-job-name-xeno-unknown
   - type: RMCActionOrder
     id: CMXenoBoiler
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/burrower.yml
@@ -16,7 +16,7 @@
     guides:
     - RMCGuideRoleBurrower
   - type: GhostRole
-    name: cm-job-name-xeno-burrower
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Burrower/burrower.rsi # AU14-Edit
   - type: MobState
@@ -149,7 +149,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
   - type: FixedIdentity
-    name: cm-job-name-xeno-burrower
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT2
   - type: VentCrawler

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -13,7 +13,7 @@
   components:
   - type: CanBuildThickFromConstructNode
   - type: GhostRole
-    name: cm-job-name-xeno-carrier
+    name: cmu-job-name-xeno-unknown
   - type: MobState
     allowedStates:
     - Alive
@@ -122,7 +122,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
   - type: FixedIdentity
-    name: cm-job-name-xeno-carrier
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT2
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -15,7 +15,7 @@
     guides:
     - RMCGuideRoleCrusher
   - type: GhostRole
-    name: cm-job-name-xeno-crusher
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Crusher/crusher.rsi # AU14-Edit
     scale: 1.3, 1.3
@@ -151,7 +151,7 @@
     value: 0.7
   - type: TantrumSpeedBuff
   - type: FixedIdentity
-    name: cm-job-name-xeno-crusher
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT3
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/defender.yml
@@ -12,7 +12,7 @@
   description: An alien with an armored crest.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-defender
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Defender/defender.rsi # AU14-Edit
   - type: MobState
@@ -127,7 +127,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.1
   - type: FixedIdentity
-    name: cm-job-name-xeno-defender
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT1
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/despoiler.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/despoiler.yml
@@ -11,7 +11,7 @@
   description: A massive, hunched xenomorph with hyper-pressurized acid sacs lining its spine. Steam hisses from cracks in its carapace.
   components:
   - type: GhostRole
-    name: rmc-xeno-despoiler-name
+    name: cmu-job-name-xeno-unknown
     description: rmc-xeno-despoiler-description
   - type: Sprite
     sprite: _RMC14/Mobs/Xenonids/Despoiler/despoiler.rsi
@@ -167,7 +167,7 @@
       types:
         Heat: 2
   - type: FixedIdentity
-    name: rmc-xeno-despoiler-name
+    name: cmu-job-name-xeno-unknown
   - type: RMCActionOrder
     id: RMCXenoDespoiler
   - type: IntelRecoverCorpseObjectiveOnDeath

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/drone.yml
@@ -13,7 +13,7 @@
   description: An alien drone.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-drone
+    name: cmu-job-name-xeno-unknown
   - type: MobState
     allowedStates:
     - Alive
@@ -126,7 +126,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.1
   - type: FixedIdentity
-    name: cm-job-name-xeno-drone
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT1
   - type: CMUXenoZJump

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/fun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/fun.yml
@@ -14,7 +14,7 @@
     evolvesTo: [ ]
   - type: XenoHidden
   - type: FixedIdentity
-    name: rmc-rouny
+    name: cmu-job-name-xeno-unknown
 
 - type: entity
   parent:
@@ -31,7 +31,7 @@
     evolvesTo: [ ]
   - type: XenoHidden
   - type: FixedIdentity
-    name: rmc-wehny
+    name: cmu-job-name-xeno-unknown
 
 - type: entity
   parent:
@@ -173,4 +173,4 @@
         - XenoHeavy
   - type: XenoHidden
   - type: FixedIdentity
-    name: rmc-lesser-carrier
+    name: cmu-job-name-xeno-unknown

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/hivelord.yml
@@ -12,7 +12,7 @@
   description: A builder of really big hives.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-hivelord
+    name: cmu-job-name-xeno-unknown
   - type: MobState
     allowedStates:
     - Alive
@@ -116,7 +116,7 @@
   - type: XenoInhands
     prefix: hivelord
   - type: FixedIdentity
-    name: cm-job-name-xeno-hivelord
+    name: cmu-job-name-xeno-unknown
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
   - type: RMCSurgeryXenoHeart

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/king.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/king.yml
@@ -10,7 +10,7 @@
   description: The end of the line.
   components:
   - type: GhostRole
-    name: rmc-job-name-xeno-king
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/King/king.rsi # AU14-Edit
   - type: MobState
@@ -132,7 +132,7 @@
   - type: RMCXenoDamageVisuals
     prefix: king
   - type: FixedIdentity
-    name: rmc-job-name-xeno-king
+    name: cmu-job-name-xeno-unknown
   - type: TacticalMapIcon
     icon:
       sprite: /Textures/_RMC14/Interface/map_blips.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/larva.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/larva.yml
@@ -10,7 +10,7 @@
     guides:
     - RMCGuideRoleDrone
   - type: GhostRole
-    name: cm-job-name-xeno-larva
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Larva/larva.rsi # AU14-Edit
   - type: FiremanCarriable
@@ -104,7 +104,7 @@
       4: rmc-xeno-elder-larva
       5: rmc-xeno-elder-larva
   - type: FixedIdentity
-    name: cm-job-name-xeno-larva
+    name: cmu-job-name-xeno-unknown
   - type: VentCrawler
     ventCrawlIcon: larva
   - type: RMCActionOrder

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lesser_drone.yml
@@ -10,7 +10,7 @@
   description: An alien drone. Looks... smaller.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-lesser-drone
+    name: cmu-job-name-xeno-unknown
     description: roles-lesser-drone-description
     raffle:
       settings: short
@@ -144,7 +144,7 @@
   - type: XenoInhands
     prefix: lesser
   - type: FixedIdentity
-    name: cm-job-name-xeno-lesser-drone
+    name: cmu-job-name-xeno-unknown
   - type: VentCrawler
     ventCrawlIcon: lesser
   - type: RMCActionOrder

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/lurker.yml
@@ -12,7 +12,7 @@
   description: A beefy, fast alien with sharp claws.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-lurker
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Lurker/lurker.rsi # AU14-Edit
   - type: MobState
@@ -116,7 +116,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
   - type: FixedIdentity
-    name: cm-job-name-xeno-lurker
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT2
   - type: CMUXenoZJump

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/parasite.yml
@@ -141,7 +141,7 @@
       4: rmc-xeno-ancient-parasite
       5: rmc-xeno-prime-parasite
   - type: FixedIdentity
-    name: cm-job-name-xeno-parasite-xeno
+    name: cmu-job-name-xeno-unknown
     whitelist:
       components:
       - Xeno

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/praetorian.yml
@@ -12,7 +12,7 @@
   description: A huge, looming beast of an alien.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-praetorian
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Praetorian/praetorian.rsi # AU14-Edit
   - type: MobState
@@ -140,7 +140,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.7
   - type: FixedIdentity
-    name: cm-job-name-xeno-praetorian
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT3
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -305,7 +305,7 @@
     enabled: false
   - type: XenoToggleChargingStop
   - type: FixedIdentity
-    name: cm-job-name-xeno-queen
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartTQ
   - type: RMCTrackable

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/ravager.yml
@@ -15,7 +15,7 @@
     guides:
     - RMCGuideRoleRavager
   - type: GhostRole
-    name: cm-job-name-xeno-ravager
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Ravager/ravager.rsi # AU14-Edit
     layers:
@@ -156,7 +156,7 @@
       sprite: /Textures/_RMC14/Interface/map_blips.rsi
       state: ravager
   - type: FixedIdentity
-    name: cm-job-name-xeno-ravager
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT3
 

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/runner.yml
@@ -149,7 +149,7 @@
   - type: MobCollision
     minimumSpeedModifier: 0.1
   - type: FixedIdentity
-    name: cm-job-name-xeno-runner
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT1
   - type: CMUXenoZJump

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/sentinel.yml
@@ -12,7 +12,7 @@
   description: A slithery, spitting kind of alien.
   components:
   - type: GhostRole
-    name: cm-job-name-xeno-sentinel
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Sentinel/sentinel.rsi # AU14-Edit
   - type: MobState
@@ -99,7 +99,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.1
   - type: FixedIdentity
-    name: cm-job-name-xeno-sentinel
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT1
   - type: VentCrawler

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/spitter.yml
@@ -15,7 +15,7 @@
     guides:
     - RMCGuideRoleSpitter
   - type: GhostRole
-    name: cm-job-name-xeno-spitter
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Spitter/spitter.rsi #AU14-Edit
   - type: MobState
@@ -138,7 +138,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
   - type: FixedIdentity
-    name: cm-job-name-xeno-spitter
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT2
   - type: VentCrawler

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/warrior.yml
@@ -14,7 +14,7 @@
     guides:
     - RMCGuideRoleWarrior
   - type: GhostRole
-    name: cm-job-name-xeno-warrior
+    name: cmu-job-name-xeno-unknown
   - type: Sprite
     sprite: _AU14/Mobs/Xenos/Warrior/warrior.rsi # AU14-Edit
   - type: MobState
@@ -126,7 +126,7 @@
   - type: IntelRecoverCorpseObjectiveOnDeath
     value: 0.2
   - type: FixedIdentity
-    name: cm-job-name-xeno-warrior
+    name: cmu-job-name-xeno-unknown
   - type: RMCSurgeryXenoHeart
     item: RMCOrganXenoHeartT2
   - type: RMCActionOrder

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Base/base_structure.yml
@@ -32,6 +32,11 @@
   - type: Corrodible
     isCorrodible: false
   - type: CMIconSmooth
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: MeleeReceivedMultiplier
     otherMultiplier: 8.2
   - type: XenoConstructionSupport

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/vehicle_supply.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/vehicle_supply.yml
@@ -356,6 +356,45 @@
       - RMCAPCFlareLauncher
       - RMCAPCFreightStorage
       - RMCAPCWheel
+    - name: M577 APC 'Weyland' (WY)
+      vehicle: VehicleAPCPMC
+      group: vehicle-apc
+      loadoutCategories:
+      - id: primary
+        name: Primary
+        options:
+        - id: RMCAPCDualCannon
+          name: dual cannon
+          item: RMCAPCDualCannon
+          slot: primary
+      - id: secondary
+        name: Secondary
+        options:
+        - id: RMCAPCFrontCannon
+          name: frontal cannon
+          item: RMCAPCFrontCannon
+          slot: secondary
+      - id: wheels
+        name: Wheels
+        options:
+        - id: RMCAPCWheel
+          name: wheel
+          item: RMCAPCWheel
+          slot: wheel-1
+      - id: support
+        name: Support
+        options:
+        - id: RMCAPCFlareLauncher
+          name: flare launcher
+          item: RMCAPCFlareLauncher
+          slot: support
+      hardpoints:
+      - RMCAPCDualCannon
+      - RMCAPCFrontCannon
+      - RMCAPCCommsRelay
+      - RMCAPCFlareLauncher
+      - RMCAPCFreightStorage
+      - RMCAPCWheel
     - name: ZSL-68 APC (UPP)
       vehicle: VehicleSPPAPC
       group: vehicle-apc
@@ -520,7 +559,7 @@
       - VehicleTankRocketLauncher
       - VehicleTankFlareModule
       - VehicleTankArtilleryModule
-    - name: M34A2 Longstreet 'Yutani'
+    - name: M34A2 Longstreet 'Yutani' (WY)
       vehicle: VehicleTankPMC
       group: vehicle-tank
       loadoutCategories:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_base_hive.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_base_hive.yml
@@ -2,6 +2,11 @@
   abstract: true
   id: BaseHiveStructure
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: GuideHelp
     guides:
     - RMCGuideHiveStructures
@@ -44,6 +49,11 @@
   abstract: true
   id: BaseHiveStructureNode
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: GuideHelp
     guides:
     - RMCGuideHiveStructures

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_deployed_traps.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_deployed_traps.yml
@@ -3,6 +3,11 @@
   name: xeno trap
   description: A resin trap laid by a Trapper.
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: DeployTrapsBlocker
   - type: Transform
     anchored: true

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_egg.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_egg.yml
@@ -8,6 +8,11 @@
     snap:
     - Wall
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: Appearance
   - type: Item
     size: Ginormous
@@ -96,6 +101,11 @@
     snap:
     - Wall
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: Item
     size: Ginormous
   - type: Transform

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_floor_resin.yml
@@ -6,6 +6,11 @@
     snap:
     - Wall
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: Transform
     anchored: true
   - type: Physics

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_fruit.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_fruit.yml
@@ -9,6 +9,11 @@
     snap:
     - Wall
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: Appearance
   - type: Fixtures
     fixtures:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_nest.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_nest.yml
@@ -7,9 +7,14 @@
     snap:
     - Wall
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: Physics
     bodyType: Static
-  - type: Appearance  
+  - type: Appearance
   - type: Sprite
     sprite: _RMC14/Structures/Xenos/xeno_weeds.rsi
     state: nest_overlay

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_resin_hole.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_resin_hole.yml
@@ -7,6 +7,11 @@
     snap:
     - Wall
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: Appearance
   - type: GuideHelp
     guides:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/xeno_weeds.yml
@@ -7,6 +7,11 @@
     snap:
     - Wall
   components:
+  - type: FixedIdentity
+    name: cmu-job-name-xeno-unknown
+    whitelist:
+      components:
+      - Marine
   - type: Transform
     anchored: true
   - type: Physics

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -208,15 +208,6 @@
         reductionDecreaseRate: 0
         durationPerUnit: 8
         additive: true
-      - !type:GenericStatusEffect
-        conditions:
-        - !type:ReagentThreshold
-          min: 110
-        key: Unconscious
-        component: RMCUnconscious
-        time: 10 #Yes, it's this much.
-        type: Add
-        refresh: true
 
 - type: reagent
   parent: [ CMReagentMedicine, Kelotane ]

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
@@ -416,3 +416,30 @@
     - offset: 1.5,0
       radius: 0.7
       interiorCoords: 4.45,1.7
+
+- type: entity
+  parent: VehicleAPCBase
+  id: VehicleAPCPMC
+  name: Weyland-Yutani armored personnel carrier
+  description: An armored personnel carrier operated by Weyland-Yutani's private military contractors.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Structures/Vehicles/apc.rsi
+    layers:
+    - map: [ base ]
+      sprite: _RMC14/Structures/Vehicles/apc_pmc.rsi
+      state: hull_wy
+    - map: [ damaged_frame ]
+      state: damaged_frame
+      visible: false
+    - map: [ primary ]
+      state: PRIMARY
+      visible: false
+    - map: [ secondary ]
+      state: SECONDARY
+      visible: false
+    - map: [ support ]
+      state: SUPPORT
+      visible: false
+    - map: [ rmc-wheels ]
+      state: wheels_1


### PR DESCRIPTION
Read changelog.

**Changelog**
:cl:
- add: Added the Weyland-Yutani APC. A resprited version of the normal APC.
- add: Humans are now unable to read the names/descriptions of xenos. They will all show up as '???' to mimic the fact that the character knows nothing of/about Xenomorphs. This should hopefully help communicate to new players that we are a first contact server.
- tweak: Inapprovaline no-longer makes you go unconscious with OD (no more CLF cheesing tactic).
- tweak: Renames Admin Assistant to Deputy Administrator to be more inline with its intended role. 