### PR TITLE
SHARP tweaks

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/sharp_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/sharp_rifle.yml
@@ -281,7 +281,7 @@
     explosionType: RMC
     maxIntensity: 25
     intensitySlope: 8
-    totalIntensity: 220
+    totalIntensity: 190
     canCreateVacuum: false
   - type: RMCScorchEffect
     radius: 3
@@ -296,7 +296,7 @@
     explosionType: RMC
     maxIntensity: 25
     intensitySlope: 6
-    totalIntensity: 260
+    totalIntensity: 240
     canCreateVacuum: false
 
 - type: entity
@@ -475,6 +475,7 @@
   - type: SharpMine
     kind: Explosive
     triggerRadius: 1.5
+    upgradeEvery: 45
     effects:
     - RMCSharpExplosiveMineEffect1
     - RMCSharpExplosiveMineEffect2
@@ -483,6 +484,8 @@
   - type: StepTrigger
     active: false
     requiredTriggeredSpeed: 0
+  - type: RMCNightVisionVisible
+    priority: -1
   - type: RMCMesonsNonviewable
   - type: Flammable
     fireSpread: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
SHARP mines are now visible through walls for xenomorphs.
The first two tiers of the HE mine do less damage.
It takes slightly longer to upgrade to the next tier.

## Why / Balance
There was quite a bit of discussion over this, but I think these changes are good.
Xenos struggled against SHARP if they weren't one of the few castes that had either full explosion resist or were mostly immune. The mines are a very powerful area denial tool, and can catch you off guard quite easily. At some points, they're better at area denial than CAS flares. Making them visible through walls is a major step that should help to deal with its power.
The first two tiers now also do less damage, and no longer oneshot T1s/some T2s the moment they're set down. The argument for this was one-shot mechanics in the game being highly undesirable and just bad to play against, as not even SADAR did this. Mind you, this still crits runner and hurts anything with less than 20 explosion armor a lot. The rest of the tiers retain their damage.
Mines upgrading also take 45 seconds instead of just 30 now. 
The last two changes were also done as a compromise for the great ammo economy that SHARP has.

## Technical details
UpgradeEvery field added to yml

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: SHARP mines are now visible through walls for xenomorphs.
- tweak: The first two tiers of the HE mine do less damage.
- tweak: It takes slightly longer for mines to upgrade to the next tier.