### PR TITLE
Hot fix BUG-384

### DIFF
--- a/Content.Server/_CMU14/Round/Objectives/ObjectiveControlSystem.Completion.cs
+++ b/Content.Server/_CMU14/Round/Objectives/ObjectiveControlSystem.Completion.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using Content.Server._CMU14.RoundStatistics;
 using Content.Shared._CMU14.Round.Objectives.Component;
 using Content.Shared._CMU14.Round.Objectives.Type;
+using Content.Shared._RMC14.Intel;
 using Content.Shared._RMC14.Vendors;
 using Robust.Shared.Map;
 
@@ -12,6 +13,7 @@ public sealed partial class ObjectiveControlSystem
     [Dependency] private SharedCMAutomatedVendorSystem _vendorSystem = default!;
     [Dependency] private CMURoundStatisticsSystem _roundStats = default!;
     [Dependency] private ObjectiveConsoleSystem _objConsole = default!;
+    [Dependency] private IntelSystem _intel = default!;
 
     public void CompleteObjectiveForFaction(EntityUid uid, CMUObjectiveComponent objective, string completingFaction, bool awardPoints = true, ISawmill? sawmill = null)
     {
@@ -165,6 +167,7 @@ public sealed partial class ObjectiveControlSystem
         data.CurrentWinPoints += points;
         DirtyObjectiveMaster();
         _vendorSystem.UpdateVendorFactionPointsCache(key, data.CurrentWinPoints);
+        _intel.UpdateTree(_intel.EnsureTechTree(key));
 
         if (!master.FactionsGivenFinalObjective.Contains(key) && data.CurrentWinPoints >= data.RequiredWinPoints)
             TryActivateFinalObjective(key);


### PR DESCRIPTION
- **🔧 Total Objective System Refactor - layout**
- **🔧 Objective (Destroy) Refactor**
- **🔧 Objective (Fetch) Refactor**
- **🔧 Objective (Capture) Refactor**
- **🔧 Objective (Arrest) Refactor**
- **🔧 Objective (Kill) Refactor**
- **🔧 Objective (Interact) Refactor**
- **📋 EndRound change from PR#1578 update**
- **🔥 deprecate old AU14/Objectives system (remove later)**
- **🔧 port obj orchestrator and shared base to _CMU14/Round/Objectives**
- **🔧 port the objective type sys to _CMU14/Round/Objectives/Type**
- **🔧 port obj client UI and shared console/master comps**
- **📋 hook up the new objectives system into game systems and update .yml protos**
- **🩹 fix objective bugs/tidy and DRY/OOP-refactor the types**
- **📋 remove this incredibly weird .yml naming**
- **🔧 better type objectives logging**
- **🩹 objectives code cleanup and final touches**
- **📋 distress signal alias**
- **🔥 remove the old implementation**
- **🩹 remove stale comps - PlanetLoadsWithoutErrorsTest testcase fix**
- **🩹 fix BUG-384 - CLF tech tree console not synced to vendors**
