### PR TITLE
Remove temperature requirements for certain reagents

### DIFF
--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
@@ -185,7 +185,6 @@
 
 - type: reaction
   id: CMUFentanylPrecursor
-  minTemp: 350
   reactants:
     CMUOxycodone:
       amount: 1
@@ -196,8 +195,6 @@
 
 - type: reaction
   id: CMUFentanyl
-  minTemp: 400
-  maxTemp: 420
   reactants:
     CMUFentanylPrecursor:
       amount: 1
@@ -210,7 +207,6 @@
 
 - type: reaction
   id: CMUMethPrecursor
-  minTemp: 370
   reactants:
     RMCMethylphenidate:
       amount: 2
@@ -223,7 +219,6 @@
 
 - type: reaction
   id: CMUMethBase
-  minTemp: 400
   reactants:
     CMUMethPrecursor:
       amount: 1
@@ -236,7 +231,6 @@
 
 - type: reaction
   id: CMUMethamphetamine
-  maxTemp: 320
   reactants:
     CMUMethBase:
       amount: 1


### PR DESCRIPTION
## About the PR
Removed temperature requirements for several newly added reagents

## Why / Balance
As I have discovered, some maps have very weird temperatures, resulting in some temperature ranges being impossible to reach and thus making certain reagents unobtainable.

## Technical details
Deleted temperature values.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
remove: temperature requirements from the newly added reagents in #1673.
