### PR TITLE
Bug fixes, add NSG-23 and mk221 to weyu pmc req, weyu goons now have weapons for bioweapon containment, fv150 added to vehicle lift, longstreet and cheetath turret rotation buffed

### DIFF
--- a/Resources/Maps/_RMC14/tank_interior.yml
+++ b/Resources/Maps/_RMC14/tank_interior.yml
@@ -1,11 +1,11 @@
 meta:
   format: 7
   category: Map
-  engineVersion: v278.0.0
+  engineVersion: 264.0.2-fix-physics
   forkId: ""
   forkVersion: ""
-  time: 07/30/2026 10:00:13
-  entityCount: 41
+  time: 03/12/2026 10:11:34
+  entityCount: 40
 maps:
 - 1
 grids:
@@ -108,13 +108,6 @@ entities:
       data:
         chunkSize: 4
     - type: GasTileOverlay
-- proto: AU14VehicleRadioSet
-  entities:
-  - uid: 500
-    components:
-    - type: Transform
-      pos: 1.5,-0.5
-      parent: 2
 - proto: RMCRotaryPhoneWallmount
   entities:
   - uid: 28
@@ -133,10 +126,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 1.4387805,-0.43172377
       parent: 2
-    missingComponents:
-    - Corrodible
-    - Damageable
-    - Destructible
 - proto: RMCSeatTankGunner
   entities:
   - uid: 26
@@ -145,50 +134,12 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 0.70269585,-2.3210986
       parent: 2
-    missingComponents:
-    - Corrodible
-    - Damageable
-    - Destructible
-- proto: RMCWallInvisibleBulletBlocker
+- proto: VehicleTankAmmoLoader
   entities:
-  - uid: 32
+  - uid: 38
     components:
     - type: Transform
-      pos: 1.5094132,-3.3260386
-      parent: 2
-  - uid: 34
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.0011587,-2.441083
-      parent: 2
-  - uid: 35
-    components:
-    - type: Transform
-      pos: 0.4718294,-3.3309548
-      parent: 2
-  - uid: 46
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,-0.5
-      parent: 2
-- proto: RMCWallInvisibleBulletLightBlocker
-  entities:
-  - uid: 33
-    components:
-    - type: Transform
-      pos: 1.5,-3.5
-      parent: 2
-  - uid: 36
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 2
-  - uid: 37
-    components:
-    - type: Transform
-      pos: 2.5,-3.5
+      pos: 1.340075,-1.3274913
       parent: 2
 - proto: VehicleInteriorExtinguisher
   entities:
@@ -198,10 +149,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 0.8297322,0.3712867
       parent: 2
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
 - proto: VehicleInteriorNanomed
   entities:
   - uid: 27
@@ -209,15 +156,6 @@ entities:
     - type: Transform
       pos: 0.28445482,0.37976068
       parent: 2
-- proto: VehicleTankAmmoLoader
-  entities:
-  - uid: 38
-    components:
-    - type: Transform
-      pos: 1.340075,-1.3274913
-      parent: 2
-    missingComponents:
-    - InteractionTransparency
 - proto: VehicleTankBack1
   entities:
   - uid: 21
@@ -389,16 +327,52 @@ entities:
     - type: Transform
       pos: 2.5,0.5
       parent: 2
-- proto: VehicleViewportUnanchored
+- proto: RMCWallInvisibleBulletBlocker
   entities:
-  - uid: 39
+  - uid: 32
+    components:
+    - type: Transform
+      pos: 1.5094132,-3.3260386
+      parent: 2
+  - uid: 34
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.30790615,-0.14253885
+      pos: 2.0011587,-2.441083
       parent: 2
-    - type: Fixtures
-      fixtures: {}
-    missingComponents:
-    - InteractionTransparency
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 0.4718294,-3.3309548
+      parent: 2
+  - uid: 46
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 2
+- proto: RMCWallInvisibleBulletLightBlocker
+  entities:
+  - uid: 33
+    components:
+    - type: Transform
+      pos: 1.5,-3.5
+      parent: 2
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 0.5,-3.5
+      parent: 2
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 2
+- proto: AU14VehicleRadioSet
+  entities:
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 2
 ...

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/rmcvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/rmcvendors.yml
@@ -1184,6 +1184,7 @@
       - id: AU14CaseSentry
       - id: AU14CaseSentryMini
       - id: AU14CaseSentrySniper
+      - id: RMCM271A2BruteLauncherRigFilled
     - name: Tool Storage
       choices: { CMUCTToolStorage: 1 }
       entries:

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/wyguardvendor.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/wyguardvendor.yml
@@ -92,3 +92,30 @@
         amount: 40
       - id: RMCShoesBlack
         amount: 40
