### PR TITLE
feat(clf): net splicing lets a cell tap enemy masts for coverage

### DIFF
--- a/Content.Client/_AU14/Radio/AU14NetSpliceBandDisplay.cs
+++ b/Content.Client/_AU14/Radio/AU14NetSpliceBandDisplay.cs
@@ -1,0 +1,220 @@
+using System.Numerics;
+using Content.Shared._AU14.Radio;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Client._AU14.Radio;
+
+public sealed class AU14NetSpliceBandDisplay : Control
+{
+    private static readonly Color Background = Color.FromHex("#07130A");
+    private static readonly Color Grid = Color.FromHex("#123021");
+    private static readonly Color GridMajor = Color.FromHex("#1B4630");
+    private static readonly Color NoiseFloor = Color.FromHex("#1A4A2C");
+    private static readonly Color Sweep = Color.FromHex("#2F8F55");
+    private static readonly Color DeadMark = Color.FromHex("#2A5C3A");
+    private static readonly Color WeakSignal = Color.FromHex("#3E9E5E");
+    private static readonly Color StrongSignal = Color.FromHex("#8FE86B");
+    private static readonly Color LockLine = Color.FromHex("#57D67A");
+    private static readonly Color Cursor = Color.FromHex("#D8F2C4");
+    private static readonly Color Scanline = Color.FromHex("#000000");
+
+    // one noise sample per band position, re-rolled a few times a second
+    private const int NoiseSamples = 128;
+    private const float NoiseRerollInterval = 0.08f;
+    private const float SweepSeconds = 2.4f;
+
+    [Dependency] private IRobustRandom _random = default!;
+
+    private readonly float[] _noise = new float[NoiseSamples];
+
+    private float _noiseTimer;
+    private float _sweepTimer;
+    private float _pulse;
+
+    private int _bandSize = 100;
+    private int _cursor = 1;
+    private List<AU14NetSpliceReading> _readings = new();
+    private List<int> _locked = new();
+
+    public AU14NetSpliceBandDisplay()
+    {
+        IoCManager.InjectDependencies(this);
+        MinSize = new Vector2(0, 150);
+        HorizontalExpand = true;
+        RollNoise();
+    }
+
+    public void SetBand(int bandSize, List<AU14NetSpliceReading> readings, List<int> locked)
+    {
+        _bandSize = Math.Max(1, bandSize);
+        _readings = readings;
+        _locked = locked;
+    }
+
+    public void SetCursor(int position)
+    {
+        _cursor = position;
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+
+        _sweepTimer = (_sweepTimer + args.DeltaSeconds) % SweepSeconds;
+        _pulse += args.DeltaSeconds;
+        _noiseTimer += args.DeltaSeconds;
+
+        if (_noiseTimer < NoiseRerollInterval)
+            return;
+
+        _noiseTimer = 0f;
+        RollNoise();
+    }
+
+    private void RollNoise()
+    {
+        for (var i = 0; i < NoiseSamples; i++)
+            _noise[i] = _random.NextFloat();
+    }
+
+    protected override void Draw(DrawingHandleScreen handle)
+    {
+        var width = PixelWidth;
+        var height = PixelHeight;
+
+        if (width <= 0 || height <= 0)
+            return;
+
+        handle.DrawRect(PixelSizeBox, Background);
+
+        var floorY = height - 12f;
+        var barMax = floorY - 10f;
+
+        DrawGrid(handle, width, floorY);
+        DrawNoiseFloor(handle, width, floorY);
+        DrawSweep(handle, width, floorY);
+        DrawLocks(handle, width, floorY);
+        DrawReadings(handle, width, floorY, barMax);
+        DrawCursor(handle, width, height, floorY);
+        DrawScanlines(handle, width, height);
+    }
+
+    private void DrawGrid(DrawingHandleScreen handle, float width, float floorY)
+    {
+        for (var tick = 10; tick < _bandSize; tick += 10)
+        {
+            var x = ToPixel(tick, width);
+            handle.DrawRect(new UIBox2(x, 0f, x + 1f, floorY), tick % 50 == 0 ? GridMajor : Grid);
+        }
+
+        handle.DrawRect(new UIBox2(0f, floorY, width, floorY + 1f), GridMajor);
+    }
+
+    /// <summary>Receiver hash along the baseline. Purely cosmetic - it never encodes a carrier.</summary>
+    private void DrawNoiseFloor(DrawingHandleScreen handle, float width, float floorY)
+    {
+        var step = MathF.Max(2f, width / NoiseSamples);
+
+        for (var i = 0; i < NoiseSamples; i++)
+        {
+            var x = i * step;
+
+            if (x > width)
+                break;
+
+            var spike = 2f + _noise[i] * 5f;
+            handle.DrawRect(new UIBox2(x, floorY - spike, x + step - 1f, floorY), NoiseFloor);
+        }
+    }
+
+    /// <summary>A receiver sweep running the band on a loop, with a short trail behind it.</summary>
+    private void DrawSweep(DrawingHandleScreen handle, float width, float floorY)
+    {
+        var progress = _sweepTimer / SweepSeconds;
+        var sweepX = progress * width;
+        var trail = width * 0.12f;
+
+        for (var i = 0; i < 6; i++)
+        {
+            var offset = trail * (i / 6f);
+            var x = sweepX - offset;
+
+            if (x < 0f)
+                continue;
+
+            var fade = (1f - i / 6f) * 0.4f;
+            handle.DrawRect(new UIBox2(x - 1f, 0f, x, floorY), Sweep.WithAlpha(fade));
+        }
+
+        if (sweepX <= width)
+            handle.DrawRect(new UIBox2(sweepX - 1f, 0f, sweepX + 1f, floorY), Sweep.WithAlpha(0.65f));
+    }
+
+    private void DrawLocks(DrawingHandleScreen handle, float width, float floorY)
+    {
+        // locked carriers breathe slightly, so a finished stage still reads as live hardware
+        var glow = 0.55f + 0.25f * MathF.Sin(_pulse * 2.2f);
+
+        foreach (var locked in _locked)
+        {
+            var x = ToPixel(locked, width);
+
+            handle.DrawRect(new UIBox2(x - 3f, 0f, x + 4f, floorY), LockLine.WithAlpha(glow * 0.22f));
+            handle.DrawRect(new UIBox2(x - 1f, 0f, x + 2f, floorY), LockLine.WithAlpha(glow));
+            handle.DrawRect(new UIBox2(x - 4f, floorY - 3f, x + 5f, floorY), LockLine);
+        }
+    }
+
+    private void DrawReadings(DrawingHandleScreen handle, float width, float floorY, float barMax)
+    {
+        foreach (var reading in _readings)
+        {
+            var x = ToPixel(reading.Position, width);
+
+            if (reading.Strength <= 0)
+            {
+                // a dead probe still rules that stretch of band out, so it stays on the scope
+                handle.DrawRect(new UIBox2(x - 1f, floorY - 5f, x + 2f, floorY), DeadMark);
+                continue;
+            }
+
+            var fraction = Math.Clamp(reading.Strength / 100f, 0f, 1f);
+            var top = floorY - barMax * fraction;
+            var color = Color.InterpolateBetween(WeakSignal, StrongSignal, fraction);
+
+            handle.DrawRect(new UIBox2(x - 3f, top + 2f, x + 4f, floorY), color.WithAlpha(0.18f));
+            handle.DrawRect(new UIBox2(x - 1f, top, x + 2f, floorY), color);
+            handle.DrawRect(new UIBox2(x - 3f, top, x + 4f, top + 2f), StrongSignal);
+        }
+    }
+
+    private void DrawCursor(DrawingHandleScreen handle, float width, float height, float floorY)
+    {
+        var x = ToPixel(_cursor, width);
+
+        handle.DrawRect(new UIBox2(x - 1f, 0f, x + 1f, height), Cursor.WithAlpha(0.85f));
+
+        // caret at the top so the tuned position is readable at a glance while the sweep is moving
+        for (var i = 0; i < 5; i++)
+            handle.DrawRect(new UIBox2(x - (5f - i), i, x + (6f - i), i + 1f), Cursor);
+
+        handle.DrawRect(new UIBox2(x - 4f, floorY - 2f, x + 5f, floorY + 1f), Cursor);
+    }
+
+    /// <summary>Phosphor scanlines over the top of everything, purely for the CRT look.</summary>
+    private void DrawScanlines(DrawingHandleScreen handle, float width, float height)
+    {
+        for (var y = 0f; y < height; y += 3f)
+            handle.DrawRect(new UIBox2(0f, y, width, y + 1f), Scanline.WithAlpha(0.18f));
+    }
+
+    private float ToPixel(int position, float width)
+    {
+        var fraction = (position - 1f) / Math.Max(1f, _bandSize - 1f);
+
+        return MathF.Round(fraction * (width - 10f)) + 5f;
+    }
+}

--- a/Content.Client/_AU14/Radio/AU14NetSpliceBui.cs
+++ b/Content.Client/_AU14/Radio/AU14NetSpliceBui.cs
@@ -1,0 +1,29 @@
+using Content.Shared._AU14.Radio;
+using Robust.Client.UserInterface;
+
+namespace Content.Client._AU14.Radio;
+
+public sealed class AU14NetSpliceBui : BoundUserInterface
+{
+    [ViewVariables]
+    private AU14NetSpliceWindow? _window;
+
+    public AU14NetSpliceBui(EntityUid owner, Enum uiKey) : base(owner, uiKey) { }
+
+    protected override void Open()
+    {
+        base.Open();
+        _window = this.CreateWindow<AU14NetSpliceWindow>();
+
+        _window.OnProbe += position => SendMessage(new AU14NetSpliceProbeMsg(position));
+        _window.OnLock += position => SendMessage(new AU14NetSpliceLockMsg(position));
+    }
+
+    protected override void UpdateState(BoundUserInterfaceState state)
+    {
+        if (state is not AU14NetSpliceBuiState spliceState)
+            return;
+
+        _window?.UpdateState(spliceState);
+    }
+}

--- a/Content.Client/_AU14/Radio/AU14NetSpliceMeter.cs
+++ b/Content.Client/_AU14/Radio/AU14NetSpliceMeter.cs
@@ -1,0 +1,83 @@
+using System.Numerics;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Shared.Maths;
+using Robust.Shared.Timing;
+
+namespace Content.Client._AU14.Radio;
+
+/// <summary>
+///     Segmented detection meter on the splice panel. Segments light green through amber to red, and the lit
+///     end blinks once the meter is high enough that another missed lock ends the job.
+/// </summary>
+public sealed class AU14NetSpliceMeter : Control
+{
+    private const int Segments = 20;
+    private const float BlinkThreshold = 70f;
+
+    private static readonly Color Empty = Color.FromHex("#141A16");
+    private static readonly Color EmptyBorder = Color.FromHex("#1F2A22");
+    private static readonly Color Low = Color.FromHex("#4FCB6B");
+    private static readonly Color Mid = Color.FromHex("#D69B32");
+    private static readonly Color High = Color.FromHex("#C4453C");
+
+    private float _value;
+    private float _blink;
+
+    public AU14NetSpliceMeter()
+    {
+        MinSize = new Vector2(0, 16);
+        HorizontalExpand = true;
+    }
+
+    public void SetValue(float value)
+    {
+        _value = Math.Clamp(value, 0f, 100f);
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+        _blink += args.DeltaSeconds;
+    }
+
+    protected override void Draw(DrawingHandleScreen handle)
+    {
+        var width = PixelWidth;
+        var height = PixelHeight;
+
+        if (width <= 0 || height <= 0)
+            return;
+
+        var segmentWidth = width / (float) Segments;
+        var lit = (int) MathF.Ceiling(_value / 100f * Segments);
+        var flash = _value >= BlinkThreshold && MathF.Sin(_blink * 8f) > 0f;
+
+        for (var i = 0; i < Segments; i++)
+        {
+            var left = i * segmentWidth;
+            var box = new UIBox2(left + 1f, 0f, left + segmentWidth - 1f, height);
+
+            if (i >= lit)
+            {
+                handle.DrawRect(box, Empty);
+                handle.DrawRect(new UIBox2(box.Left, box.Bottom - 1f, box.Right, box.Bottom), EmptyBorder);
+                continue;
+            }
+
+            var fraction = i / (float) (Segments - 1);
+
+            var color = fraction switch
+            {
+                < 0.5f => Color.InterpolateBetween(Low, Mid, fraction / 0.5f),
+                _ => Color.InterpolateBetween(Mid, High, (fraction - 0.5f) / 0.5f),
+            };
+
+            // only the leading segments blink, so the meter still reads as a level rather than strobing
+            if (flash && i >= lit - 3)
+                color = color.WithAlpha(0.35f);
+
+            handle.DrawRect(box, color);
+        }
+    }
+}

