### PR TITLE
Makes brute/burn kits auto-reapply aslong as there's valid wounds

### DIFF
--- a/Content.Client/Options/UI/Tabs/CmuTab.xaml
+++ b/Content.Client/Options/UI/Tabs/CmuTab.xaml
@@ -23,6 +23,9 @@
                 <CheckBox Name="TargetedHealingCheckBox"
                           Text="{Loc 'cmu-ui-options-targeted-healing'}"
                           ToolTip="{Loc 'cmu-ui-options-targeted-healing-tooltip'}" />
+                <CheckBox Name="AutoReapplyKitsCheckBox"
+                          Text="{Loc 'cmu-ui-options-auto-reapply-kits'}"
+                          ToolTip="{Loc 'cmu-ui-options-auto-reapply-kits-tooltip'}" />
                 <CheckBox Name="UiLessSurgeryCheckBox"
                           Text="{Loc 'cmu-ui-options-ui-less-surgery'}"
                           ToolTip="{Loc 'cmu-ui-options-ui-less-surgery-tooltip'}" />

--- a/Content.Client/Options/UI/Tabs/CmuTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/CmuTab.xaml.cs
@@ -36,6 +36,7 @@ public sealed partial class CmuTab : Control
         Control.AddOptionCheckBox(CCVars.ExamineLogInChat, ExamineLogInChatCheckBox);
         Control.AddOptionCheckBox(CCVars.ExamineFullTextInChat, ExamineFullTextInChatCheckBox);
         Control.AddOptionCheckBox(CMUMedicalCCVars.TargetedHealingEnabled, TargetedHealingCheckBox);
+        Control.AddOptionCheckBox(CMUMedicalCCVars.AutoReapplyKitsEnabled, AutoReapplyKitsCheckBox);
         Control.AddOptionCheckBox(CMUMedicalCCVars.UiLessSurgeryEnabled, UiLessSurgeryCheckBox);
         Control.AddOptionCheckBox(CCVars.CMUScreamOnHotbarEnabled, ScreamOnHotbarCheckBox);
         Control.AddOptionPercentSlider(CMUZLevelsCVars.BlurStrength, ZLevelBlurSlider, scale: OldZLevelBlurStrength);

--- a/Content.IntegrationTests/_RMC14/RMCHumanPrototypeRegressionTest.cs
+++ b/Content.IntegrationTests/_RMC14/RMCHumanPrototypeRegressionTest.cs
@@ -386,16 +386,27 @@ public sealed class RMCHumanPrototypeRegressionTest
         await pair.CleanReturnAsync();
     }
 
-    [Test]
-    public async Task CmuAutomaticInstantKitSearchesBeforeChangingBodyParts()
+    [TestCase("CMTraumaKit10", WoundType.Brute, false)]
+    [TestCase("CMTraumaKit10", WoundType.Brute, true)]
+    [TestCase("CMBurnKit10", WoundType.Burn, false)]
+    [TestCase("CMBurnKit10", WoundType.Burn, true)]
+    public async Task CmuAutoReapplyInstantKitTreatsRemainingWounds(
+        string kitId,
+        WoundType woundType,
+        bool selfTreatment)
     {
-        await using var pair = await PoolManager.GetServerClient();
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            Dirty = true,
+        });
         var server = pair.Server;
         EntityUid medic = default;
         EntityUid patient = default;
         EntityUid kit = default;
         EntityUid chest = default;
         EntityUid head = default;
