### PR TITLE
Remove clandestine relay from insurgency

### DIFF
--- a/Content.Shared/_AU14/Insurgency/InsurgencyBuiltinFactions.cs
+++ b/Content.Shared/_AU14/Insurgency/InsurgencyBuiltinFactions.cs
@@ -52,7 +52,6 @@ public static class InsurgencyBuiltinFactions
         "RMCTechTreeConsoleCLF",
         "CMFaxCLF",
         "AU14AnalyzerMachineCLF",
-        "AU14CLFBaseStation",
         "RMCLampTripod",
     };
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Just reverting my change. Apparently the CLF already had a clandestine relay, just in the tool vendor.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:

- remove: Reverted addition of clandestine relay to CLF cell kit, because vendor already has a free one.

