### PR TITLE
Queen death and non-replacement causes hive collapse

### DIFF
--- a/Content.Server/_CMU14/Threats/Rules/HiveCollapseRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/HiveCollapseRuleSystem.cs
@@ -18,9 +18,7 @@ public sealed partial class HiveCollapseRuleSystem : GameRuleSystem<HiveCollapse
     [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
 
     private const string DefaultWinMsg = "The hive has collapsed!";
-
     private TimeSpan? _hiveCollapseTime;
-    
 
     public override void Initialize()
     {
@@ -29,41 +27,54 @@ public sealed partial class HiveCollapseRuleSystem : GameRuleSystem<HiveCollapse
         SubscribeLocalEvent<XenoHiveQueenChangedEvent>(OnQueenChanged);
     }
 
+    protected override void Started(EntityUid uid, HiveCollapseRuleComponent component,
+        GameRuleComponent gameRule, GameRuleStartedEvent args)
+    {
+        base.Started(uid, component, gameRule, args);
+
+        _hiveCollapseTime = AnyHiveHasQueen()
+            ? null
+            : _timing.CurTime + component.HiveCollapseDuration;
+    }
+
+    private bool AnyHiveHasQueen()
+    {
+        var query = EntityQueryEnumerator<HiveComponent>();
+        while (query.MoveNext(out _, out var hive))
+        {
+            if (hive.CurrentQueen != null)
+                return true;
+        }
+
+        return false;
+    }
+
     private void OnQueenChanged(XenoHiveQueenChangedEvent ev)
     {
         if (!_gameTicker.IsGameRuleActive<HiveCollapseRuleComponent>())
-        {
             return;
-        }
+
         EntityQueryEnumerator<ActiveGameRuleComponent, HiveCollapseRuleComponent, GameRuleComponent> queryRule
             = QueryActiveRules();
         if (!ThreatRuleHelper.TryGetActiveRule(ref queryRule, out HiveCollapseRuleComponent ruleComp, out _))
             return;
 
-        if (ev.NewQueen == null)
-        {
-            _hiveCollapseTime = _timing.CurTime + ruleComp.HiveCollapseDuration;
-        }
-        else
-        {
+        if (AnyHiveHasQueen())
             _hiveCollapseTime = null;
-        }
+        else
+            _hiveCollapseTime ??= _timing.CurTime + ruleComp.HiveCollapseDuration;
     }
 
-    public override void Update(float frameTime)
+    protected override void ActiveTick(EntityUid uid, HiveCollapseRuleComponent component, GameRuleComponent gameRule,
+        float frameTime)
     {
-        base.Update(frameTime);
+        base.ActiveTick(uid, component, gameRule, frameTime);
 
-        if (!_gameTicker.IsGameRuleActive<HiveCollapseRuleComponent>() ||
-            _hiveCollapseTime == null)
+        if (_hiveCollapseTime == null || _timing.CurTime < _hiveCollapseTime)
             return;
 
-        
-        if (_timing.CurTime > _hiveCollapseTime)
-        {
-            string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
-            _roundStats.RecordThreatDefeatedRule("HiveCollapseRule");
-            _gameTicker.EndRound(string.IsNullOrEmpty(winMessage) ? DefaultWinMsg : winMessage);
-        }
+        string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+        _roundStats.RecordThreatDefeatedRule("HiveCollapseRule");
+        _gameTicker.EndRound(string.IsNullOrEmpty(winMessage) ? DefaultWinMsg : winMessage);
     }
 }