+        EntityUid? originalAttached = null;
 
         await server.WaitAssertion(() =>
         {
@@ -404,15 +415,20 @@ public sealed class RMCHumanPrototypeRegressionTest
             var skills = entMan.System<SkillsSystem>();
             var targeting = entMan.System<SharedBodyZoneTargetingSystem>();
             medic = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
-            patient = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
-            kit = entMan.SpawnEntity("CMTraumaKit10", MapCoordinates.Nullspace);
+            patient = selfTreatment
+                ? medic
+                : entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            kit = entMan.SpawnEntity(kitId, MapCoordinates.Nullspace);
             chest = GetBodyPart(entMan, patient, BodyPartType.Torso, BodyPartSymmetry.None);
             head = GetBodyPart(entMan, patient, BodyPartType.Head, BodyPartSymmetry.None);
 
+            var player = server.PlayerMan.Sessions[0];
+            originalAttached = player.AttachedEntity;
+            server.PlayerMan.SetAttachedEntity(player, medic);
             skills.SetSkill(medic, "RMCSkillMedical", 2);
             targeting.SelectZone((medic, null), TargetBodyZone.Chest);
-            AddBodyPartWound(entMan, chest, WoundType.Brute, size: WoundSize.CutSmall);
-            AddBodyPartWound(entMan, head, WoundType.Brute, size: WoundSize.CutSmall);
+            AddBodyPartWound(entMan, chest, woundType, size: WoundSize.CutSmall);
+            AddBodyPartWound(entMan, head, woundType, size: WoundSize.CutSmall);
 
             var interact = new AfterInteractEvent(medic, kit, patient, default, true);
             entMan.EventBus.RaiseLocalEvent(kit, interact);
@@ -422,18 +438,24 @@ public sealed class RMCHumanPrototypeRegressionTest
             Assert.Multiple(() =>
             {
                 Assert.That(interact.Handled, Is.True);
-                Assert.That(ledger.GetEntries(chestWounds)[0].Wound.Treated, Is.True);
+                Assert.That(ledger.GetEntries(chestWounds)[0].Wound.Treated, Is.False);
                 Assert.That(ledger.GetEntries(headWounds)[0].Wound.Treated, Is.False);
-                Assert.That(entMan.HasComponent<CMUBandagePendingComponent>(medic), Is.False);
-                Assert.That(entMan.GetComponent<StackComponent>(kit).Count, Is.EqualTo(9));
+                Assert.That(entMan.HasComponent<CMUBandagePendingComponent>(medic), Is.True);
+                Assert.That(entMan.GetComponent<StackComponent>(kit).Count, Is.EqualTo(10));
             });
+        });
 
