### PR TITLE
Removes weyu scout rifle burst mode

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
@@ -201,6 +201,8 @@
     recoilUnwielded: 1
     scatterWielded: 4
     baseFireRate: 2.8
+    baseFireModes:
+    - SemiAuto
   - type: ItemSlots
     slots:
       gun_magazine:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Giving scout rifle burst was already denied a while ago, this is just an oversight that's fixed. Additionally, it had better dps than a smart gunner.
Was missing baseFireMode in the yml

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
no cl
