### PR TITLE
Clients can Hide the Vote Popup

### DIFF
--- a/Content.Client/Voting/UI/VotePopup.xaml
+++ b/Content.Client/Voting/UI/VotePopup.xaml
@@ -1,15 +1,24 @@
 <Control xmlns="https://spacestation14.io" MinWidth="560" MaxWidth="1280" RectClipContent="True">
     <PanelContainer Name="VotePanel" StyleClasses="CrtPanel" />
-    <BoxContainer Margin="10 8" Orientation="Vertical" SeparationOverride="6">
+
+    <BoxContainer Name="MainContent" Margin="10 8" Orientation="Vertical" SeparationOverride="6">
         <Label Name="VoteCaller" StyleClasses="CrtHeading" />
         <RichTextLabel Name="VoteTitle" StyleClasses="CrtRichText" />
         <Button Margin="0 2" Name="FollowVoteTarget" Text="{Loc 'ui-vote-follow-button-popup'}" Visible="False" />
 
         <GridContainer Columns="3" Name="VoteOptionsContainer" HorizontalExpand="True"
-                       HSeparationOverride="8" VSeparationOverride="6" />
+            HSeparationOverride="8" VSeparationOverride="6" />
         <BoxContainer Orientation="Horizontal" Margin="0 2 0 0">
             <ProgressBar Margin="0 0 8 0" HorizontalExpand="True" Name="TimeLeftBar" MinValue="0" MaxValue="1" MinSize="0 20" StyleClasses="CrtProgressBar" />
             <Label Name="TimeLeftText" StyleClasses="CrtHeading" MinWidth="42" HorizontalAlignment="Right" />
+            <Button Name="MinimizeButton" Text="{Loc 'ui-vote-minimize'}" Margin="8 0 0 0" MinWidth="80" />
         </BoxContainer>
+    </BoxContainer>
+
+    <BoxContainer Name="MinimizedContent" Margin="10 8" Orientation="Horizontal" Visible="False"
+            HorizontalExpand="True" VerticalAlignment="Center">
+        <Label Name="MinimizedTitle" HorizontalExpand="True" StyleClasses="CrtHeading" ClipText="True" />
+        <Label Name="MinimizedTimeLeft" StyleClasses="CrtHeading" MinWidth="42" HorizontalAlignment="Right" Margin="0 0 8 0" />
+        <Button Name="RestoreButton" Text="{Loc 'ui-vote-restore'}" MinWidth="80" />
     </BoxContainer>
 </Control>

--- a/Content.Client/Voting/UI/VotePopup.xaml.cs
+++ b/Content.Client/Voting/UI/VotePopup.xaml.cs
@@ -83,6 +83,8 @@ namespace Content.Client.Voting.UI
                 button.OnPressed += _ => _voteManager.SendCastVote(vote.Id, i1);
             }
 
+            MinimizeButton.OnPressed += _ => SetMinimized(true);
+            RestoreButton.OnPressed += _ => SetMinimized(false);
             ReflowOptions(GetRawOptionTexts());
         }
 
@@ -147,7 +149,7 @@ namespace Content.Client.Voting.UI
         {
             VoteTitle.SetMessage(FormattedMessage.FromUnformatted(_vote.Title));
             VoteCaller.Text = Loc.GetString("ui-vote-created", ("initiator", _vote.Initiator));
-
+            MinimizedTitle.Text = _vote.Title;
             var buttonTexts = new string[_voteButtons.Length];
 
             for (var i = 0; i < _voteButtons.Length; i++)
@@ -285,10 +287,30 @@ namespace Content.Client.Voting.UI
             // Round up a second.
             timeLeft = TimeSpan.FromSeconds(Math.Ceiling(timeLeft.TotalSeconds));
 
-            TimeLeftBar.Value = Math.Min(1, (float) ((curTime.TotalSeconds - _vote.StartTime.TotalSeconds) /
-                                                     (_vote.EndTime.TotalSeconds - _vote.StartTime.TotalSeconds)));
+            TimeLeftBar.Value = Math.Min(1, (float) ((curTime.TotalSeconds - _vote.StartTime.TotalSeconds)
+                / (_vote.EndTime.TotalSeconds - _vote.StartTime.TotalSeconds)));
 
             TimeLeftText.Text = $"{timeLeft:m\\:ss}";
+            if (MinimizedContent.Visible)
+                MinimizedTimeLeft.Text = $"{timeLeft:m\\:ss}";
+        }
+
+        private void SetMinimized(bool minimized)
+        {
+            MainContent.Visible = !minimized;
+            MinimizedContent.Visible = minimized;
+
+            if (minimized)
+            {
+                MinWidth = 280;
+                MaxWidth = 400;
+                MinimizedTitle.Text = _vote.Title;
+            }
+            else
+            {
+                MinWidth = 560;
+                MaxWidth = 1280;
+            }
         }
     }
 }