+    - name: Limited Weaponry (Only for EMERGENCIES)
+      entries:
+      - id: RMCWeaponFlamerColony
+        amount: 1
+      - id: RMCTankFlamerColony
+        amount: 3
+      - id: RMCWeaponSMGPDW90
+        amount: 4
+      - id: CMUBoxMagazineSMGPDW90
+        amount: 2
+      - id: AU14WeaponShotgunM890Tactical
+        amount: 1
+      - id: RMCBoxShellsBuckshot
+        amount: 1
+      - id: RMCBoxShellsSlugs
+        amount: 1
+      - id: RMCBoxShellsBeanbag
+        amount: 1
+      - id: RMCBoxShellsFlechette
+        amount: 1
+      - id: RMCWeaponRifleSSG45
+        amount: 2
+      - id: RMCBoxMagazineRifleSSG45
+        amount: 1
+      - id: RMCMagazineRifleSSG45AP
+        amount: 3
+

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
@@ -875,10 +875,13 @@
     - name: Weapons
       choices: { CMUPrimaryWeapon: 1 }
       entries:
+      - id: CMUGunCaseRifleNSG23
       - id: AU14KitWeaponFP9000
       - id: AU14KitWeaponM39B2
     - name: Weapon Ammunition
       entries:
+      - id: RMCMagazineRifleSSG45
+        amount: 60
       - id: RMCMagazineSMGFP9000
         amount: 60
       - id: CMMagazineSMGM63
@@ -989,6 +992,10 @@
         amount: 8
       - id: AU14WeaponRifleF44AA
         amount: 1
+      - id: RMCWeaponRifleSSG45
+        amount: 3
+      - id: WeaponShotgunM890
+        amount: 3
     - name: primary ammunition
       entries:
       - id: RMCMagazineSMGFP9000
@@ -1009,6 +1016,12 @@
         amount: 5
       - id: AU14MagazineRifleF44AA
         amount: 5
+      - id: RMCMagazineRifleSSG45AP
+        amount: 25
+      - id: RMCMagazineRifleSSG45Extended
+        amount: 30
+      - id: RMCMagazineRifleSSG45
+        amount: 100
       - id: RMCBoxShotgunBuckshot
         amount: 20
       - id: RMCBoxShotgunFlechette

--- a/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Survivors/Roles/FORECONMarksman.yml
+++ b/Resources/Prototypes/_CMU14/ThirdParties/Military/FORECON/Survivors/Roles/FORECONMarksman.yml
@@ -100,7 +100,7 @@
     pocket2: AU14PouchIFAKFill
     back: RMCSatchelMarineForeconSurvivorFill
     ears: RMCHeadsetForecon
-    suitstorage: AU14WeaponRifleM49A
+    suitstorage: WeaponRifleM4SPRCustom
   storage:
     back:
     - RMCAttachmentRailFlashlight

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/gun_cases.yml
@@ -941,3 +941,23 @@
     - id: RMCMagazineM2C
     - id: AU14MagazineM2CTracter
     - id: RMCBeltMachineGunner
+
+- type: entity
+  parent: RMCCaseBase
+  id: CMUGunCaseRifleNSG23
+  name: NSG23 Rifle case
+  description: A gun case containing the NSG23.
+  components:
+  - type: Storage
+    maxItemSize: Huge
+    grid:
+    - 0,0,5,1
+  - type: StorageFill
+    contents:
+    - id: RMCWeaponRifleSSG45NoLockStripped
+    - id: RMCMagazineRifleSSG45
+      amount: 7
+    - id: RMCMagazineRifleSSG45Extended
+      amount: 2
+    - id: RMCMagazineRifleSSG45AP
+      amount: 2

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/vehicle_supply.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/vehicle_supply.yml
@@ -762,6 +762,59 @@
       - VehicleSPPTankWarningArray
       - VehicleSPPTankOverdriveEnhancer
       - VehicleSPPTankArtilleryModule