--- a/Content.Client/_AU14/Radio/AU14NetSpliceWindow.cs
+++ b/Content.Client/_AU14/Radio/AU14NetSpliceWindow.cs
@@ -1,0 +1,347 @@
+using System.Collections.Generic;
+using System.Numerics;
+using Content.Shared._AU14.Radio;
+using Robust.Client.Graphics;
+using Robust.Client.UserInterface;
+using Robust.Client.UserInterface.Controls;
+using Robust.Client.UserInterface.CustomControls;
+using Robust.Shared.Maths;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Client._AU14.Radio;
+
+/// <summary>
+///     The splice panel, laid out as the hand-built band scope the kit's description says it is. Built in
+///     code rather than XAML because the scope and the detection meter are custom-drawn controls.
+///
+///     Colours follow the AN/PRC panel: dark chassis, green phosphor readouts, blue-grey chrome.
+/// </summary>
+public sealed class AU14NetSpliceWindow : DefaultWindow
+{
+    private static readonly Color Chassis = Color.FromHex("#0E0F13");
+    private static readonly Color PanelFill = Color.FromHex("#181A20");
+    private static readonly Color PanelBorder = Color.FromHex("#343846");
+    private static readonly Color ScopeBorder = Color.FromHex("#245236");
+    private static readonly Color ScopeFill = Color.FromHex("#07130A");
+    private static readonly Color Chrome = Color.FromHex("#C8D2E8");
+    private static readonly Color Muted = Color.FromHex("#687A9A");
+    private static readonly Color Phosphor = Color.FromHex("#4A7A55");
+    private static readonly Color PhosphorBright = Color.FromHex("#8FE86B");
+    private static readonly Color Danger = Color.FromHex("#C4453C");
+    private static readonly Color Caution = Color.FromHex("#D69B32");
+    private static readonly Color Calm = Color.FromHex("#4FCB6B");
+
+    public event Action<int>? OnProbe;
+    public event Action<int>? OnLock;
+
+    private readonly AU14NetSpliceBandDisplay _band;
+    private readonly AU14NetSpliceMeter _meter;
+    private readonly Slider _tuner;
+    private readonly Label _stageLabel;
+    private readonly Label _probesLabel;
+    private readonly Label _detectionLabel;
+    private readonly Label _positionLabel;
+    private readonly Label _readingLabel;
+    private readonly Label _statusLabel;
+    private readonly Button _probeButton;
+    private readonly Button _lockButton;
+
+    private int _bandSize = 100;
+    private float _statusBlink;
+    private bool _warning;
+
+    public AU14NetSpliceWindow()
+    {
+        Title = Loc.GetString("au14-splice-window-title");
+        MinSize = new Vector2(500, 500);
+        SetSize = new Vector2(520, 560);
+
+        var chassis = new PanelContainer
+        {
+            PanelOverride = new StyleBoxFlat { BackgroundColor = Chassis },
+        };
+
+        AddChild(chassis);
+
+        var root = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Margin = new Thickness(6),
+            SeparationOverride = 5,
+        };
+
+        chassis.AddChild(root);
+
+        // ----- header --------------------------------------------------------------------------------
+
+        _stageLabel = new Label { FontColorOverride = PhosphorBright };
+        _probesLabel = new Label { FontColorOverride = Muted, HorizontalAlignment = HAlignment.Right };
+
+        var headerLeft = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            HorizontalExpand = true,
+            SeparationOverride = 1,
+        };
+
+        headerLeft.AddChild(new Label { Text = "FEEDER JUNCTION", FontColorOverride = Chrome });
+        headerLeft.AddChild(new Label { Text = "TRUNK SPLICE", FontColorOverride = Muted });
+
+        var headerRight = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            SeparationOverride = 1,
+        };
+
+        headerRight.AddChild(_stageLabel);
+        headerRight.AddChild(_probesLabel);
+
+        var headerRow = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Horizontal,
+            Margin = new Thickness(6, 4),
+            SeparationOverride = 6,
+        };
+
+        headerRow.AddChild(headerLeft);
+        headerRow.AddChild(headerRight);
+        root.AddChild(Framed(headerRow, PanelFill, PanelBorder));
+
+        // ----- scope ---------------------------------------------------------------------------------
+
+        _band = new AU14NetSpliceBandDisplay();
+
+        var scopeBox = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Margin = new Thickness(4),
+            SeparationOverride = 2,
+        };
+
+        scopeBox.AddChild(_band);
+        scopeBox.AddChild(BuildScale());
+        root.AddChild(Framed(scopeBox, ScopeFill, ScopeBorder, 2));
+
+        _readingLabel = new Label
+        {
+            Text = Loc.GetString("au14-splice-no-reading"),
+            FontColorOverride = Phosphor,
+            Margin = new Thickness(2, 0),
+        };
+
+        root.AddChild(_readingLabel);
+
+        // ----- detection -----------------------------------------------------------------------------
+
+        _detectionLabel = new Label { FontColorOverride = Calm, HorizontalExpand = true };
+        _statusLabel = new Label { FontColorOverride = Danger, HorizontalAlignment = HAlignment.Right };
+
+        var detectionHeader = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Horizontal,
+            SeparationOverride = 6,
+        };
+
+        detectionHeader.AddChild(_detectionLabel);
+        detectionHeader.AddChild(_statusLabel);
+
+        _meter = new AU14NetSpliceMeter();
+
+        var detectionBox = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Margin = new Thickness(6, 5),
+            SeparationOverride = 4,
+        };
+
+        detectionBox.AddChild(detectionHeader);
+        detectionBox.AddChild(_meter);
+        root.AddChild(Framed(detectionBox, PanelFill, PanelBorder));
+
+        // ----- tuner ---------------------------------------------------------------------------------
+
+        _positionLabel = new Label { FontColorOverride = PhosphorBright };
+
+        _tuner = new Slider
+        {
+            MinValue = 1f,
+            MaxValue = _bandSize,
+            Value = 1f,
+            Rounded = true,
+            HorizontalExpand = true,
+        };
+
+        _tuner.OnValueChanged += _ => UpdateCursor();
+
+        // the lock tolerance is three positions wide, so the slider alone is not enough to aim with
+        var nudges = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Horizontal,
+            SeparationOverride = 3,
+        };
+
+        AddNudge(nudges, "<<", -10);
+        AddNudge(nudges, "<", -1);
+        AddNudge(nudges, ">", 1);
+        AddNudge(nudges, ">>", 10);
+
+        var tunerBox = new BoxContainer
+        {
+            Orientation = BoxContainer.LayoutOrientation.Vertical,
+            Margin = new Thickness(6, 5),
+            SeparationOverride = 4,
+        };
+
+        tunerBox.AddChild(_positionLabel);
+        tunerBox.AddChild(_tuner);
+        tunerBox.AddChild(nudges);
+        root.AddChild(Framed(tunerBox, PanelFill, PanelBorder));
+
+        // ----- actions -------------------------------------------------------------------------------
+
+        _probeButton = new Button
+        {
+            Text = Loc.GetString("au14-splice-probe"),
+            HorizontalExpand = true,
+            Margin = new Thickness(0, 0, 4, 0),
+        };
+
+        _lockButton = new Button
+        {
+            Text = Loc.GetString("au14-splice-lock"),
+            HorizontalExpand = true,
+        };
+
+        _probeButton.OnPressed += _ => OnProbe?.Invoke(CurrentPosition);
+        _lockButton.OnPressed += _ => OnLock?.Invoke(CurrentPosition);
+
+        var actions = new BoxContainer { Orientation = BoxContainer.LayoutOrientation.Horizontal };
+        actions.AddChild(_probeButton);
+        actions.AddChild(_lockButton);
+        root.AddChild(actions);
+
+        var help = new RichTextLabel { HorizontalExpand = true, Margin = new Thickness(2, 4, 2, 0) };
+        help.SetMessage(FormattedMessage.FromMarkupPermissive(Loc.GetString("au14-splice-help")));
+        root.AddChild(help);
+
+        UpdateCursor();
+    }
+
+    private int CurrentPosition => (int) MathF.Round(_tuner.Value);
+
+    private static PanelContainer Framed(Control child, Color fill, Color border, float thickness = 1f)
+    {
+        var panel = new PanelContainer
+        {
+            PanelOverride = new StyleBoxFlat
+            {
+                BackgroundColor = fill,
+                BorderColor = border,
+                BorderThickness = new Thickness(thickness),
+            },
+        };
+
+        panel.AddChild(child);
+
+        return panel;
+    }
+
+    /// <summary>Numeric scale under the scope. Labels rather than drawn text, so the scope needs no font.</summary>
+    private Control BuildScale()
+    {
+        var scale = new BoxContainer { Orientation = BoxContainer.LayoutOrientation.Horizontal };
+
+        for (var i = 0; i <= 4; i++)
+        {
+            scale.AddChild(new Label
+            {
+                Text = (i * 25).ToString(),
+                FontColorOverride = Phosphor,
+                HorizontalAlignment = i switch
+                {
+                    0 => HAlignment.Left,
+                    4 => HAlignment.Right,
+                    _ => HAlignment.Center,
+                },
+                HorizontalExpand = true,
+            });
+        }
+
+        return scale;
+    }
+
+    private void AddNudge(Control parent, string text, int delta)
+    {
+        var button = new Button { Text = text, HorizontalExpand = true };
+
+        button.OnPressed += _ => _tuner.Value = Math.Clamp(CurrentPosition + delta, 1, _bandSize);
+        parent.AddChild(button);
+    }
+
+    private void UpdateCursor()
+    {
+        _band.SetCursor(CurrentPosition);
+        _positionLabel.Text = Loc.GetString("au14-splice-position", ("position", CurrentPosition));
+    }
+
+    protected override void FrameUpdate(FrameEventArgs args)
+    {
+        base.FrameUpdate(args);
+
+        if (!_warning)
+            return;
+
+        // the warning line blinks in step with the meter's lit end
+        _statusBlink += args.DeltaSeconds;
+        _statusLabel.Visible = MathF.Sin(_statusBlink * 8f) > 0f;
+    }
+
+    public void UpdateState(AU14NetSpliceBuiState state)
+    {
+        if (state.BandSize != _bandSize)
+        {
+            _bandSize = Math.Max(1, state.BandSize);
+            _tuner.MaxValue = _bandSize;
+        }
+
+        _band.SetBand(state.BandSize, state.Readings, state.Locked);
+
+        _stageLabel.Text = Loc.GetString("au14-splice-stage",
+            ("current", Math.Min(state.Stage + 1, state.Carriers)),
+            ("total", state.Carriers));
+
+        _probesLabel.Text = Loc.GetString("au14-splice-probes", ("probes", state.ProbesLeft));
+
+        _detectionLabel.Text = Loc.GetString("au14-splice-detection", ("percent", (int) state.Detection));
+        _meter.SetValue(state.Detection);
+
+        _detectionLabel.FontColorOverride = state.Detection switch
+        {
+            >= 70f => Danger,
+            >= 40f => Caution,
+            _ => Calm,
+        };
+
+        _warning = state.Detection >= 70f;
+        _statusLabel.Text = _warning ? Loc.GetString("au14-splice-warning") : string.Empty;
+        _statusLabel.Visible = _warning;
+
+        _readingLabel.Text = state.Readings.Count == 0
+            ? Loc.GetString("au14-splice-no-reading")
+            : Loc.GetString("au14-splice-reading",
+                ("position", state.Readings[^1].Position),
+                ("strength", state.Readings[^1].Strength));
+
+        _readingLabel.FontColorOverride = state.Readings.Count > 0 && state.Readings[^1].Strength > 0
+            ? PhosphorBright
+            : Phosphor;
+
+        var running = state.Status == AU14NetSpliceStatus.Running;
+
+        _probeButton.Disabled = !running || state.ProbesLeft <= 0;
+        _lockButton.Disabled = !running;
+
+        UpdateCursor();
+    }
+}

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
@@ -31,20 +31,24 @@ public sealed partial class ANPRCRadioSystem
         }
 
         // a planted pack works like a field phone, anyone at it can take the handset.
