### PR TITLE
Fixed govfor roles having incorrect ranks

### DIFF
--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Engineering/AuxTech.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Engineering/AuxTech.yml
@@ -51,18 +51,12 @@
   ranks:
     RMCRankCivilian: []
   chevrons:
-    RMCRankSergeant:
-      entity: AU14ChevronUSCMSergeant
-      requirements:
-      - !type:RoleTimeRequirement
-        role: AU14JobGOVFORAuxTech
-        time: 86400 # 24 hours
     RMCRankCorporal:
       entity: AU14ChevronUSCMCorporal
       requirements:
       - !type:RoleTimeRequirement
         role: AU14JobGOVFORAuxTech
-        time: 61200 # 17 hours
+        time: 86400 # 24 hours
     RMCRankLanceCorporal:
       entity: AU14ChevronUSCMLanceCorporal
       requirements:

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Engineering/EngineeringTechnician.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Engineering/EngineeringTechnician.yml
@@ -41,14 +41,20 @@
   ranks:
     RMCRankCivilian: []
   chevrons:
-    RMCRankPrivateFirstClass:
-      entity: AU14ChevronUSCMPrivateFirstClass
+    RMCRankCorporal:
+      entity: AU14ChevronUSCMCorporal
+      requirements:
+      - !type:RoleTimeRequirement
+        role: AU14JobGOVFOREngineeringTech
+        time: 86400 # 24 hours
+    RMCRankLanceCorporal:
+      entity: AU14ChevronUSCMLanceCorporal
       requirements:
       - !type:RoleTimeRequirement
         role: AU14JobGOVFOREngineeringTech
         time: 36000 # 10 hours
-    RMCRankPrivate:
-      entity: AU14ChevronUSCMPrivate
+    RMCRankPrivateFirstClass:
+      entity: AU14ChevronUSCMPrivateFirstClass
       requirements: []
 
 - type: playTimeTracker

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Medical/MilitaryDoctor.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Medical/MilitaryDoctor.yml
@@ -36,12 +36,6 @@
   ranks:
     RMCRankCivilian: []
   chevrons:
-    RMCRankFirstLT:
-      entity: AU14ChevronFirstLT
-      requirements:
-      - !type:RoleTimeRequirement
-        role: AU14JobGOVFORMilitaryDoctor
-        time: 86400 # 24 hours
     RMCRankSecondLT:
       entity: AU14ChevronSecondLT
       requirements: []


### PR DESCRIPTION



## About the PR
Changed a few ranks/chevron's for a few govfor roles to be in line with the intended command structure.

## Why / Balance
Changes are made to fit with Troy's intended rank structure as seen in the attached image [Intended Ranks](https://media.discordapp.net/attachments/1501079607645048912/1526468560120057936/GOVFOR_Structure.png?ex=6a699721&is=6a6845a1&hm=0e8dd8f2c12ef2025923cd40d364c1152b8c337886189e0ad557fd3a7271c625&=&format=webp&quality=lossless)

## Technical details
Yaml job files in ColonialMarinesUniverse\Resources\Prototypes\_CMU14\Roles\Military\GovFor\Platoon

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
Medical Officer, Auxiliary Technician, and Logistics Technician had their ranks fixed.
:cl:
- fix: Medical Officer Rank O1-O2 > O1
- fix: Auxiliary Technician Rank E1-E2 > E2-E4
- fix: Engineering Technician Rank E1-E2 > E2-E4