--- a/Content.Server/_CMU14/Threats/Rules/HiveCollapseRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/HiveCollapseRuleSystem.cs
@@ -1,0 +1,69 @@
+using Content.Server._CMU14.RoundStatistics;
+using Content.Server._RMC14.Xenonids.Hive;
+using Content.Server.AU14.Round;
+using Content.Server.GameTicking;
+using Content.Server.GameTicking.Rules;
+using Content.Shared._RMC14.Xenonids.Hive;
+using Content.Shared.GameTicking.Components;
+using Robust.Shared.Timing;
+using HiveCollapseRuleComponent = Content.Shared._CMU14.Threats.Rules.HiveCollapseRuleComponent;
+
+namespace Content.Server._CMU14.Threats.Rules;
+
+public sealed partial class HiveCollapseRuleSystem : GameRuleSystem<HiveCollapseRuleComponent>
+{
+    [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private AuRoundSystem _auRoundSystem = default!;
+    [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
+
+    private const string DefaultWinMsg = "The threat has been eliminated!";
+
+    private TimeSpan? _hiveCollapseTime;
+    
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<XenoHiveQueenChangedEvent>(OnQueenChanged);
+    }
+
+    private void OnQueenChanged(XenoHiveQueenChangedEvent ev)
+    {
+        if (!_gameTicker.IsGameRuleActive<HiveCollapseRuleComponent>())
+        {
+            return;
+        }
+        EntityQueryEnumerator<ActiveGameRuleComponent, HiveCollapseRuleComponent, GameRuleComponent> queryRule
+            = QueryActiveRules();
+        if (!ThreatRuleHelper.TryGetActiveRule(ref queryRule, out HiveCollapseRuleComponent ruleComp, out _))
+            return;
+
+        if (ev.NewQueen == null)
+        {
+            _hiveCollapseTime = _timing.CurTime + ruleComp.HiveCollapseDuration;
+        }
+        else
+        {
+            _hiveCollapseTime = null;
+        }
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_gameTicker.IsGameRuleActive<HiveCollapseRuleComponent>() ||
+            _hiveCollapseTime == null)
+            return;
+
+        
+        if (_timing.CurTime > _hiveCollapseTime)
+        {
+            string? winMessage = _auRoundSystem.SelectedThreat?.WinMessage;
+            _roundStats.RecordThreatDefeatedRule("HiveCollapseRule");
+            _gameTicker.EndRound(string.IsNullOrEmpty(winMessage) ? DefaultWinMsg : winMessage);
+        }
+    }
+}

--- a/Content.Server/_CMU14/Threats/Rules/HiveCollapseRuleSystem.cs
+++ b/Content.Server/_CMU14/Threats/Rules/HiveCollapseRuleSystem.cs
@@ -17,7 +17,7 @@ public sealed partial class HiveCollapseRuleSystem : GameRuleSystem<HiveCollapse
     [Dependency] private AuRoundSystem _auRoundSystem = default!;
     [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
 
-    private const string DefaultWinMsg = "The threat has been eliminated!";
+    private const string DefaultWinMsg = "The hive has collapsed!";
 
     private TimeSpan? _hiveCollapseTime;
     

--- a/Content.Shared/_CMU14/Threats/Rules/HiveCollapseRuleComponent.cs
+++ b/Content.Shared/_CMU14/Threats/Rules/HiveCollapseRuleComponent.cs
@@ -8,6 +8,6 @@ public sealed partial class HiveCollapseRuleComponent : Component
     ///     Default 10 Minutes.
     /// </summary>
     [DataField("hiveCollapseDuration")]
-    public TimeSpan HiveCollapseDuration = TimeSpan.FromSeconds(600);
+    public TimeSpan HiveCollapseDuration = TimeSpan.FromMinutes(10);
 
 }

--- a/Content.Shared/_CMU14/Threats/Rules/HiveCollapseRuleComponent.cs
+++ b/Content.Shared/_CMU14/Threats/Rules/HiveCollapseRuleComponent.cs
@@ -5,9 +5,9 @@ public sealed partial class HiveCollapseRuleComponent : Component
 {
     /// <summary>
     ///     Duration in seconds for the hive to collapse once the Queen has fallen.
-    ///     Default 5 Minutes.
+    ///     Default 10 Minutes.
     /// </summary>
     [DataField("hiveCollapseDuration")]
-    public TimeSpan HiveCollapseDuration = TimeSpan.FromSeconds(300);
+    public TimeSpan HiveCollapseDuration = TimeSpan.FromSeconds(600);
 
 }

--- a/Content.Shared/_CMU14/Threats/Rules/HiveCollapseRuleComponent.cs
+++ b/Content.Shared/_CMU14/Threats/Rules/HiveCollapseRuleComponent.cs
@@ -1,0 +1,13 @@
+namespace Content.Shared._CMU14.Threats.Rules;
+
+[RegisterComponent]
+public sealed partial class HiveCollapseRuleComponent : Component
+{
+    /// <summary>
+    ///     Duration in seconds for the hive to collapse once the Queen has fallen.
+    ///     Default 5 Minutes.
+    /// </summary>
+    [DataField("hiveCollapseDuration")]
+    public TimeSpan HiveCollapseDuration = TimeSpan.FromSeconds(300);
+
+}

--- a/Content.Shared/_CMU14/Threats/Rules/HiveCollapseRuleComponent.cs
+++ b/Content.Shared/_CMU14/Threats/Rules/HiveCollapseRuleComponent.cs
@@ -7,7 +7,6 @@ public sealed partial class HiveCollapseRuleComponent : Component
     ///     Duration in seconds for the hive to collapse once the Queen has fallen.
     ///     Default 10 Minutes.
     /// </summary>
-    [DataField("hiveCollapseDuration")]
+    [DataField]
     public TimeSpan HiveCollapseDuration = TimeSpan.FromMinutes(10);