-            var search = new AfterInteractEvent(medic, kit, patient, default, true);
-            entMan.EventBus.RaiseLocalEvent(kit, search);
+        await pair.RunSeconds(0.3f);
 
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var ledger = entMan.System<CMUWoundLedgerSystem>();
+            var chestWounds = entMan.GetComponent<BodyPartWoundComponent>(chest);
+            var headWounds = entMan.GetComponent<BodyPartWoundComponent>(head);
             Assert.Multiple(() =>
             {
-                Assert.That(search.Handled, Is.True);
+                Assert.That(ledger.GetEntries(chestWounds)[0].Wound.Treated, Is.True);
                 Assert.That(ledger.GetEntries(headWounds)[0].Wound.Treated, Is.False);
                 Assert.That(entMan.HasComponent<CMUBandagePendingComponent>(medic), Is.True);
                 Assert.That(entMan.GetComponent<StackComponent>(kit).Count, Is.EqualTo(9));
@@ -457,11 +479,65 @@ public sealed class RMCHumanPrototypeRegressionTest
 
         await server.WaitPost(() =>
         {
+            server.PlayerMan.SetAttachedEntity(server.PlayerMan.Sessions[0], originalAttached);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CmuAutoReapplyInstantKitCanBeDisabled()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            Dirty = true,
+        });
+        var server = pair.Server;
+        var client = pair.Client;
+        EntityUid? originalAttached = null;
+
+        await client.WaitPost(() =>
+            client.CfgMan.SetCVar(CMUMedicalCCVars.AutoReapplyKitsEnabled, false));
+        await pair.RunTicksSync(2);
+
+        await server.WaitAssertion(() =>
+        {
             var entMan = server.EntMan;
-            foreach (var entity in new[] { kit, patient, medic })
+            var ledger = entMan.System<CMUWoundLedgerSystem>();
+            var skills = entMan.System<SkillsSystem>();
+            var targeting = entMan.System<SharedBodyZoneTargetingSystem>();
+            var medic = entMan.SpawnEntity("CMMobHuman", MapCoordinates.Nullspace);
+            var kit = entMan.SpawnEntity("CMTraumaKit10", MapCoordinates.Nullspace);
+
+            try
             {
-                if (entMan.EntityExists(entity))
-                    entMan.DeleteEntity(entity);
+                var player = server.PlayerMan.Sessions[0];
+                originalAttached = player.AttachedEntity;
+                server.PlayerMan.SetAttachedEntity(player, medic);
+                skills.SetSkill(medic, "RMCSkillMedical", 2);
+                targeting.SelectZone((medic, null), TargetBodyZone.Chest);
+
+                var chest = GetBodyPart(entMan, medic, BodyPartType.Torso, BodyPartSymmetry.None);
+                var head = GetBodyPart(entMan, medic, BodyPartType.Head, BodyPartSymmetry.None);
+                AddBodyPartWound(entMan, chest, WoundType.Brute, size: WoundSize.CutSmall);
+                AddBodyPartWound(entMan, head, WoundType.Brute, size: WoundSize.CutSmall);
+
+                var interact = new AfterInteractEvent(medic, kit, medic, default, true);
+                entMan.EventBus.RaiseLocalEvent(kit, interact);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(interact.Handled, Is.True);
+                    Assert.That(ledger.GetEntries(entMan.GetComponent<BodyPartWoundComponent>(chest))[0].Wound.Treated, Is.True);
+                    Assert.That(ledger.GetEntries(entMan.GetComponent<BodyPartWoundComponent>(head))[0].Wound.Treated, Is.False);
+                    Assert.That(entMan.HasComponent<CMUBandagePendingComponent>(medic), Is.False);
+                    Assert.That(entMan.GetComponent<StackComponent>(kit).Count, Is.EqualTo(9));
+                });
+            }
+            finally
+            {
+                server.PlayerMan.SetAttachedEntity(server.PlayerMan.Sessions[0], originalAttached);
             }
         });
 

--- a/Content.Server/_CMU14/Medical/Injuries/Wounds/CMUBandageInterceptionSystem.cs
+++ b/Content.Server/_CMU14/Medical/Injuries/Wounds/CMUBandageInterceptionSystem.cs
@@ -125,17 +125,21 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
         var canInstantWound = woundTarget != null && CanApplyInstantWoundTreatment(args.User, treater);
         var canInstantKit = CanApplyInstantKit(args.User, used);
         var canApplyInstantTreatment = canInstantWound || canInstantKit;
+        var autoReapplyKit = ShouldAutoReapplyKit(args.User, used, treater);
         if (canApplyInstantTreatment &&
             !targetSelection.UsedSearch &&
-            TryApplyInstantTreatment(args.User, patient, targetPart, used, treater))
+            !autoReapplyKit &&
+            TryApplyInstantTreatment(args.User, patient, targetPart, used, treater, out _))
         {
             args.Handled = true;
             return;
         }
 
-        var deferInstantTreatment = canApplyInstantTreatment && targetSelection.UsedSearch;
+        var deferInstantTreatment = canApplyInstantTreatment && (targetSelection.UsedSearch || autoReapplyKit);
         var fumblingDelay = TimeSpan.Zero;
-        var delay = ResolveSearchDelay(targetSelection);
+        var delay = deferInstantTreatment && autoReapplyKit
+            ? SearchTreatmentDelay
+            : ResolveSearchDelay(targetSelection);
         if (!deferInstantTreatment)
             delay += ResolveBandageDelay(args.User, patient, targetPart, used, treater, out fumblingDelay);
 
@@ -166,6 +170,7 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
         pending.Treater = used;
         pending.PartHealthCapPart = targetPart;
         pending.PartHealthCap = partHealthCap;
