### PR TITLE
Reagent recipes, changes and other unrelated fixes

### DIFF
--- a/Resources/Prototypes/_CMU14/Economy/Recipes/Reactions/other.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Recipes/Reactions/other.yml
@@ -98,3 +98,16 @@
       catalyst: true
   products:
     CMUPhenolFormaldehyde: 1
+
+- type: reaction
+  id: AU14Albuterol
+  reactants:
+    CMUAtropine:
+      amount: 1
+    CMUPhenol:
+      amount: 1
+    CMUPulmovine:
+      amount: 3
+  products:
+    AU14Albuterol: 3
+

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/cmbciuvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/cmbciuvendors.yml
@@ -361,7 +361,6 @@
     # - id: AU14PillCanisterImidazoline
     - name: Limited Injector Medications
       choices: { CMUPlatoonMedicalLimitedMedicationsInjectors: 6 }
-      takeAll: CMULimitedPills
       entries:
       - id: AU14MeraBicAutoInjector
       - id: AU14KeloDermAutoInjector

--- a/Resources/Prototypes/_CMU14/Entities/Objects/Items/Medical/medical.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/Items/Medical/medical.yml
@@ -691,7 +691,7 @@
   name: reagent-name-albuterol
   desc: reagent-desc-albuterol
   color: "#1f83a7"
-  overdose: 35
+  overdose: 20
   metabolisms:
     Medicine:
       metabolismRate: 0.04
@@ -703,14 +703,14 @@
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 30
+          min: 20
         damage:
           groups:
             Toxin: 0.5
       - !type:HealthChange
         conditions:
         - !type:ReagentThreshold
-          min: 50
+          min: 30
         damage:
           groups:
             Brute: 1

--- a/Resources/Prototypes/_CMU14/Medical/Treatment/Reagents/painkillers.yml
+++ b/Resources/Prototypes/_CMU14/Medical/Treatment/Reagents/painkillers.yml
@@ -281,9 +281,12 @@
         durationPerUnit: 75
       - !type:ModifyStatusEffect
         effectProto: StatusEffectDrowsiness
-        time: 5
+        conditions:
+        - !type:ReagentThreshold
+          min: 8
+        time: 15
         type: Add
-        refresh: false
+        refresh: true
       - !type:ModifyStatusEffect
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Medical/AU14JobCivilianHeadPhysician.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Medical/AU14JobCivilianHeadPhysician.yml
@@ -61,7 +61,6 @@
 - type: startingGear
   id: AU14GearCivilianHeadPhysician
   equipment: {}
-    ears: AU14ColonyAdminHeadset
   storage:
     back:
     - AU14StampHPHY

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Medical/AU14JobCivilianHeadPhysician.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Medical/AU14JobCivilianHeadPhysician.yml
@@ -61,6 +61,7 @@
 - type: startingGear
   id: AU14GearCivilianHeadPhysician
   equipment: {}
+  ears: AU14ColonyAdminHeadset
   storage:
     back:
     - AU14StampHPHY

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Medical/AU14JobCivilianHeadPhysician.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Medical/AU14JobCivilianHeadPhysician.yml
@@ -61,7 +61,7 @@
 - type: startingGear
   id: AU14GearCivilianHeadPhysician
   equipment: {}
-  ears: AU14ColonyAdminHeadset
+    ears: AU14ColonyAdminHeadset
   storage:
     back:
     - AU14StampHPHY

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -129,8 +129,8 @@
   name: reagent-name-cmdexalinplus
   desc: reagent-desc-cmdexalinplus
   color: "#5887D5"
-  overdose: 15
-  criticalOverdose: 25
+  overdose: 5
+  criticalOverdose: 15
   class: Uncommon
   metabolisms:
     Medicine:
@@ -342,16 +342,16 @@
   name: reagent-name-rmcrussianred
   desc: reagent-desc-rmcrussianred
   color: "#ce2727"
-  overdose: 20
-  criticalOverdose: 30
+  overdose: 15
+  criticalOverdose: 25
   metabolisms:
     Medicine:
-      metabolismRate: 0.5
+      metabolismRate: 0.1
       effects:
-      - !type:Antitoxic
-        potency: 1
-      - !type:Biocidic
-        potency: 2
+      - !type:Toxic
+        potency: 4
+      - !type:Corrosive
+        potency: 4
 
 # Antidepressants/ADHD meds
 - type: reagent

--- a/Resources/Prototypes/_RMC14/Reagents/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Reagents/medicine.yml
@@ -348,6 +348,10 @@
     Medicine:
       metabolismRate: 0.1
       effects:
+      - !type:EqualHealthChange
+        conditions:
+        damage:
+        - Genetic: -0.1
       - !type:Toxic
         potency: 4
       - !type:Corrosive

--- a/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Reactions/medicine.yml
@@ -438,3 +438,17 @@
       amount: 1
   products:
     RMCLipozine: 3
+
+- type: reaction
+  id: RMCRussianRed
+  reactants:
+    RMCEthanol:
+      amount: 1
+    CMArithrazine:
+      amount: 1
+    CMTricordrazine:
+      amount: 1
+  products:
+    RMCRussianRed: 3
+
+


### PR DESCRIPTION
## About the PR
Added Russian Red and Albuterol crafting recipes. Changes Albuterol & Dexalin Plus OD threshold. Fixed Soporific causing really long uncon times (10u would result in 5m of "drowsiness" which is effectively unconsciousness as the character rapidly falls asleep).  Fixed CMB CIU corpsman vendor, can now take 6 injectors of choice as inline with all the other factions (this was a copy and paste error).

## Why / Balance
Russian Red is a very crude chemical that can treat genetic damage, currently the only way to treat it would be using cryochambers which arent functional however it is still x10 less effective that the cryo treatments themself. Albuterol craft was added to allow CLF docs, colony hospital and govfor doctors, to be able to use the chem as currently only corpsmen get access. The recipe itself is hopefully a bit time consuming as it requires organ meds and botany chems to make. Albuterol and Dexalin Plus ODs were lowered to make IB's (and other asphyxiating events) less trivialized by medication. 
## Technical details
YAML changes

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added Russian Red and Albuterol crafting recipes.
- tweak: Changed Russian Red as a medicine, now acts as a very crude treatment for genetic damage.
- tweak: Changed OD amounts for Albuterol (20 OD, 30 Crit OD) and Dexalin Plus (5 OD, 15 Crit OD).
- tweak: Changed soporifics drowsiness so it no longer accumulates, no more 5 minutes of fading in and out of consciousness.
- fix: Fixed CMB CIU corpsman vendor, can now take 6 injectors of choice.