-
 }

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -394,11 +394,13 @@ public abstract partial class SharedXenoHiveSystem : EntitySystem
         if (hive.Comp.CurrentQueen == queen)
             return true;
 
+        var oldQueen = hive.Comp.CurrentQueen;
+
         hive.Comp.CurrentQueen = queen;
         Dirty(hive);
 
-        var ev = new XenoHiveQueenChangedEvent();
-        RaiseLocalEvent(hive.Owner, ref ev);
+        var ev = new XenoHiveQueenChangedEvent(oldQueen, queen);
+        RaiseLocalEvent(hive.Owner, ev, true);
         return true;
     }
 
@@ -412,6 +414,7 @@ public abstract partial class SharedXenoHiveSystem : EntitySystem
 
     private void ClearHiveQueen(Entity<HiveComponent> hive, bool died = false)
     {
+        var oldQueen = hive.Comp.CurrentQueen;
         hive.Comp.CurrentQueen = null;
 
         if (died)
@@ -423,8 +426,8 @@ public abstract partial class SharedXenoHiveSystem : EntitySystem
 
         Dirty(hive);
 
-        var ev = new XenoHiveQueenChangedEvent();
-        RaiseLocalEvent(hive.Owner, ref ev);
+        var ev = new XenoHiveQueenChangedEvent(oldQueen, null);
+        RaiseLocalEvent(hive.Owner, ev, true);
     }
 
     public bool HasHiveCore(Entity<HiveComponent> hive)

--- a/Content.Shared/_RMC14/Xenonids/Hive/XenoHiveQueenChangedEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/XenoHiveQueenChangedEvent.cs
@@ -1,4 +1,8 @@
 namespace Content.Shared._RMC14.Xenonids.Hive;
 
-[ByRefEvent]
-public readonly record struct XenoHiveQueenChangedEvent;
+/// <summary>
+///    Event that is raised whenever the Queen of a Hive changes;
+/// </summary>
+/// <param name="OldQueen"></param>
+/// <param name="NewQueen"></param>
+public record struct XenoHiveQueenChangedEvent(EntityUid? OldQueen, EntityUid? NewQueen);

--- a/Resources/Prototypes/_CMU14/RoundSetup/Scenario/distress_signal/threats.yml
+++ b/Resources/Prototypes/_CMU14/RoundSetup/Scenario/distress_signal/threats.yml
@@ -37,6 +37,7 @@
   winConditionRuleIds:
     - KillAllGovforRule
     - KillAllXenoRule
+    - HiveCollapseRule
 
 - type: roundGroup
   id: DistressSignalAbominationRoundGroup

--- a/Resources/Prototypes/_CMU14/Threats/Shared/win_rules.yml
+++ b/Resources/Prototypes/_CMU14/Threats/Shared/win_rules.yml
@@ -53,6 +53,14 @@
       percent: 100
 
 - type: entity
+  id: HiveCollapsedRule
+  parent: BaseGameRule
+  name: Kill The Queen and Let the Hive Collapse
+  description: Threat wins when the Queen is dead and no Replacement Queen evolves in time.
+  components:
+    - type: HiveCollapseRule
+
+- type: entity
   id: KillAllXenoRule
   parent: BaseGameRule
   name: Kill All Xenos/Cultists

--- a/Resources/Prototypes/_CMU14/Threats/Shared/win_rules.yml
+++ b/Resources/Prototypes/_CMU14/Threats/Shared/win_rules.yml
@@ -53,7 +53,7 @@
       percent: 100
 
 - type: entity
-  id: HiveCollapsedRule
+  id: HiveCollapseRule
   parent: BaseGameRule
   name: Kill The Queen and Let the Hive Collapse
   description: Threat wins when the Queen is dead and no Replacement Queen evolves in time.

--- a/Resources/Prototypes/_CMU14/Threats/Shared/win_rules.yml
+++ b/Resources/Prototypes/_CMU14/Threats/Shared/win_rules.yml
@@ -59,6 +59,7 @@
   description: Threat wins when the Queen is dead and no Replacement Queen evolves in time.
   components:
     - type: HiveCollapseRule
+      hiveCollapseDuration: 10 # minutes
 
 - type: entity
   id: KillAllXenoRule


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added new rule to force xeno loss after a certain amount of time after loosing the queen. 10 minutes as default hive collapse duration.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->
<img width="1680" height="1050" alt="Screenshot 2026-08-01 at 3 26 44 PM" src="https://github.com/user-attachments/assets/a448b75d-665e-4ebe-9c64-a446f15bbaf5" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: blueDev2
- tweak: Hive collapse occurs 10 minutes after queen dies without replacement.