+        pending.AutoReapplyKit = autoReapplyKit;
 
         _audio.PlayPvs(treater.TreatBeginSound, args.User);
         if (args.User != patient && treater.TargetStartPopup is { } startPopup)
@@ -281,6 +286,32 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
     {
         return TryComp<ActorComponent>(medic, out var actor) &&
             _netConfig.GetClientCVar(actor.PlayerSession.Channel, CMUMedicalCCVars.TargetedHealingEnabled);
+    }
+
+    private bool IsAutoReapplyKitsEnabled(EntityUid medic)
+    {
+        return TryComp<ActorComponent>(medic, out var actor) &&
+            _netConfig.GetClientCVar(actor.PlayerSession.Channel, CMUMedicalCCVars.AutoReapplyKitsEnabled);
+    }
+
+    private bool IsTraumaOrBurnKit(EntityUid treaterUid, WoundTreaterComponent treater)
+    {
+        if (!treater.CMUTreatsWounds || !TryComp<StackComponent>(treaterUid, out var stack))
+            return false;
+
+        return stack.StackTypeId == BurnKitStack || stack.StackTypeId == TraumaKitStack;
+    }
+
+    private bool ShouldAutoReapplyKit(EntityUid medic, EntityUid treaterUid, WoundTreaterComponent treater)
+    {
+        if (!IsAutoReapplyKitsEnabled(medic) ||
+            !IsTraumaOrBurnKit(treaterUid, treater) ||
+            !TryComp<StackComponent>(treaterUid, out var stack))
+        {
+            return false;
+        }
+
+        return stack.Unlimited || stack.Count > 1;
     }
 
     private static TimeSpan ResolveSearchDelay(TreatmentTarget target)
@@ -562,8 +593,23 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
 
         if (args.ApplyInstantTreatment)
         {
-            TryApplyInstantTreatment(medic, patient, part, treaterUid, treater);
-            RemComp<CMUBandagePendingComponent>(ent);
+            var instantTreated = TryApplyInstantTreatment(medic, patient, part, treaterUid, treater, out var instantHasTreater);
+            var instantRepeatPart = instantTreated && instantHasTreater && ent.Comp.AutoReapplyKit
+                ? GetAutoReapplyKitPart(medic, patient, part, treater)
+                : null;
+            args.Repeat = instantRepeatPart != null;
+            if (instantRepeatPart is { } instantNextTarget)
+            {
+                args.Part = GetNetEntity(instantNextTarget.Part);
+                args.Args.Delay = ResolveSearchDelay(instantNextTarget);
+                _audio.PlayPvs(treater.TreatBeginSound, medic);
+                if (medic != patient && treater.TargetStartPopup is { } startPopup)
+                    _popup.PopupEntity(Loc.GetString(startPopup, ("user", medic)), patient, patient, PopupType.Medium);
+            }
+            else
+            {
+                RemComp<CMUBandagePendingComponent>(ent);
+            }
             return;
         }
 
@@ -648,7 +694,11 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
         _audio.PlayPvs(treater.TreatEndSound, medic);
 
         var hasTreater = ConsumeTreater(treaterUid, treater);
-        var repeatPart = GetRepeatPart(medic, patient, part, treater, repeatPartHealthCap);
+        var repeatPart = IsTraumaOrBurnKit(treaterUid, treater)
+            ? ent.Comp.AutoReapplyKit
+                ? GetAutoReapplyKitPart(medic, patient, part, treater)
+                : null
+            : GetRepeatPart(medic, patient, part, treater, repeatPartHealthCap);
         args.Repeat = hasTreater && repeatPart != null;
         if (args.Repeat && repeatPart is { } nextTarget)
         {
@@ -716,6 +766,18 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
         return PickDamageOnlyTarget(medic, patient, treater, currentPart, partHealthCap);
     }
 