--- a/Resources/Locale/en-US/voting/ui/vote-popup.ftl
+++ b/Resources/Locale/en-US/voting/ui/vote-popup.ftl
@@ -2,3 +2,5 @@ ui-vote-created = { $initiator } has called a vote:
 ui-vote-button  = { $text } ({ $votes })
 ui-vote-button-no-votes  = { $text }
 ui-vote-follow-button-popup = Follow User
+ui-vote-minimize = Hide
+ui-vote-restore = Show

--- a/Resources/Prototypes/_CMU14/Entities/Objects/Guidebook/CMURules.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Guidebook/CMURules.yml
@@ -1,4 +1,4 @@
-﻿- type: guideEntry
+- type: guideEntry
   parent: RMC
   id: RMCOverview
   name: Rules Overview
@@ -41,10 +41,10 @@
   text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesOverview.xml"
   children:
   - AU14GamemodeRulesInsurgency
-  - AU14GamemodeRulesForceOnForce
-  - AU14GamemodeRulesDistressSignal
-  - AU14GamemodeRulesColonyFall
-  - AU14GamemodeRulesPrometheus
+  # - AU14GamemodeRulesForceOnForce
+  # - AU14GamemodeRulesDistressSignal
+  # - AU14GamemodeRulesColonyFall
+  # - AU14GamemodeRulesPrometheus
 
 - type: guideEntry
   parent: RMC
@@ -60,30 +60,33 @@
   priority: 6
   text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesInsurgency.xml"
 
-- type: guideEntry
-  parent: RMC
-  id: AU14GamemodeRulesForceOnForce
-  name: Force on Force Rules
-  priority: 7
-  text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesForceOnForce.xml"
-
-- type: guideEntry
-  parent: RMC
-  id: AU14GamemodeRulesDistressSignal
-  name: Distress Signal Rules
-  priority: 8
-  text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesDistressSignal.xml"
-
-- type: guideEntry
-  parent: RMC
-  id: AU14GamemodeRulesColonyFall
-  name: Colony Fall Rules
-  priority: 9
-  text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesColonyFall.xml"
-
-- type: guideEntry
-  parent: RMC
-  id: AU14GamemodeRulesPrometheus
-  name: Prometheus Rules
-  priority: 10
-  text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesPrometheus.xml"
+# Placeholder stubs below,
+# require actual rules
+#
+# - type: guideEntry
+#   parent: RMC
+#   id: AU14GamemodeRulesForceOnForce
+#   name: Force on Force Rules
+#   priority: 7
+#   text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesForceOnForce.xml"
+#
+# - type: guideEntry
+#   parent: RMC
+#   id: AU14GamemodeRulesDistressSignal
+#   name: Distress Signal Rules
+#   priority: 8
+#   text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesDistressSignal.xml"
+               #
+# - type: guideEntry
+#   parent: RMC
+#   id: AU14GamemodeRulesColonyFall
+#   name: Colony Fall Rules
+#   priority: 9
+#   text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesColonyFall.xml"
+#
+# - type: guideEntry
+#   parent: RMC
+#   id: AU14GamemodeRulesPrometheus
+#   name: Prometheus Rules
+#   priority: 10
+#   text: "/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesPrometheus.xml"

--- a/Resources/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesOverview.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Rules/Gamemodes/AU14GamemodeRulesOverview.xml
@@ -1,4 +1,4 @@
-﻿<Document>
+<Document>
   # Gamemode Rules
 
   The Alien universe is one of many different stories. Each gamemode represents a different narrative and is governed by its own expectations and rule set.
@@ -7,8 +7,9 @@
 
   ###Universal Rules
   - [textlink="Insurgency Rules." link="AU14GamemodeRulesInsurgency"/]
-  - [textlink="Force on Force Rules." link="AU14GamemodeRulesForceOnForce"/]
-  - [textlink="Distress Signal Rules." link="AU14GamemodeRulesDistressSignal"/]
-  - [textlink="Colony Fall Rules." link="AU14GamemodeRulesColonyFall"/]
-  - [textlink="Prometheus Rules." link="AU14GamemodeRulesPrometheus"/]
+  - Distress Signal Rules: exercise common sense.
+  <!-- - [textlink="Force on Force Rules." link="AU14GamemodeRulesForceOnForce"/] -->
+  <!-- - [textlink="Distress Signal Rules." link="AU14GamemodeRulesDistressSignal"/] -->
+  <!-- - [textlink="Colony Fall Rules." link="AU14GamemodeRulesColonyFall"/] -->
+  <!-- - [textlink="Prometheus Rules." link="AU14GamemodeRulesPrometheus"/] -->
 </Document>


### PR DESCRIPTION
- **🩹 hide the empty rule pages for now**
- **✨ you can now hide/show the vote popup and reclaim your screen**

**Changelog**
:cl:
- add: Vote popups can now be minimized to reclaim your screen and get back in the fight
- admin: Empty gamemode rule pages have been hidden for now