-        // for a worn pack the verb lives on the wearer instead
-        if (ent.Comp.Planted && ent.Comp.Enabled)
+        // for a worn pack the verb lives on the wearer instead. a relay-only set has
+        // no handset to take - it is a repeater, not a station
+        if (ent.Comp.Planted && ent.Comp.Enabled && !ent.Comp.RelayOnly)
             AddHandsetVerbs(ent, user, ref args);
 
         if (!HasComp<ANPRCRadioUserComponent>(user))
             return;
 
-        args.Verbs.Add(new AlternativeVerb
+        if (!ent.Comp.RelayOnly)
         {
-            Text = Loc.GetString("anprc-verb-open"),
-            IconEntity = GetNetEntity(ent.Owner),
-            Priority = 2,
-            Act = () => _ui.OpenUi(ent.Owner, ANPRCRadioUI.Key, user)
-        });
+            args.Verbs.Add(new AlternativeVerb
+            {
+                Text = Loc.GetString("anprc-verb-open"),
+                IconEntity = GetNetEntity(ent.Owner),
+                Priority = 2,
+                Act = () => _ui.OpenUi(ent.Owner, ANPRCRadioUI.Key, user)
+            });
+        }
 
         if (!ent.Comp.Planted && !ent.Comp.IsEquipped && !_container.IsEntityInContainer(ent.Owner))
         {

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Handset.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Handset.cs
@@ -92,6 +92,9 @@ public sealed partial class ANPRCRadioSystem
         // it if the starting whip lands in the slot after this runs
         UpdatePackVisuals(ent);
 
+        if (ent.Comp.RelayOnly)
+            return;
+
         if (!TrySpawnInContainer(ent.Comp.HandsetId, ent, ANPRCRadioComponent.HandsetContainerId, out var handset))
             return;
 

--- a/Content.Server/_AU14/Radio/AU14NetSpliceSystem.cs
+++ b/Content.Server/_AU14/Radio/AU14NetSpliceSystem.cs
@@ -1,0 +1,629 @@
+using System.Linq;
+using Content.Shared._AU14.Radio;
+using Content.Shared._CMU14.Threats.Mobs.CLF;
+using Content.Shared.Administration.Logs;
+using Content.Shared.Database;
+using Content.Shared.DoAfter;
+using Content.Shared.Examine;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
+using Content.Shared.Popups;
+using Content.Shared.Radio;
+using Content.Shared.Verbs;
+using Robust.Shared.Audio;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+using Robust.Shared.Utility;
+
+namespace Content.Server._AU14.Radio;
+
+/// <summary>
+///     CLF net splicing. A trained insurgent operator uses a splice kit on a mast or array, runs a do-after
+///     to get the feeder junction open, and then plays the band: each hidden trunk carrier has to be found by
+///     probing positions and reading the strength that comes back, then committed to with a lock. Probes are
+///     a fixed budget for the whole job and each one raises a detection meter, so it is a budget problem
+///     rather than a timer. Locking every carrier grafts the cell nets onto the anchor and leaves a tap
+///     behind. Running out of probes or filling the meter alarms the junction instead.
+///
+///     The mast sparks for the duration of the job, and the tap left by a successful one is a visible entity
+///     anyone can pull off (see <see cref="AU14NetSpliceTapComponent"/>).
+/// </summary>
+public sealed partial class AU14NetSpliceSystem : EntitySystem
+{
+    [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private SharedAudioSystem _audio = default!;
+    [Dependency] private SharedTransformSystem _transform = default!;
+    [Dependency] private SharedHandsSystem _hands = default!;
+    [Dependency] private SharedUserInterfaceSystem _ui = default!;
+    [Dependency] private IRobustRandom _random = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private ISharedAdminLogManager _adminLog = default!;
+
+    // all played at the mast rather than to the operator: someone standing next to a junction being worked
+    // should be able to hear it happening
+    private static readonly SoundSpecifier ProbeSound =
+        new SoundPathSpecifier("/Audio/_RMC14/Machines/click.ogg", AudioParams.Default.WithVolume(-6f));
+
+    private static readonly SoundSpecifier CarrierLockedSound =
+        new SoundPathSpecifier("/Audio/_RMC14/Effects/tick.ogg", AudioParams.Default.WithVolume(-2f));
+
+    private static readonly SoundSpecifier MissedLockSound =
+        new SoundPathSpecifier("/Audio/_RMC14/Machines/buzz_two.ogg", AudioParams.Default.WithVolume(-4f));
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AU14NetSpliceKitComponent, AfterInteractEvent>(OnKitAfterInteract);
+        SubscribeLocalEvent<AU14NetSpliceTargetComponent, AU14NetSpliceOpenDoAfterEvent>(OnJunctionOpened);
+        SubscribeLocalEvent<AU14NetSpliceTargetComponent, ExaminedEvent>(OnTargetExamined);
+        SubscribeLocalEvent<AU14NetSplicedComponent, EntityTerminatingEvent>(OnTargetTerminating);
+
+        SubscribeLocalEvent<AU14NetSpliceTapComponent, GetVerbsEvent<AlternativeVerb>>(OnTapVerbs);
+        SubscribeLocalEvent<AU14NetSpliceTapComponent, AU14NetSpliceRemoveDoAfterEvent>(OnTapRemoved);
+        SubscribeLocalEvent<AU14NetSpliceTapComponent, ExaminedEvent>(OnTapExamined);
+        // covers every other way a tap can stop existing - shot off the mast, gibbed, admin-deleted -
+        // so the grafted nets never outlive the hardware holding them up
+        SubscribeLocalEvent<AU14NetSpliceTapComponent, EntityTerminatingEvent>(OnTapTerminating);
+
+        Subs.BuiEvents<AU14NetSpliceInProgressComponent>(AU14NetSpliceUiKey.Key, subs =>
+        {
+            subs.Event<AU14NetSpliceProbeMsg>(OnProbe);
+            subs.Event<AU14NetSpliceLockMsg>(OnLock);
+        });
+    }
+
+    // ----- starting the job ---------------------------------------------------------------------------
+
+    private void OnKitAfterInteract(Entity<AU14NetSpliceKitComponent> ent, ref AfterInteractEvent args)
+    {
+        if (args.Handled || !args.CanReach || args.Target is not { } target)
+            return;
+
+        if (!TryComp(target, out AU14NetSpliceTargetComponent? spliceTarget))
+            return;
+
+        args.Handled = true;
+        var user = args.User;
+
+        // the tap grafts the cell's own nets on, so it is CLF hardware and operator work both
+        if (!HasComp<CLFMemberComponent>(user))
+        {
+            _popup.PopupEntity(Loc.GetString("au14-splice-not-clf"), target, user, PopupType.SmallCaution);
+            return;
+        }
+
+        if (!HasComp<ANPRCRadioUserComponent>(user))
+        {
+            _popup.PopupEntity(Loc.GetString("au14-splice-untrained"), target, user, PopupType.SmallCaution);
+            return;
+        }
+
+        if (HasComp<AU14NetSplicedComponent>(target))
+        {
+            _popup.PopupEntity(Loc.GetString("au14-splice-already-tapped"), target, user, PopupType.SmallCaution);
+            return;
+        }
+
+        if (HasComp<AU14NetSpliceInProgressComponent>(target))
+        {
+            _popup.PopupEntity(Loc.GetString("au14-splice-already-working"), target, user, PopupType.SmallCaution);
+            return;
+        }
+
+        // a failed job costs the window as well as the kit, otherwise a cell with spare kits just retries
+        // through the alarm and the alarm means nothing
+        if (HasComp<AU14NetSpliceAlarmedComponent>(target))
+        {
+            _popup.PopupEntity(Loc.GetString("au14-splice-alarmed"), target, user, PopupType.SmallCaution);
+            return;
+        }
+
+        if (!HasComp<ANPRCRelayAnchorComponent>(target))
+        {
+            _popup.PopupEntity(Loc.GetString("au14-splice-no-feeder"), target, user, PopupType.SmallCaution);
+            return;
+        }
+
+        if (ent.Comp.WorkSound is { } work)
+            _audio.PlayPvs(work, target);
+
+        _popup.PopupEntity(Loc.GetString("au14-splice-opening"), target, user);
+
+        var doAfter = new DoAfterArgs(
+            EntityManager,
+            user,
+            TimeSpan.FromSeconds(spliceTarget.OpenTime),
+            new AU14NetSpliceOpenDoAfterEvent(),
+            target,
+            target,
+            ent.Owner)
+        {
+            NeedHand = true,
+            BreakOnMove = true,
+            BreakOnHandChange = true,
+        };
+
+        _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnJunctionOpened(Entity<AU14NetSpliceTargetComponent> ent, ref AU14NetSpliceOpenDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled || args.Used is not { } kit)
+            return;
+
+        if (!TryComp(kit, out AU14NetSpliceKitComponent? kitComp))
+            return;
+
+        args.Handled = true;
+
+        // somebody else got there first while this one was working
+        if (HasComp<AU14NetSplicedComponent>(ent) || HasComp<AU14NetSpliceInProgressComponent>(ent))
+            return;
+
+        // the kit goes into the junction here and does not come back out. otherwise you could probe until
+        // the meter got dangerous, walk away, and start again for free
+        QueueDel(kit);
+
+        var session = EnsureComp<AU14NetSpliceInProgressComponent>(ent);
+        session.User = args.User;
+        session.Kit = kit;
+        session.TapPrototype = kitComp.TapPrototype;
+        session.Stage = 0;
+        session.Detection = 0f;
+        session.ProbesLeft = ent.Comp.Probes;
+        session.Readings.Clear();
+        session.Locked.Clear();
+        session.Carriers = RollCarriers(ent.Comp);
+        session.NextSpark = _timing.CurTime + TimeSpan.FromSeconds(session.SparkIntervalMin);
+
+        _ui.OpenUi(ent.Owner, AU14NetSpliceUiKey.Key, args.User);
+        PushState((ent.Owner, session), ent.Comp, AU14NetSpliceStatus.Running);
+
+        _adminLog.Add(LogType.Action, LogImpact.Medium,
+            $"{ToPrettyString(args.User):player} opened the feeder junction on {ToPrettyString(ent.Owner)} and started a net splice.");
+    }
+
+    /// <summary>
+    ///     Carriers sit clear of the band edges and clear of each other, so a later stage is never sitting
+    ///     next to one the operator has already found.
+    /// </summary>
+    private List<int> RollCarriers(AU14NetSpliceTargetComponent target)
+    {
+        var margin = target.LockTolerance + 2;
+        var minSeparation = target.CarrierRadius / 2;
+        var carriers = new List<int>();
+
+        for (var i = 0; i < target.Carriers; i++)
+        {
+            var position = 0;
+
+            // bounded: on a crowded band we simply take the last roll rather than spinning
+            for (var attempt = 0; attempt < 24; attempt++)
+            {
+                position = _random.Next(margin, Math.Max(margin + 1, target.BandSize - margin + 1));
+
+                if (carriers.All(c => Math.Abs(c - position) >= minSeparation))
+                    break;
+            }
+
+            carriers.Add(position);
+        }
+
+        return carriers;
+    }
+
+    // ----- the band game ------------------------------------------------------------------------------
+
+    private void OnProbe(Entity<AU14NetSpliceInProgressComponent> ent, ref AU14NetSpliceProbeMsg args)
+    {
+        if (!TryGetSession(ent, args.Actor, out var target))
+            return;
+
+        if (ent.Comp.ProbesLeft <= 0)
+            return;
+
+        var position = Math.Clamp(args.Position, 1, target.BandSize);
+
+        ent.Comp.ProbesLeft--;
+        ent.Comp.Detection += target.ProbeDetection;
+        ent.Comp.Readings.Add(new AU14NetSpliceReading(position, ReadStrength(target, position, CurrentCarrier(ent))));
+
+        _audio.PlayPvs(ProbeSound, ent.Owner);
+
+        // running the band dry without locking every carrier fails the job as well
+        if (ent.Comp.Detection >= 100f || ent.Comp.ProbesLeft <= 0)
+        {
+            FailSplice((ent.Owner, ent.Comp), target,
+                ent.Comp.Detection >= 100f ? "au14-splice-failed-detected" : "au14-splice-failed-probes");
+            return;
+        }
+
+        PushState(ent, target, AU14NetSpliceStatus.Running);
+    }
+
+    private void OnLock(Entity<AU14NetSpliceInProgressComponent> ent, ref AU14NetSpliceLockMsg args)
+    {
+        if (!TryGetSession(ent, args.Actor, out var target))
+            return;
+
+        var position = Math.Clamp(args.Position, 1, target.BandSize);
+        var carrier = CurrentCarrier(ent);
+
+        if (Math.Abs(position - carrier) <= target.LockTolerance)
+        {
+            ent.Comp.Locked.Add(carrier);
+            ent.Comp.Stage++;
+            ent.Comp.Readings.Clear();
+
+            if (ent.Comp.Stage >= ent.Comp.Carriers.Count)
+            {
+                CompleteSplice((ent.Owner, ent.Comp), target);
+                return;
+            }
+
+            _audio.PlayPvs(CarrierLockedSound, ent.Owner);
+
+            _popup.PopupEntity(
+                Loc.GetString("au14-splice-carrier-locked",
+                    ("done", ent.Comp.Stage),
+                    ("total", ent.Comp.Carriers.Count)),
+                ent.Owner,
+                ent.Comp.User);
+
+            PushState(ent, target, AU14NetSpliceStatus.Running);
+            return;
+        }
+
+        // a miss costs probes and most of a detection meter, so guessing is worse than probing again
+        ent.Comp.Detection += target.FailedLockDetection;
+        ent.Comp.ProbesLeft = Math.Max(0, ent.Comp.ProbesLeft - target.FailedLockProbeCost);
+
+        _audio.PlayPvs(MissedLockSound, ent.Owner);
+        Spawn(ent.Comp.SparkEffect, Transform(ent.Owner).Coordinates);
+
+        if (ent.Comp.Detection >= 100f || ent.Comp.ProbesLeft <= 0)
+        {
+            FailSplice((ent.Owner, ent.Comp), target,
+                ent.Comp.Detection >= 100f ? "au14-splice-failed-detected" : "au14-splice-failed-probes");
+            return;
+        }
+
+        PushState(ent, target, AU14NetSpliceStatus.Running);
+    }
+
+    /// <summary>
+    ///     Signal falls off linearly to nothing at <see cref="AU14NetSpliceTargetComponent.CarrierRadius"/>,
+    ///     with slop on top so the meter cannot be read straight off as a distance. Outside the radius the
+    ///     reading is a clean zero, which is what a coarse opening sweep is for.
+    /// </summary>
+    private int ReadStrength(AU14NetSpliceTargetComponent target, int position, int carrier)
+    {
+        var distance = Math.Abs(position - carrier);
+
+        if (distance >= target.CarrierRadius)
+            return 0;
+
+        var raw = 100f * (1f - (float) distance / target.CarrierRadius);
+        var noised = raw + _random.Next(-target.ReadingNoise, target.ReadingNoise + 1);
+
+        return Math.Clamp((int) MathF.Round(noised), 0, 100);
+    }
+
+    private static int CurrentCarrier(Entity<AU14NetSpliceInProgressComponent> ent)
+    {
+        return ent.Comp.Carriers[Math.Clamp(ent.Comp.Stage, 0, ent.Comp.Carriers.Count - 1)];
+    }
+
+    private bool TryGetSession(
+        Entity<AU14NetSpliceInProgressComponent> ent,
+        EntityUid actor,
+        out AU14NetSpliceTargetComponent target)
+    {
+        target = default!;
+
+        // only the operator who opened the junction is working it
+        if (actor != ent.Comp.User)
+            return false;
+
+        if (ent.Comp.Stage >= ent.Comp.Carriers.Count)
+            return false;
+
+        return TryComp(ent.Owner, out target!);
+    }
+
+    // ----- landing it, or not -------------------------------------------------------------------------
+
+    private void CompleteSplice(Entity<AU14NetSpliceInProgressComponent> ent, AU14NetSpliceTargetComponent target)
+    {
+        var user = ent.Comp.User;
+
+        CloseSession(ent);
+
+        if (!TryComp(ent.Owner, out ANPRCRelayAnchorComponent? anchor))
+            return;
+
+        // only the nets this tap actually adds are recorded, so pulling it later puts the anchor back
+        // exactly as it was instead of stripping nets the mast owned to begin with
+        var grafted = new HashSet<ProtoId<RadioChannelPrototype>>();
+
+        foreach (var channel in target.Channels)
+        {
+            if (anchor.Channels.Add(channel))
+                grafted.Add(channel);
+        }
+
+        var tap = Spawn(ent.Comp.TapPrototype, Transform(ent.Owner).Coordinates);
+
+        // the prototype is already anchored:true, so Spawn has put it in the snap grid cell. anchoring it
+        // a second time asserts on the duplicate - only reach for it if something spawned it loose
+        var tapXform = Transform(tap);
+
+        if (!tapXform.Anchored)
+            _transform.AnchorEntity(tap, tapXform);
+
+        var tapComp = EnsureComp<AU14NetSpliceTapComponent>(tap);
+        tapComp.Target = ent.Owner;
+        Dirty(tap, tapComp);
+
+        var spliced = EnsureComp<AU14NetSplicedComponent>(ent.Owner);
+        spliced.Tap = tap;
+        spliced.Grafted = grafted;
+        Dirty(ent.Owner, spliced);
+
+        _audio.PlayPvs(new SoundPathSpecifier("/Audio/_RMC14/Effects/tech_notification.ogg"), ent.Owner);
+
+        if (user.IsValid())
+            _popup.PopupEntity(Loc.GetString("au14-splice-success"), ent.Owner, user, PopupType.Medium);
+
+        _adminLog.Add(LogType.Action, LogImpact.High,
+            $"{ToPrettyString(user):player} spliced {ToPrettyString(ent.Owner)}; grafted nets: {string.Join(", ", grafted)}.");
+    }
+
+    private void FailSplice(
+        Entity<AU14NetSpliceInProgressComponent> ent,
+        AU14NetSpliceTargetComponent target,
+        string reason)
+    {
+        var user = ent.Comp.User;
+
+        CloseSession(ent);
+
+        var alarmed = EnsureComp<AU14NetSpliceAlarmedComponent>(ent.Owner);
+        alarmed.RecoverAt = _timing.CurTime + alarmed.RecoverDelay;
+        alarmed.NextSpark = _timing.CurTime;
+        // the buzzer fires once here as part of the failure, so hold the recurring one off a full interval
+        alarmed.NextSound = _timing.CurTime + TimeSpan.FromSeconds(alarmed.SoundIntervalMin);
+
+        _audio.PlayPvs(alarmed.AlarmSound, ent.Owner);
+
+        // a burst rather than the usual single spark, so the moment it goes wrong is visible from a distance
+        var coordinates = Transform(ent.Owner).Coordinates;
+
+        for (var i = 0; i < 3; i++)
+            Spawn(alarmed.SparkEffect, coordinates);
+
+        if (user.IsValid())
+            _popup.PopupEntity(Loc.GetString(reason), ent.Owner, user, PopupType.LargeCaution);
+
+        _adminLog.Add(LogType.Action, LogImpact.Medium,
+            $"{ToPrettyString(user):player} botched a net splice on {ToPrettyString(ent.Owner)} ({reason}); the junction alarmed.");
+    }
+
+    /// <summary>Tears the session down and shuts the panel, whichever way the job ended.</summary>
+    private void CloseSession(Entity<AU14NetSpliceInProgressComponent> ent)
+    {
+        _ui.CloseUi(ent.Owner, AU14NetSpliceUiKey.Key);
+        RemCompDeferred<AU14NetSpliceInProgressComponent>(ent.Owner);
+    }
+
+    private void PushState(
+        Entity<AU14NetSpliceInProgressComponent> ent,
+        AU14NetSpliceTargetComponent target,
+        AU14NetSpliceStatus status)
+    {
+        _ui.SetUiState(
+            ent.Owner,
+            AU14NetSpliceUiKey.Key,
+            new AU14NetSpliceBuiState(
+                target.BandSize,
+                ent.Comp.Stage,
+                ent.Comp.Carriers.Count,
+                ent.Comp.ProbesLeft,
+                MathF.Min(ent.Comp.Detection, 100f),
+                status,
+                new List<AU14NetSpliceReading>(ent.Comp.Readings),
+                new List<int>(ent.Comp.Locked)));
+    }
+
+    // ----- the tap, and taking it off -----------------------------------------------------------------
+
+    private void OnTapVerbs(Entity<AU14NetSpliceTapComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract || args.Hands == null)
+            return;
+
+        var user = args.User;
+
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Text = Loc.GetString("au14-splice-verb-remove"),
+            Priority = 1,
+            Act = () => StartTapRemoval(ent, user),
+        });
+    }
+
+    private void StartTapRemoval(Entity<AU14NetSpliceTapComponent> ent, EntityUid user)
+    {
+        _popup.PopupEntity(Loc.GetString("au14-splice-removing"), ent.Owner, user);
+
+        var doAfter = new DoAfterArgs(
+            EntityManager,
+            user,
+            TimeSpan.FromSeconds(ent.Comp.RemoveTime),
+            new AU14NetSpliceRemoveDoAfterEvent(),
+            ent.Owner,
+            ent.Owner)
+        {
+            BreakOnMove = true,
+        };
+
+        _doAfter.TryStartDoAfter(doAfter);
+    }
+
+    private void OnTapRemoved(Entity<AU14NetSpliceTapComponent> ent, ref AU14NetSpliceRemoveDoAfterEvent args)
+    {
+        if (args.Handled || args.Cancelled)
+            return;
+
+        args.Handled = true;
+
+        UnsplicedTarget(ent);
+
+        // what the finder gets for spotting it. the keying module reads cell traffic until CLF leadership
+        // orders a recrypto, so it is worth taking without being worth the round
+        if (ent.Comp.SalvagedCrypto is { } crypto)
+        {
+            var card = Spawn(crypto, Transform(ent.Owner).Coordinates);
+            _hands.TryPickupAnyHand(args.User, card);
+            _popup.PopupEntity(Loc.GetString("au14-splice-salvaged"), args.User, args.User, PopupType.Medium);
+        }
+        else
+        {
+            _popup.PopupEntity(Loc.GetString("au14-splice-removed"), args.User, args.User);
+        }
+
+        _adminLog.Add(LogType.Action, LogImpact.High,
+            $"{ToPrettyString(args.User):player} pulled the net splice tap off {ToPrettyString(ent.Comp.Target ?? EntityUid.Invalid)}.");
+
+        QueueDel(ent.Owner);
+    }
+
+    /// <summary>Puts the anchor back the way it was: removes exactly the nets this tap grafted on.</summary>
+    private void UnsplicedTarget(Entity<AU14NetSpliceTapComponent> ent)
+    {
+        if (ent.Comp.Target is not { } target || TerminatingOrDeleted(target))
+            return;
+
+        if (!TryComp(target, out AU14NetSplicedComponent? spliced))
+            return;
+
+        if (TryComp(target, out ANPRCRelayAnchorComponent? anchor))
+        {
+            foreach (var channel in spliced.Grafted)
+                anchor.Channels.Remove(channel);
+        }
+
+        RemComp<AU14NetSplicedComponent>(target);
+    }
+
+    private void OnTapTerminating(Entity<AU14NetSpliceTapComponent> ent, ref EntityTerminatingEvent args)
+    {
+        UnsplicedTarget(ent);
+    }
+
+    /// <summary>A mast that dies takes its tap with it, rather than leaving the box anchored in the rubble.</summary>
+    private void OnTargetTerminating(Entity<AU14NetSplicedComponent> ent, ref EntityTerminatingEvent args)
+    {
+        if (!TerminatingOrDeleted(ent.Comp.Tap))
+            QueueDel(ent.Comp.Tap);
+    }
+
+    // ----- examine ------------------------------------------------------------------------------------
+
+    private void OnTargetExamined(Entity<AU14NetSpliceTargetComponent> ent, ref ExaminedEvent args)
+    {
+        if (HasComp<AU14NetSpliceAlarmedComponent>(ent))
+        {
+            args.PushMarkup(Loc.GetString("au14-splice-examine-alarmed"));
+            return;
+        }
+
+        if (HasComp<AU14NetSplicedComponent>(ent))
+            args.PushMarkup(Loc.GetString("au14-splice-examine-tapped"));
+    }
+
+    private void OnTapExamined(Entity<AU14NetSpliceTapComponent> ent, ref ExaminedEvent args)
+    {
+        args.PushMarkup(Loc.GetString("au14-splice-examine-tap"));
+    }
+
+    // ----- ticking ------------------------------------------------------------------------------------
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var now = _timing.CurTime;
+
+        // a job in progress sparks the whole time it is running, and breaks off if the operator wanders
+        var sessions = EntityQueryEnumerator<AU14NetSpliceInProgressComponent, AU14NetSpliceTargetComponent>();
+        while (sessions.MoveNext(out var uid, out var session, out var target))
+        {
+            if (!InWorkRange(session.User, uid, target.WorkRange))
+            {
+                if (session.User.IsValid())
+                    _popup.PopupEntity(Loc.GetString("au14-splice-abandoned"), uid, session.User, PopupType.MediumCaution);
+
+                _ui.CloseUi(uid, AU14NetSpliceUiKey.Key);
+                RemCompDeferred<AU14NetSpliceInProgressComponent>(uid);
+                continue;
+            }
+
+            if (now < session.NextSpark)
+                continue;
+
+            session.NextSpark = now + TimeSpan.FromSeconds(
+                _random.NextFloat(session.SparkIntervalMin, session.SparkIntervalMax));
+
+            Spawn(session.SparkEffect, Transform(uid).Coordinates);
+        }
+
+        var alarmed = EntityQueryEnumerator<AU14NetSpliceAlarmedComponent>();
+        while (alarmed.MoveNext(out var uid, out var alarm))
+        {
+            if (now >= alarm.RecoverAt)
+            {
+                RemCompDeferred<AU14NetSpliceAlarmedComponent>(uid);
+                continue;
+            }
+
+            // sparks and buzzer run on separate irregular timers: the fault should look continuous without
+            // sounding like a metronome to anyone standing near it
+            if (now >= alarm.NextSpark)
+            {
+                alarm.NextSpark = now + TimeSpan.FromSeconds(
+                    _random.NextFloat(alarm.SparkIntervalMin, alarm.SparkIntervalMax));
+
+                Spawn(alarm.SparkEffect, Transform(uid).Coordinates);
+            }
+
+            if (now < alarm.NextSound)
+                continue;
+
+            alarm.NextSound = now + TimeSpan.FromSeconds(
+                _random.NextFloat(alarm.SoundIntervalMin, alarm.SoundIntervalMax));
+
+            _audio.PlayPvs(alarm.AlarmSound, uid);
+        }
+    }
+
+    private bool InWorkRange(EntityUid user, EntityUid target, float range)
+    {
+        if (!Exists(user) || !Exists(target))
+            return false;
+
+        var userXform = Transform(user);
+        var targetXform = Transform(target);
+
+        if (userXform.MapID != targetXform.MapID)
+            return false;
+
+        var distance = (_transform.GetWorldPosition(userXform) - _transform.GetWorldPosition(targetXform)).Length();
+
+        return distance <= range;
+    }
+}