+    private TreatmentTarget? GetAutoReapplyKitPart(
+        EntityUid medic,
+        EntityUid patient,
+        EntityUid currentPart,
+        WoundTreaterComponent treater)
+    {
+        if (IsAttachedPart(patient, currentPart) && PartHasTreatableWound(currentPart, treater))
+            return new TreatmentTarget(currentPart, false);
+
+        return PickBandageTarget(medic, patient, treater);
+    }
+
     private bool TryTreatOneWoundWithTreater(EntityUid part, WoundTreaterComponent treater, out bool completed)
     {
         return _wounds.TryTreatWound(
@@ -742,8 +804,10 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
         EntityUid patient,
         EntityUid firstPart,
         EntityUid treaterUid,
-        WoundTreaterComponent treater)
+        WoundTreaterComponent treater,
+        out bool hasTreater)
     {
+        hasTreater = false;
         var maxWounds = Math.Max(1, treater.WoundsTreatedPerUse);
         var treatedWounds = 0;
         var part = firstPart;
@@ -801,7 +865,7 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
             return false;
 
         _audio.PlayPvs(treater.TreatEndSound, medic);
-        ConsumeTreater(treaterUid, treater);
+        hasTreater = ConsumeTreater(treaterUid, treater);
 
         var userPopup = treater.UserFinishPopup ?? treater.UserPopup;
         var targetPopup = treater.TargetFinishPopup ?? treater.TargetPopup;

--- a/Content.Server/_CMU14/Medical/Injuries/Wounds/CMUBandagePendingComponent.cs
+++ b/Content.Server/_CMU14/Medical/Injuries/Wounds/CMUBandagePendingComponent.cs
@@ -23,4 +23,7 @@ public sealed partial class CMUBandagePendingComponent : Component
 
     [DataField]
     public FixedPoint2? PartHealthCap;
+
+    [DataField]
+    public bool AutoReapplyKit;
 }

--- a/Content.Shared/_CMU14/Medical/Core/CMUMedicalCCVars.cs
+++ b/Content.Shared/_CMU14/Medical/Core/CMUMedicalCCVars.cs
@@ -51,6 +51,13 @@ public sealed partial class CMUMedicalCCVars : CVars
         CVarDef.Create("cmu.medical.targeted_healing.enabled", false, CVar.REPLICATED | CVar.CLIENT | CVar.ARCHIVE);
 
     /// <summary>
+    ///     Whether stacked trauma and burn kits automatically continue to the next applicable wound.
+    ///     Replicated so the server can honor the treating player's preference.
+    /// </summary>
+    public static readonly CVarDef<bool> AutoReapplyKitsEnabled =
+        CVarDef.Create("cmu.medical.auto_reapply_kits.enabled", true, CVar.REPLICATED | CVar.CLIENT | CVar.ARCHIVE);
+
+    /// <summary>
     ///     Whether this client performs surgery directly from tool intent instead of opening the surgery window.
     ///     Replicated so the server can honor the operating player's preference.
     /// </summary>

--- a/Resources/Locale/en-US/_CMU14/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/_CMU14/escape-menu/ui/options-menu.ftl
@@ -9,6 +9,8 @@ cmu-ui-options-construction-mode-default = Default
 cmu-ui-options-medical = Medical
 cmu-ui-options-targeted-healing = Target bandages and medical kits to the selected body part
 cmu-ui-options-targeted-healing-tooltip = Prevents wound treatments from automatically moving to another body part when the selected part cannot be treated.
+cmu-ui-options-auto-reapply-kits = Auto reapply kits on valid wounds
+cmu-ui-options-auto-reapply-kits-tooltip = Automatically continues using stacked trauma and burn kits while the patient has applicable untreated wounds.
 cmu-ui-options-ui-less-surgery = Perform surgery directly with tools
 cmu-ui-options-ui-less-surgery-tooltip = Interprets surgery tools from the selected body part and its current surgical access instead of opening the surgery window.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
As the title says. I'm tired of spam clicking boss.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
QOL, my finger got tired.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Brute/burn kits now auto-reapply if needed/valid