### PR TITLE
chloral hydrate recipe

### DIFF
--- a/Resources/Prototypes/_RMC14/Reagents/toxins.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/toxins.yml
@@ -132,7 +132,7 @@
       - !type:Emote # Sedative 6
         emote: Yawn
         showInChat: true
-        probability: 0.25 #TODO makes them confused and eventually sleepy
+        probability: 0.01 #TODO makes them confused and eventually sleepy
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
@@ -141,7 +141,7 @@
         component: RMCUnconscious
         type: Add
         time: 3
-        refresh: false
+        refresh: true
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/toxins.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/toxins.yml
@@ -9,3 +9,15 @@
       amount: 1
   products:
     RMCLexorin: 3
+
+- type: reaction
+  id: RMCChloralhydrate
+  reactants:
+    RMCChlorine:
+      amount: 3
+    RMCEthanol:
+      amount: 1
+    Water:
+      amount: 1
+  products:
+    RMCChloralhydrate: 1


### PR DESCRIPTION
## About the PR
Added craft for chloral hydrate and tweaked some values

## Why / Balance
Chloral hydrate is required in the crafting of soporific. The values were changes so that people dont end up uncon for 5m, making inap 2.0....

## Technical details
Added original recipe, changed a false statement to true for uncon buildup and reduced the yawning sfx spam.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
Added Chloral Hydrate recipe. Soporific can now be made! No more malpractice lawsuits.