--- a/Content.Shared/_AU14/Insurgency/Sapper/SapperWorkbenchComponent.cs
+++ b/Content.Shared/_AU14/Insurgency/Sapper/SapperWorkbenchComponent.cs
@@ -47,6 +47,11 @@ public sealed partial class SapperWorkbenchComponent : Component
         // The siphon rig moved into the recipe list (was: apply a cable coil to the bench).
         new("AU14SapperSiphonRig", "Siphon rig", 6f, new() { { "CMSteel", 9 }, { "RMCPlastic", 6 } },
             new() { Cable(30), AnyElectronics(), PowerCell() }),
+        // Comms hardware.
+        new("AU14CLFNetSpliceKit", "Net splice kit", 8f, new() { { "CMSteel", 12 }, { "RMCPlastic", 9 } },
+            new() { Cable(30), AnyElectronics(), AnyElectronics() }),
+        new("AU14CLFClandestineRelay", "Clandestine relay set", 6f, new() { { "CMSteel", 9 }, { "RMCPlastic", 6 } },
+            new() { Cable(20), AnyElectronics(), PowerCell() }),
         // The "Switch" illegal fire-selector chip. Deliberately plasteel-hungry: it turns any rifle
         // into a bullet hose, so the cost is the whole balance lever.
         new("AU14AttachmentSwitch", "Switch (auto-sear chip)", 8f, new() { { "CMPlasteel", 40 } },

--- a/Content.Shared/_AU14/Radio/ANPRCRadioComponent.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCRadioComponent.cs
@@ -28,6 +28,9 @@ public sealed partial class ANPRCRadioComponent : Component
     [DataField]
     public string RequiredSlot = "back";
 
+    [DataField]
+    public bool RelayOnly;
+
     [DataField, AutoNetworkedField]
     public bool IsEquipped = false;
 

--- a/Content.Shared/_AU14/Radio/AU14NetSpliceComponents.cs
+++ b/Content.Shared/_AU14/Radio/AU14NetSpliceComponents.cs
@@ -1,0 +1,244 @@
+using Content.Shared.DoAfter;
+using Content.Shared.Radio;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._AU14.Radio;
+
+/// <summary>
+///     A fixed mast or array whose feeder junction the CLF can splice a tap into, putting the cell nets on
+///     it at its own range and on its own power. All of the per-target balance lives here, so a field mast
+///     and a site array can be very different jobs.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AU14NetSpliceTargetComponent : Component
+{
+    /// <summary>Nets grafted onto the anchor when a splice lands. Removed again when the tap comes out.</summary>
+    [DataField]
+    public HashSet<ProtoId<RadioChannelPrototype>> Channels = new()
+    {
+        "radioCLF",
+        "radioCLFCommand",
+    };
+
+    /// <summary>How many trunk carriers have to be found and locked before the tap takes.</summary>
+    [DataField]
+    public int Carriers = 3;
+
+    /// <summary>Width of the band the carriers hide in. Positions run 1..BandSize.</summary>
+    [DataField]
+    public int BandSize = 100;
+
+    /// <summary>
+    ///     How far either side of a carrier still reads as signal. This sets the opening sweep: with a
+    ///     100-wide band and a 30 radius, probes at 15/45/75 always touch a carrier.
+    /// </summary>
+    [DataField]
+    public int CarrierRadius = 30;
+
+    /// <summary>How close a lock has to be to take.</summary>
+    [DataField]
+    public int LockTolerance = 4;
+
+    /// <summary>Random slop on every strength reading, so the meter cannot be read off as an exact distance.</summary>
+    [DataField]
+    public int ReadingNoise = 6;
+
+    /// <summary>Total probes for the whole job, shared across every carrier.</summary>
+    [DataField]
+    public int Probes = 32;
+
+    /// <summary>
+    ///     Detection added per probe. Kept low on purpose: searching the band carefully should not be the
+    ///     thing that gets the operator caught. Guessing at a lock is.
+    /// </summary>
+    [DataField]
+    public float ProbeDetection = 1.5f;
+
+    /// <summary>Detection added by a lock attempt that misses, plus <see cref="FailedLockProbeCost"/> probes.</summary>
+    [DataField]
+    public float FailedLockDetection = 30f;
+
+    [DataField]
+    public int FailedLockProbeCost = 2;
+
+    /// <summary>How long forcing the junction cover takes before the set can be worked at all.</summary>
+    [DataField]
+    public float OpenTime = 8f;
+
+    /// <summary>How far the splicer can get from the junction before the job breaks off.</summary>
+    [DataField]
+    public float WorkRange = 1.5f;
+}
+
+/// <summary>
+///     Live state of one splice attempt, sitting on the mast being worked. It holds the hidden carrier
+///     positions, so it is server-only and never networked: the client is not supposed to know where they
+///     are. The mast throws sparks for as long as this is on it, which is the window a passing marine has
+///     to notice the job.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AU14NetSpliceInProgressComponent : Component
+{
+    [ViewVariables]
+    public EntityUid User;
+
+    [ViewVariables]
+    public EntityUid Kit;
+
+    /// <summary>Copied off the kit as it goes into the junction, since the kit is gone by the time the job
+    /// finishes.</summary>
+    [ViewVariables]
+    public EntProtoId TapPrototype = "AU14CLFNetSpliceTap";
+
+    /// <summary>Hidden carrier positions, one per stage.</summary>
+    [ViewVariables]
+    public List<int> Carriers = new();
+
+    /// <summary>Which carrier is being hunted now. Equals Carriers.Count once the job is done.</summary>
+    [ViewVariables]
+    public int Stage;
+
+    [ViewVariables]
+    public int ProbesLeft;
+
+    [ViewVariables]
+    public float Detection;
+
+    /// <summary>Readings taken against the current carrier. Cleared each time one is locked.</summary>
+    [ViewVariables]
+    public List<AU14NetSpliceReading> Readings = new();
+
+    /// <summary>Carriers already locked, in order, for the readout.</summary>
+    [ViewVariables]
+    public List<int> Locked = new();
+
+    [ViewVariables]
+    public TimeSpan NextSpark;
+
+    /// <summary>Sparks land on a random gap in this range. A fixed metronome reads as a broken animation.</summary>
+    [DataField]
+    public float SparkIntervalMin = 1.1f;
+
+    [DataField]
+    public float SparkIntervalMax = 2.6f;
+
+    [DataField]
+    public EntProtoId SparkEffect = "RMCEffectWeldingSparks";
+}
+
+/// <summary>
+///     A mast that currently has a tap on it. Points at the tap entity so removing it puts the anchor back
+///     exactly as it was, and stops a second tap being stacked on the same junction.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AU14NetSplicedComponent : Component
+{
+    [DataField]
+    public EntityUid Tap;
+
+    /// <summary>Exactly the channels this tap added, so removing it takes those and nothing else.</summary>
+    [DataField]
+    public HashSet<ProtoId<RadioChannelPrototype>> Grafted = new();
+}
+
+/// <summary>
+///     The physical tap: a junction box wired onto the mast's feeder, sharing the mast's tile. It is meant
+///     to be findable. It is visible, it can be shot, and anyone can pull it off given
+///     <see cref="AU14NetSpliceTapComponent.RemoveTime"/> seconds.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AU14NetSpliceTapComponent : Component
+{
+    /// <summary>The mast this tap is feeding off. Cleared if the mast dies first.</summary>
+    [DataField]
+    public EntityUid? Target;
+
+    /// <summary>How long pulling the tap off takes.</summary>
+    [DataField]
+    public float RemoveTime = 8f;
+
+    /// <summary>
+    ///     Dropped by the tap when it is pulled off, as the reward for finding it. Live cell crypto, good
+    ///     until CLF leadership orders a recrypto, and nothing beyond that.
+    /// </summary>
+    [DataField]
+    public EntProtoId? SalvagedCrypto = "ANPRCFillCardCLF";
+}
+
+/// <summary>
+///     A mast whose junction alarmed on a failed splice. It sparks and buzzes for a few minutes, so the
+///     garrison has something to walk into and read rather than a silent failure.
+/// </summary>
+[RegisterComponent]
+public sealed partial class AU14NetSpliceAlarmedComponent : Component
+{
+    [DataField]
+    public TimeSpan RecoverDelay = TimeSpan.FromSeconds(90);
+
+    /// <summary>Sparks land on a random gap in this range so the fault reads as a fault, not a metronome.</summary>
+    [DataField]
+    public float SparkIntervalMin = 2f;
+
+    [DataField]
+    public float SparkIntervalMax = 6f;
+
+    /// <summary>
+    ///     The buzzer runs on its own much slower timer rather than firing with every spark. A junction that
+    ///     buzzes every few seconds for the whole recovery window is unbearable to stand near.
+    /// </summary>
+    [DataField]
+    public float SoundIntervalMin = 12f;
+
+    [DataField]
+    public float SoundIntervalMax = 22f;
+
+    [DataField]
+    public EntProtoId SparkEffect = "RMCEffectWeldingSparks";
+
+    [DataField]
+    public SoundSpecifier AlarmSound =
+        new SoundPathSpecifier("/Audio/_RMC14/Machines/buzz_two.ogg", AudioParams.Default.WithVolume(-6f));
+
+    [ViewVariables]
+    public TimeSpan RecoverAt;
+
+    [ViewVariables]
+    public TimeSpan NextSpark;
+
+    [ViewVariables]
+    public TimeSpan NextSound;
+}
+
+/// <summary>
+///     The splice kit. Consumed either way: on a success it stays in the junction as the tap, on a failure
+///     it burns out in there.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class AU14NetSpliceKitComponent : Component
+{
+    /// <summary>What gets left bolted to the mast when the job lands.</summary>
+    [DataField]
+    public EntProtoId TapPrototype = "AU14CLFNetSpliceTap";
+
+    /// <summary>Played at the mast when the cover starts coming off, so the job is audible from the start.</summary>
+    [DataField]
+    public SoundSpecifier? WorkSound = new SoundPathSpecifier("/Audio/_RMC14/Machines/hydraulics_1.ogg");
+
+    [DataField]
+    public SoundSpecifier? SuccessSound = new SoundPathSpecifier("/Audio/_RMC14/Effects/tech_notification.ogg");
+}
+
+/// <summary>DoAfter for forcing the junction cover open before the splice can start.</summary>
+[Serializable, NetSerializable]
+public sealed partial class AU14NetSpliceOpenDoAfterEvent : SimpleDoAfterEvent
+{
+}
+
+/// <summary>DoAfter for pulling a tap back off a mast.</summary>
+[Serializable, NetSerializable]
+public sealed partial class AU14NetSpliceRemoveDoAfterEvent : SimpleDoAfterEvent
+{
+}

--- a/Content.Shared/_AU14/Radio/AU14NetSpliceUi.cs
+++ b/Content.Shared/_AU14/Radio/AU14NetSpliceUi.cs
@@ -1,0 +1,79 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._AU14.Radio;
+
+[Serializable, NetSerializable]
+public enum AU14NetSpliceUiKey : byte
+{
+    Key,
+}
+
+[Serializable, NetSerializable]
+public enum AU14NetSpliceStatus : byte
+{
+    Running,
+    Success,
+    Failed,
+}
+
+/// <summary>One probe taken against the carrier currently being hunted: the position looked at, and the
+/// strength that came back. The noise is already applied server-side.</summary>
+[Serializable, NetSerializable]
+public readonly record struct AU14NetSpliceReading(int Position, int Strength);
+
+[Serializable, NetSerializable]
+public sealed class AU14NetSpliceBuiState : BoundUserInterfaceState
+{
+    public int BandSize;
+    public int Stage;
+    public int Carriers;
+    public int ProbesLeft;
+    public float Detection;
+    public AU14NetSpliceStatus Status;
+    public List<AU14NetSpliceReading> Readings;
+    public List<int> Locked;
+
+    public AU14NetSpliceBuiState(
+        int bandSize,
+        int stage,
+        int carriers,
+        int probesLeft,
+        float detection,
+        AU14NetSpliceStatus status,
+        List<AU14NetSpliceReading> readings,
+        List<int> locked)
+    {
+        BandSize = bandSize;
+        Stage = stage;
+        Carriers = carriers;
+        ProbesLeft = probesLeft;
+        Detection = detection;
+        Status = status;
+        Readings = readings;
+        Locked = locked;
+    }
+}
+
+/// <summary>Sample the band at one position. Costs one probe and a little detection.</summary>
+[Serializable, NetSerializable]
+public sealed class AU14NetSpliceProbeMsg : BoundUserInterfaceMessage
+{
+    public int Position;
+
+    public AU14NetSpliceProbeMsg(int position)
+    {
+        Position = position;
+    }
+}
+
+/// <summary>Commit to a position as the carrier. Missing is what gets the operator caught.</summary>
+[Serializable, NetSerializable]
+public sealed class AU14NetSpliceLockMsg : BoundUserInterfaceMessage
+{
+    public int Position;
+
+    public AU14NetSpliceLockMsg(int position)
+    {
+        Position = position;
+    }
+}

--- a/Resources/Locale/en-US/_AU14/net-splice.ftl
+++ b/Resources/Locale/en-US/_AU14/net-splice.ftl
@@ -1,0 +1,34 @@
+au14-splice-not-clf = You have no idea what this thing is for.
+au14-splice-untrained = You fiddle with it, but you were never trained on trunk feeders.
+au14-splice-already-tapped = There's already a tap on this junction.
+au14-splice-already-working = Someone else has this junction open.
+au14-splice-alarmed = The junction is still in fault. Nothing you do here will take until it resets.
+au14-splice-no-feeder = There's no feeder junction on this to tap.
+
+au14-splice-opening = You start working the cover off the feeder junction.
+au14-splice-carrier-locked = Carrier { $done } of { $total } locked.
+au14-splice-success = The tap takes. Your nets are on this mast now.
+au14-splice-failed-detected = The junction throws a fault and locks you out of it.
+au14-splice-failed-probes = The band scope burns out in the junction.
+au14-splice-abandoned = You leave the junction half-spliced. The kit stays in it.
+
+au14-splice-verb-remove = Pull off the feeder tap
+au14-splice-removing = You start working the tap off the feeder.
+au14-splice-removed = The tap comes off and the junction is clean.
+au14-splice-salvaged = The tap comes off. Its keying module is still intact.
+
+au14-splice-examine-tapped = [color=#c46f3c]Something has been spliced into the feeder junction.[/color]
+au14-splice-examine-alarmed = [color=#c4453c]The junction cover hangs open and the fault light is flashing.[/color]
+au14-splice-examine-tap = [color=#c46f3c]This was not fitted at the factory.[/color]
+
+au14-splice-window-title = Feeder Junction - Trunk Splice
+au14-splice-stage = CARRIER { $current } OF { $total }
+au14-splice-probes = PROBES LEFT: { $probes }
+au14-splice-detection = DETECTION: { $percent }%
+au14-splice-position = TUNED TO: { $position }
+au14-splice-probe = PROBE
+au14-splice-lock = LOCK CARRIER
+au14-splice-warning = JUNCTION ALERT
+au14-splice-no-reading = No reading on this carrier yet.
+au14-splice-reading = Last probe: { $position } returned { $strength }.
+au14-splice-help = Sweep the band coarsely, then walk in on whatever came back strongest. Every probe raises detection. A lock in the wrong place raises it far more and costs probes as well.

--- a/Resources/Prototypes/_CMU14/Economy/Misc/clfstuff.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Misc/clfstuff.yml
@@ -356,9 +356,11 @@
       - id: CMUGasMaskFilterHAZOPS
         amount: 3
         points: 5
-    # the cell's starting comms: one manpack and one base station on the house so a
-    # round-start cell is never without its net. gated to the radio operator; spares
-    # and replacements stay as the paid entries under Special Equipment
+    # the cell's starting comms: one manpack, one base station, one splice kit and one
+    # relay on the house, so a round-start cell has its net and one attempt at somebody
+    # else's mast without waiting on a sapper's bench. everything past that is crafted at
+    # the workbench or paid for under Special Equipment. gated to the radio operator, who
+    # is the only one trained to use any of it
     - name: Radio Operator Issue
       jobs:
       - AU14JobCLFRadioOperator
@@ -367,6 +369,12 @@
         amount: 1
         points: 0
       - id: AU14CLFBaseStation
+        amount: 1
+        points: 0
+      - id: AU14CLFNetSpliceKit
+        amount: 1
+        points: 0
+      - id: AU14CLFClandestineRelay
         amount: 1
         points: 0
     - name: Special Equipment
@@ -392,6 +400,12 @@
       - id: AU14CLFBaseStation
         amount: 1
         points: 18
+      - id: AU14CLFNetSpliceKit
+        amount: 3
+        points: 12
+      - id: AU14CLFClandestineRelay
+        amount: 3
+        points: 6
       - id: ANPRCFillCardCLF
         amount: 3
         points: 4
@@ -528,6 +542,10 @@
     - id: ANPRC117GRadioCLFFilled
       amount: 1
     - id: AU14CLFBaseStation
+      amount: 1
+    - id: AU14CLFNetSpliceKit
+      amount: 1
+    - id: AU14CLFClandestineRelay
       amount: 1
     - id:  AU14GunCaseRifleMar30
       amount: 2

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/clfvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/clfvendors.yml
@@ -270,6 +270,10 @@
         amount: 3
       - id: ANPRC117GRadioCLFFilled
         amount: 1
+      - id: AU14CLFNetSpliceKit
+        amount: 1
+      - id: AU14CLFClandestineRelay
+        amount: 2
       - id: ANPRCMastAntenna
         amount: 1
       - id: RMCEngineerKit

--- a/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
@@ -36,9 +36,9 @@
     callsignPresets:
     - PLT ACTUAL
     - PLT MAIN
-    - RED ACTUAL
-    - YELLOW ACTUAL
-    - PURPLE 6
+    - SABRE ACTUAL
+    - DAGGER ACTUAL
+    - PIKE 6
     - SUNRAY
     - OVERLORD
     - DUSTOFF

--- a/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
@@ -250,6 +250,74 @@
         startingItem: RMCPowerCellHigh
 
 - type: entity
+  parent: BaseItem
+  id: AU14CLFClandestineRelay
+  name: clandestine relay set
+  suffix: CLF, Cache Relay
+  description: >-
+    A stripped transceiver board and a power cell taped into a scavenged field set, with
+    a reel of wire for an antenna. There are no controls on it worth the name - it
+    repeats what it is told to repeat and nothing else.
+  components:
+  - type: Item
+    size: Normal
+    sprite: _RMC14/Objects/Devices/communication.rsi
+    heldPrefix: walkietalkie
+    shape:
+    - 0,0,0,0
+  - type: Sprite
+    sprite: _RMC14/Objects/Devices/communication.rsi
+    color: "#7a7a5a"
+    layers:
+    - state: walkietalkie
+      map: [ "base" ]
+  - type: Appearance
+  - type: ANPRCRadio
+    operatorFaction: clf
+    requiredSlot: none
+    relayOnly: true
+    dfReportFactions:
+    - GOVFOR
+    defaultSlots:
+    - label: CELL
+      channel: radioCLF
+    - label: CMD
+      channel: radioCLFCommand
+  - type: ANPRCCryptoSlot
+  - type: PowerCellSlot
+    cellSlotId: cell_slot
+  - type: PowerCellDraw
+    enabled: false
+    drawRate: 1
+    useRate: 0
+  - type: ContainerContainer
+    containers:
+      fill_card: !type:ContainerSlot
+      antenna: !type:ContainerSlot
+      cell_slot: !type:ContainerSlot
+      anprc_handset: !type:ContainerSlot
+  - type: ItemSlots
+    slots:
+      fill_card:
+        name: COMSEC fill card
+        whitelist:
+          components:
+          - ANPRCFillCard
+      antenna:
+        name: antenna
+        whitelist:
+          components:
+          - ANPRCAntenna
+        startingItem: ANPRCWireAntenna
+      cell_slot:
+        name: power-cell-slot-component-slot-name-default
+        startingItem: RMCPowerCellHigh
+  - type: ContainerFill
+    containers:
+      fill_card:
+      - ANPRCFillCardCLF
+
+- type: entity
   parent: CMPaperWritten
   id: ANPRCNetLogPrintout
   name: AN/PRC-117G net log printout

--- a/Resources/Prototypes/_CMU14/Entities/Objects/anprc_antennas.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/anprc_antennas.yml
@@ -26,6 +26,25 @@
 
 - type: entity
   parent: ANPRCAntennaBase
+  id: ANPRCWireAntenna
+  name: improvised wire antenna
+  description: >-
+    A reel of insulated wire, a ceramic insulator and a length of paracord. Thrown
+    over a branch or a rafter it will hold a net together, and looks like scrap in
+    a bag until it is strung up.
+  components:
+  - type: Sprite
+    sprite: _AU14/Objects/Radio/anprc117g.rsi
+    state: antenna_w
+  - type: ANPRCAntenna
+    label: WIRE
+    fullRange: 35
+    partialRange: 50
+    requiresStationary: true
+    movingRangeMultiplier: 0.5
+
+- type: entity
+  parent: ANPRCAntennaBase
   id: ANPRCMastAntenna
   name: AN/PRC-117G mast antenna
   description: >-

--- a/Resources/Prototypes/_CMU14/Entities/Objects/anprc_splice.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/anprc_splice.yml
@@ -1,0 +1,65 @@
+- type: entity
+  parent: BaseItem
+  id: AU14CLFNetSpliceKit
+  name: net splice kit
+  suffix: CLF, Sapper
+  description: >-
+    A junction tap wound out of stolen feeder cable, a keying module, and a band scope
+    built out of parts that did not start life together. Clamp it onto a mast's feeder
+    and go looking for the trunk carriers.
+  components:
+  - type: Sprite
+    sprite: _RMC14/Objects/Devices/sentrycomp.rsi
+    state: sentrycomp_cl
+    color: "#7a6a4a"
+  - type: Item
+    size: Small
+  - type: AU14NetSpliceKit
+
+- type: entity
+  parent: BaseStructure
+  id: AU14CLFNetSpliceTap
+  name: feeder tap
+  suffix: CLF
+  description: >-
+    A junction box wired into the mast's feeder, humming to itself. Nothing about it
+    matches the rest of the hardware.
+  components:
+  - type: Transform
+    anchored: true
+    noRot: true
+  - type: Clickable
+  - type: InteractionOutline
+  - type: Sprite
+    sprite: _RMC14/Objects/Devices/sentrycomp.rsi
+    state: sentrycomp_on
+    color: "#8a7a5a"
+    drawdepth: SmallObjects
+    scale: 0.8, 0.8
+    offset: 0.25, -0.15
+  - type: Physics
+    bodyType: Static
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.2,-0.2,0.2,0.2"
+        density: 40
+        mask:
+        - None
+  - type: Damageable
+    damageContainer: Inorganic
+    damageModifierSet: null
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTrigger
+        damage: 60
+      behaviors:
+      - !type:PlaySoundBehavior
+        sound:
+          collection: MetalBreak
+      - !type:DoActsBehavior
+        acts: [ "Destruction" ]
+  - type: AU14NetSpliceTap

--- a/Resources/Prototypes/_CMU14/Entities/Structures/comms_array.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Structures/comms_array.yml
@@ -66,6 +66,12 @@
     idleLoad: 0
     activeLoad: 5000
     channel: Equipment
+  # every fixed mast and array carries a feeder junction the CLF can splice a tap into, see AU14NetSpliceSystem
+  - type: AU14NetSpliceTarget
+  - type: UserInterface
+    interfaces:
+      enum.AU14NetSpliceUiKey.Key:
+        type: AU14NetSpliceBui
   - type: MarineMapTracked
   - type: TacticalMapTracked
   - type: ActiveTacticalMapTracked
@@ -83,6 +89,10 @@
   name: GOVFOR comms array
   suffix: GOVFOR, All Nets
   components:
+  - type: AU14NetSpliceTarget
+    carriers: 4
+    probes: 40
+    openTime: 12
   - type: ANPRCRelayAnchor
     fullRange: 200
     partialRange: 250
@@ -102,6 +112,10 @@
   name: OPFOR comms array
   suffix: OPFOR, All Nets
   components:
+  - type: AU14NetSpliceTarget
+    carriers: 4
+    probes: 40
+    openTime: 12
   - type: ANPRCRelayAnchor
     fullRange: 200
     partialRange: 250
@@ -129,6 +143,15 @@
     layers:
     - state: comm_tower_off
       map: [ "base" ]
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.49,-0.49,0.49,0.49"
+        density: 200
+        mask:
+        - MobLayer
   - type: GenericVisualizer
     visuals:
       enum.AU14CommsStructureVisuals.Damaged:
@@ -249,6 +272,10 @@
   name: field antenna mast
   suffix: Field-Built, Both Sides
   components:
+  - type: AU14NetSpliceTarget
+    carriers: 2
+    probes: 24
+    openTime: 6
   - type: ANPRCRelayAnchor
     fullRange: 75
     partialRange: 100

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/squads.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/squads.yml
@@ -4,7 +4,7 @@
   name: Alpha
   components:
   - type: AU14SquadCallsign
-    word: RED
+    word: SABRE
   - type: SquadTeam
     color: "#F0433E"
     radio: radioGovforAlpha
@@ -20,7 +20,7 @@
   name: Bravo
   components:
   - type: AU14SquadCallsign
-    word: YELLOW
+    word: DAGGER
   - type: SquadTeam
     roundStart: true
     color: "#c7b646"
@@ -36,7 +36,7 @@
   name: Charlie
   components:
   - type: AU14SquadCallsign
-    word: PURPLE
+    word: PIKE
   - type: SquadTeam
     roundStart: true
     group: GOVFOR
@@ -52,7 +52,7 @@
   name: Auxiliary
   components:
   - type: AU14SquadCallsign
-    word: GREEN
+    word: LONGBOW
   - type: SquadTeam
     group: GOVFOR
     roundStart: true

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml
@@ -193,30 +193,30 @@
     </ColorBox>
 
     <ColorBox>
-      <Box Margin="4">RED ACTUAL</Box>
+      <Box Margin="4">SABRE ACTUAL</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Red (Alpha) squad leader</Box>
-    </ColorBox>
-
-    <ColorBox>
-      <Box Margin="4">RED ROMEO</Box>
-    </ColorBox>
-    <ColorBox>
-      <Box Margin="4">Radio operator attached to Red (Alpha)</Box>
+      <Box Margin="4">Sabre (Alpha) squad leader</Box>
     </ColorBox>
 
     <ColorBox>
-      <Box Margin="4">RED 1-1 ... 1-N</Box>
+      <Box Margin="4">SABRE ROMEO</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Red (Alpha) squad members</Box>
+      <Box Margin="4">Radio operator attached to Sabre (Alpha)</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">SABRE 1-1 ... 1-N</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Sabre (Alpha) squad members</Box>
     </ColorBox>
   </Table>
 
   [bold]ACTUAL[/bold] identifies the person in charge speaking personally rather than an operator transmitting on their behalf.
 
-  Squad leaders answer as their element's ACTUAL station, for example [bold]RED ACTUAL[/bold]. At platoon level, [bold]HAVOC 6 ACTUAL[/bold] means the commander has taken the handset personally instead of the RTO.
+  Squad leaders answer as their element's ACTUAL station, for example [bold]SABRE ACTUAL[/bold]. At platoon level, [bold]HAVOC 6 ACTUAL[/bold] means the commander has taken the handset personally instead of the RTO.
 
   ### Comms Net Directory
 

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsFirstNet.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsFirstNet.xml
@@ -35,6 +35,8 @@
   - A powered shipboard communications array.
   - A vehicle radio aboard a dropship or vehicle, covering little more than the hull.
   - A field antenna mast raised from ten metal sheets by engineering-trained personnel.
+  - A clandestine base station or a staked-down relay set, if you are with the CLF.
+  - Any mast or array the CLF have spliced a tap into.
 
   If none of those are within range of you, your squad net is dead. Not degraded. Dead. You will speak and nothing will happen.
 
@@ -75,6 +77,55 @@
   </Table>
 
   Coverage reaches one level above or below the anchor, so a tunnel or a lower deck usually needs its own relay. Only a shipboard array covers a whole site vertically.
+
+  ### If you are with the CLF
+
+  The CLF has no communications array and never gets one. Your coverage is either something you build, or something the enemy already built that you tap.
+
+  <Box>
+    <GuideEntityEmbed Entity="AU14CLFNetSpliceKit" Caption="Splice Kit"/>
+    <GuideEntityEmbed Entity="AU14CommsMastField" Caption="Field Mast"/>
+    <GuideEntityEmbed Entity="AU14CLFBaseStation" Caption="Base Station"/>
+    <GuideEntityEmbed Entity="AU14CLFClandestineRelay" Caption="Relay Set"/>
+  </Box>
+
+  #### Tapping somebody else's mast
+
+  Every fixed mast and array has a feeder junction, and a junction can be spliced. Do it and your cell nets run on that mast at that mast's range. A command-post mast is worth 75 tiles to you. A site array is worth 200.
+
+  A tap [bold]adds[/bold] your nets and takes nothing away. The mast keeps carrying whatever it carried before, for whoever built it. Splicing one does not knock it down, jam it, or cut the garrison off it. If you want a mast gone, break it.
+
+  You need a [bold]net splice kit[/bold], built at the sapper's workbench, and you need to be the [bold]Radio Operator[/bold]. Nobody else is trained for it.
+
+  Use the kit on the mast. Getting the cover off takes several seconds, then the splice panel opens. The trunk carriers are hidden somewhere in the band and you have to find each one:
+
+  - [bold]PROBE[/bold] a position and the panel reports what came back. A strong reading means you are close. A zero means there is no carrier within thirty of where you looked.
+  - [bold]LOCK[/bold] when you think you have it. Within three positions and the carrier is yours. Miss it and you lose two probes and take a large hit to the detection meter.
+  - Probes are shared across the whole job rather than given per carrier. Each one nudges detection a little. A missed lock costs twenty times as much, so probe again rather than guess.
+
+  Sweep coarsely before you do anything else. Three probes spread evenly across the band will always touch a carrier, and from there you walk in on whichever came back strongest.
+
+  Run out of probes, or fill the detection meter, and the job fails. The kit is gone and the junction drops into fault for ninety seconds, during which nobody can splice it again. Bring a second kit if you want a second try, and expect to wait.
+
+  The mast throws sparks the whole time you are working on it, and keeps sparking through the fault. Neither is subtle. Put someone on the approach before you start.
+
+  #### Building your own
+
+  - A [bold]field antenna mast[/bold] is ten metal sheets and eight seconds, and gives 75 tiles clear and 100 degraded. Your Cell Leader, Radio Operator, Guerillas and Machine Gunners all have the engineering skill for it. It is also tall, outdoors only, and anyone can tap it or break it, marines included.
+  - A [bold]clandestine base station[/bold] reaches 55 clear and 80 degraded and can be worked on its handset, which no relay can. It is too heavy to conceal on a person, so the place you hide it is a place worth defending.
+  - A [bold]relay set[/bold] reaches 35 clear and 50 degraded and has no controls on it at all. It is the weakest thing on this list. Use it where there is no mast to tap and no room to raise one, such as inside a building or down a tunnel.
+
+  Only your Cell Leader and Radio Operator can stake down a relay or a base station.
+
+  #### What it costs you
+
+  None of this is hidden from the enemy.
+
+  A [bold]tap[/bold] sits at the foot of the mast where anyone walking past can see it. It can be shot, and anyone can pull it off in eight seconds. Whoever does gets its keying module, which reads your cell's traffic until your leadership orders a recrypto.
+
+  A [bold]relay[/bold] is staked down, not locked down. Anyone can pack one up in three seconds and walk off with that piece of your coverage.
+
+  Put both somewhere nobody has a reason to walk past.
 
   ## Step 3: Say something on your headset
 

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsQuickRef.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsQuickRef.xml
@@ -108,6 +108,26 @@
     </ColorBox>
 
     <ColorBox>
+      <Box Margin="4">CLF relay set (staked down)</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">0-35 tiles.</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Degraded to 50 tiles. No signal beyond 50.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">CLF base station (staked down)</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">0-55 tiles.</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Degraded to 80 tiles. No signal beyond 80.</Box>
+    </ColorBox>
+
+    <ColorBox>
       <Box Margin="4">Shipboard communications array</Box>
     </ColorBox>
     <ColorBox>
@@ -115,6 +135,16 @@
     </ColorBox>
     <ColorBox>
       <Box Margin="4">Provides no coverage when destroyed or unpowered.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">CLF feeder tap</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Whatever the tapped mast or array covers.</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Adds the CLF nets without removing any. The host keeps working normally for its owners.</Box>
     </ColorBox>
 
     <ColorBox>
@@ -138,8 +168,72 @@
   - A powered communications array.
   - A vehicle radio set aboard a dropship or vehicle (covers little more than the hull).
   - A field antenna mast, raised from ten metal sheets by engineering-trained personnel.
+  - A CLF clandestine base station or relay set, staked down (CLF nets only).
+  - Any mast or array carrying a CLF feeder tap (CLF nets only, until the tap is removed).
 
   Colony and civilian channels are not relay-gated and keep stock behavior.
+
+  ## Net Splicing
+
+  A CLF Radio Operator with a net splice kit can tap a mast or array and add the cell nets to it. The host is not disabled and keeps serving its owners. Probe the band to find each hidden trunk carrier, then lock it. Probes are shared across the whole job. Running out of probes, or filling the detection meter, fails the job and faults the junction.
+
+  <Table Columns="4" MinForcedColumnWidth="80">
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Target[/bold]</Box>
+    </ColorBox>
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Carriers[/bold]</Box>
+    </ColorBox>
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Probes[/bold]</Box>
+    </ColorBox>
+    <ColorBox Color="#263238">
+      <Box Margin="4">[bold]Open time[/bold]</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Field antenna mast</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">2</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">24</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">6 seconds</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Command-post mast</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">3</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">32</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">8 seconds</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Communications array</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">4</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">40</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">12 seconds</Box>
+    </ColorBox>
+  </Table>
+
+  Signal reads zero more than 30 positions from a carrier. A lock takes within 4. Each probe adds 1.5% detection. A missed lock adds 30% and costs 2 probes. The mast sparks throughout, and holds a fault for 90 seconds after a failure, during which it cannot be spliced again.
+
+  Anyone can pull a tap off in eight seconds, and recovers a CLF fill card for doing it.
 
   ## Antennas
 
@@ -172,6 +266,16 @@
     </ColorBox>
     <ColorBox>
       <Box Margin="4">Approximately double range while stationary and half standard range while moving.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">[bold]WIRE[/bold]</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Improvised, fitted to the CLF relay set only.</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">35 tiles clear and 50 degraded while stationary, half standard range while moving.</Box>
     </ColorBox>
   </Table>
 

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsVoiceProcedure.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsVoiceProcedure.xml
@@ -18,7 +18,7 @@
 
   Address the receiving station first, then identify the transmitting station.
 
-  [color=#a4885c]HAVOC 6, this is RED ROMEO, message, over.[/color]
+  [color=#a4885c]HAVOC 6, this is SABRE ROMEO, message, over.[/color]
 
   A complete call normally contains:
 
@@ -30,11 +30,11 @@
 
   The receiving station answers using the same order:
 
-  [color=#a4885c]RED ROMEO, this is HAVOC 6, send it, over.[/color]
+  [color=#a4885c]SABRE ROMEO, this is HAVOC 6, send it, over.[/color]
 
   After both stations have established contact, [bold]THIS IS[/bold] may be omitted:
 
-  [color=#a4885c]RED ROMEO, HAVOC 6, send it, over.[/color]
+  [color=#a4885c]SABRE ROMEO, HAVOC 6, send it, over.[/color]
 
   ## Prowords
 
@@ -181,9 +181,9 @@
 
   A radio check confirms that two stations can hear each other.
 
-  [color=#a4885c]HAVOC ROMEO, this is RED ROMEO, radio check, over.[/color]
+  [color=#a4885c]HAVOC ROMEO, this is SABRE ROMEO, radio check, over.[/color]
 
-  [color=#a4885c]RED ROMEO, this is HAVOC ROMEO, Lima Charlie. How me? Over.[/color]
+  [color=#a4885c]SABRE ROMEO, this is HAVOC ROMEO, Lima Charlie. How me? Over.[/color]
 
   [color=#a4885c]Lima Charlie, out.[/color]
 
@@ -203,19 +203,19 @@
   - Approximate strength.
   - What the reporting element is doing.
 
-  [color=#a4885c]HAVOC 6, this is RED ACTUAL, contact. Infantry, squad strength, east treeline near grid two-four-five. Engaging, over.[/color]
+  [color=#a4885c]HAVOC 6, this is SABRE ACTUAL, contact. Infantry, squad strength, east treeline near grid two-four-five. Engaging, over.[/color]
 
-  [color=#a4885c]RED ACTUAL, HAVOC 6, roger. YELLOW is moving to your flank. Hold your position, over.[/color]
+  [color=#a4885c]SABRE ACTUAL, HAVOC 6, roger. DAGGER is moving to your flank. Hold your position, over.[/color]
 
-  [color=#a4885c]HAVOC 6, RED ACTUAL, wilco, out.[/color]
+  [color=#a4885c]HAVOC 6, SABRE ACTUAL, wilco, out.[/color]
 
   ## Fire-Support Request
 
   Establish contact before sending the full request.
 
-  [color=#a4885c]HAVOC OPS, this is RED ROMEO, fire mission, over.[/color]
+  [color=#a4885c]HAVOC OPS, this is SABRE ROMEO, fire mission, over.[/color]
 
-  [color=#a4885c]RED ROMEO, HAVOC OPS, send it, over.[/color]
+  [color=#a4885c]SABRE ROMEO, HAVOC OPS, send it, over.[/color]
 
   The request should identify:
 
@@ -226,17 +226,17 @@
 
   [color=#a4885c]Enemy machine-gun position on the north ridge beside the communications tower. Friendlies are two-five-zero meters east, marked by smoke. Request suppression, over.[/color]
 
-  [color=#a4885c]RED ROMEO, HAVOC OPS, roger. Rounds out, impact in three-zero seconds, over.[/color]
+  [color=#a4885c]SABRE ROMEO, HAVOC OPS, roger. Rounds out, impact in three-zero seconds, over.[/color]
 
-  [color=#a4885c]HAVOC OPS, RED ROMEO, impact observed. Target suppressed. End of mission, out.[/color]
+  [color=#a4885c]HAVOC OPS, SABRE ROMEO, impact observed. Target suppressed. End of mission, out.[/color]
 
   ## Casualty Evacuation Request
 
   Establish contact before sending casualty details.
 
-  [color=#a4885c]HAVOC ROMEO, this is YELLOW ROMEO, casualty evacuation request, over.[/color]
+  [color=#a4885c]HAVOC ROMEO, this is DAGGER ROMEO, casualty evacuation request, over.[/color]
 
-  [color=#a4885c]YELLOW ROMEO, HAVOC ROMEO, send it, over.[/color]
+  [color=#a4885c]DAGGER ROMEO, HAVOC ROMEO, send it, over.[/color]
 
   Include:
 
@@ -248,15 +248,15 @@
 
   [color=#a4885c]Two casualties. One urgent surgical, one walking wounded. Pickup at the landing zone south of the bridge. Area is secure and marked with green smoke, over.[/color]
 
-  [color=#a4885c]YELLOW ROMEO, HAVOC ROMEO, good copy. Evacuation craft inbound in five minutes, out.[/color]
+  [color=#a4885c]DAGGER ROMEO, HAVOC ROMEO, good copy. Evacuation craft inbound in five minutes, out.[/color]
 
   ## Using ACTUAL
 
   [bold]ACTUAL[/bold] identifies the person in charge speaking personally rather than an RTO or other person speaking on their behalf.
 
-  Squad leaders carry it as their assigned station: [bold]RED ACTUAL[/bold] is the Red (Alpha) squad leader. Command stations append it when the officer takes the handset personally.
+  Squad leaders carry it as their assigned station: [bold]SABRE ACTUAL[/bold] is the Sabre (Alpha) squad leader. Command stations append it when the officer takes the handset personally.
 
-  [color=#a4885c]RED ACTUAL, this is HAVOC 6 ACTUAL. Move past phase line DODGE, over.[/color]
+  [color=#a4885c]SABRE ACTUAL, this is HAVOC 6 ACTUAL. Move past phase line DODGE, over.[/color]
 
   Without [bold]ACTUAL[/bold], [bold]HAVOC 6[/bold] traffic may be the RTO relaying for the commander. With it, the commander is speaking personally.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

This replaces the temporary CLF comms coverage fix with an actual mechanic

The CLF Radio Operator can now use a net splice kit on a fixed antenna mast or communications array. If they complete the splice, the mast starts carrying `radioCLF` and `radioCLFCommand` using that mast’s existing range and power

The host mast keeps working normally for its owners. Splicing only adds the CLF nets. It does not disable, jam or remove anything that was already there

To start the job, the operator opens the mast’s feeder junction. This takes between 6 and 12 seconds depending on the target. The splice kit is installed into the junction and consumed, then the operator gets access to the splice panel.

The panel contains a 100-position band with a number of hidden trunk carriers. The operator has to find and lock all of them

PROBE checks the selected position and returns a noisy signal reading. Signal strength falls off until it reaches zero 30 positions away from a carrier. Because the reading includes some noise, it points the operator in the right direction without giving away the exact position

LOCK commits to the selected position. Locking within four positions captures the carrier and moves on to the next one. Missing costs two probes and adds 30% detection

The probe budget is shared across the full job, not refreshed for every carrier. Each probe adds 1.5% detection

A successful splice leaves a visible feeder tap on the mast’s tile. Anyone can examine it, damage it or pull it off. Removing it takes eight seconds and gives an `ANPRCFillCardCLF`, which stays useful until the CLF orders a recrypto

The whole process is meant to be visible. The mast throws sparks while someone is working on it. Failed attempts fault the junction for 90 seconds, leaving it sparking, buzzing and unable to be spliced again until the fault clears

Relays also remain recoverable. They are staked down rather than locked down, so anyone can pack one up in three seconds if they find it

This came from feedback that the current CLF radio setup was making leadership and coordination much harder than intended

## Why / Balance

The CLF does not have a communications array and is not meant to build one. Under the anchor-based radio system this leaves them with much worse coverage than the other factions

The first fix was to give them cheap relay boxes and quietly put their nets on the field mast. It worked mechanically, but it was not very interesting. The CLF could solve coverage by dropping a box and GOVFOR had no way to know their infrastructure was carrying enemy traffic

It also left the Radio Operator without much of a role. They had equipment to carry, but no real specialist job to perform

The intended coverage order is:

* A staked CLF relay reaches 35 tiles in clear conditions and 50 in degraded conditions
* A staked CLF base station reaches 55 clear and 80 degraded
* A tapped field or command-post mast reaches 75 clear and 100 degraded
* A tapped communications array reaches 200 clear and 250 degraded

Splicing is meant to be better than building. It is also much riskier and depends on infrastructure the CLF does not control

Target difficulty scales with the value of the mast:

* Field antenna masts have two carriers, 24 probes and a six second opening time
* Command-post masts have three carriers, 32 probes and an eight second opening time
* Communications arrays have four carriers, 40 probes and a twelve second opening time

The relay set is now made at the sapper’s workbench instead of being issued through the crate. `ANPRCWireAntenna` range has been reduced from 45/65 to 35/50 and it is no longer stocked loose, so it cannot become a low-risk manpack upgrade

The CLF Radio Operator now starts with one splice kit and one relay alongside the existing manpack and base station

Spare kits cost 12 points and spare relays cost 6 points. The vendor stocks one kit and two relays

The splice kit recipe uses 12 metal, 9 plastic, 30 cable and 2 electronics with an eight second craft time

The relay recipe uses 9 metal, 6 plastic, 20 cable, 1 electronics and 1 power cell with a six second craft time

## Technical details

`AU14NetSpliceSystem` handles the server-side mechanic. This includes interaction checks, role gating, junction do-afters, carrier generation, probe and lock handling, detection, junction faults, radio net grafting, teardown, tap removal, examine text and ticking

`AU14NetSpliceComponents` and `AU14NetSpliceUi` contain the shared target, session, completed splice, tap, alarm, kit and BUI definitions

The client UI is handled by:

* `AU14NetSpliceBui`
* `AU14NetSpliceWindow`
* `AU14NetSpliceBandDisplay`
* `AU14NetSpliceMeter`

`Content.Shared`, `Content.Server` and `Content.Client` build with zero errors

Both guidebook parse tests pass

`SpawnAndDeleteAllEntitiesInTheSameSpot` passes for the new prototypes

## Media

<img width="514" height="557" alt="image" src="https://github.com/user-attachments/assets/b3d53920-57af-4fa1-b6f8-c8e9bf73c225" />
<img width="476" height="323" alt="image" src="https://github.com/user-attachments/assets/76e83668-88c9-4d15-8465-2d3fc81d6cd7" />
<img width="420" height="222" alt="image" src="https://github.com/user-attachments/assets/acf901f9-ec0f-436a-8762-c40acb4be2ea" />

<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements

<!-- Confirm the following by placing an X in the brackets [X]: -->

* [X] I have read and am following the [[Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
* [X] I have added media to this PR or it does not require an ingame showcase.
* [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
* [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:

* add: CLF Radio Operators can splice antenna masts and communications arrays to carry the CLF radio nets at the mast’s full range
* add: Splicing uses a band search with a limited probe budget and a detection meter. Failed attempts fault the junction for 90 seconds
* add: Successful splices leave a visible feeder tap that anyone can remove to recover a live CLF fill card
* add: CLF relay sets can now be built at the sapper’s workbench. Radio Operators receive one relay and one splice kit at round start
* tweak: Tapped masts keep working normally for their owners. A splice only adds the CLF nets
* tweak: CLF relay range has been reduced to 35 tiles clear and 50 tiles degraded
* fix: Antenna masts no longer have a two-tile-wide hitbox
* tweak: GOVFOR squad callsigns are now SABRE (Alpha), DAGGER (Bravo), PIKE (Charlie) and LONGBOW (Auxiliary), replacing the colour words