+    - name: FV150 Hobelar LCT (TWE)
+      vehicle: VehicleTankTWE
+      group: vehicle-tank
+      loadoutCategories:
+      - id: primary
+        name: Primary
+        options:
+        - id: VehicleTankAutocannonTWE
+          name: L26A2 45mm Autocannon
+          item: VehicleTankAutocannonTWE
+          slot: primary::turret-cannon
+      - id: secondary
+        name: Secondary
+        options:
+        - id: VehicleTankFlamer
+          name: flamer
+          item: VehicleTankFlamer
+          slot: primary::turret-launcher
+        - id: VehicleTankGrenadeLauncher
+          name: grenade launcher
+          item: VehicleTankGrenadeLauncher
+          slot: primary::turret-launcher
+        - id: VehicleTankTowLauncher
+          name: TOW launcher
+          item: VehicleTankTowLauncher
+          slot: primary::turret-launcher
+        - id: VehicleTankM56Cupola
+          name: M56 cupola
+          item: VehicleTankM56Cupola
+          slot: primary::turret-launcher
+      - id: standardtreads
+        name: Treads
+        options:
+        - id: VehicleTankTreadsTWE
+          name: treads
+          item: VehicleTankTreadsTWE
+          slot: wheel-1
+      - id: support
+        name: Support
+        options:
+        - id: VehicleTankRocketLauncherTWE
+          name: L-39T Smoke Discharger
+          item: VehicleTankRocketLauncherTWE
+          slot: support
+      hardpoints:
+      - VehicleTankTurretTWE
+      - VehicleTankTreadsTWE
+      - VehicleTankFlamer
+      - VehicleTankGrenadeLauncher
+      - VehicleTankTowLauncher
+      - VehicleTankM56Cupola
+      - VehicleTankRERE700
+      - VehicleTankRocketLauncherTWE
 #    - name: blackfoot
 #      vehicle: VehicleBlackfoot
 #      group: vehicle-support

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/hardpoints_base.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/hardpoints_base.yml
@@ -32,7 +32,7 @@
   - type: VehicleTurret
     rotateToCursor: true
     stabilizedRotation: false
-    rotationSpeed: 60
+    rotationSpeed: 80
     showOverlay: true
     overlayRsi: _RMC14/Structures/Vehicles/tank.rsi
     overlayState: tank_turret_0
@@ -122,7 +122,7 @@
       hardpointType: Launcher
       slotType: Launcher
       required: false
-      insertDelay: 2.0      
+      insertDelay: 2.0
 
 - type: entity
   parent: VehicleTankHardpointBase
@@ -144,7 +144,7 @@
   - type: VehicleTurret
     rotateToCursor: true
     stabilizedRotation: false
-    rotationSpeed: 60
+    rotationSpeed: 80
     showOverlay: true
     overlayRsi: _RMC14/Structures/Vehicles/wytank.rsi
     overlayState: tank_turret_0
@@ -221,7 +221,7 @@
   - type: VehicleWheelItem
   - type: RemoveComponents
     components:
-    - type: PowerLoaderGrabbable    
+    - type: PowerLoaderGrabbable
 
 - type: entity
   parent: VehicleTankHardpointBase

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/spp_hardpoints.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/Hardpoints/spp_hardpoints.yml
@@ -24,7 +24,7 @@
   - type: VehicleTurret
     rotateToCursor: true
     stabilizedRotation: false
-    rotationSpeed: 60
+    rotationSpeed: 80
     showOverlay: true
     overlayRsi: _RMC14/Structures/Vehicles/spptank.rsi
     overlayState: tank_turret_0

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/vehicles.yml
@@ -545,10 +545,6 @@
     layers:
     - map: [ base ]
       state: tank_base
-    - map: [ armor ]
-      sprite: _RMC14/Structures/Vehicles/tank.rsi
-      state: ARMOR
-      visible: false
     - map: [ primary ]
       state: tank_turret_0
     - map: [ secondary ]
@@ -563,11 +559,6 @@
       state: wheels_1
   - type: ItemSlots
     slots:
-      armor:
-        disableEject: true
-        whitelist:
-          components:
-          - HardpointItem
       primary:
         startingItem: VehicleTankTurretTWE
         disableEject: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
fixed TWE CT not getting brute as a option, FORECON marksman (survivor) now gets their m4ra, tank turret rotation buffed by 20, weyu pmc now gets a RIFLE as a choice with a UBF variant avail in requisitions alongside mk221 shotguns. weyu goons can now prevent a bioweapon from escaping the lab! (hopefully) they now have access to 1x LC9, 4x P90, 1x shotgun, 2x NSGs in their disposal with munition to hold the biological threat off or any other sorts of attack. longstreet now has a viewport to see the exterior

## Why / Balance
whenever xenos are made we-yu security cannot handle the infestation at all and crumbles very fast which leads to modes like insurgencies becoming like colony fall/distress signal. the addition of long arms should hopefully give weyu goons a chance to fight the bioweapon before help arrives. longstreet and cheetah turret rotate speed has been upped as they cannot counter against xenomorphs/neomorphs (very much tanky and too fast in the case of neomorphs)

## Technical details
yaml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->
<img width="541" height="448" alt="image" src="https://github.com/user-attachments/assets/afc88382-538a-401a-8251-2a2a929a4032" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: FV150 LCT is now available in vehicle lift
- add: NSG23 is now in WEYU PMC weapon vendor. 
- add: NSG23 (UBF) and MK221 now in WEYU PMC req
- add: Corporate has allocated more funds into security, certain firearms are now in disposal for emergencies.
- tweak: longstreet/cheetah turret rotation speed has been increased 
- add: a viewport exterior has been added to longstreet interior
- fix: TWE CT now gets brute as a option in their vendor
- fix: FORECON marksman now gets the M4RA Custom instead of the m49a2

