### PR TITLE
Qyj buff and GAU 19 fix

### DIFF
--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/LMGs/gau19e2.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/LMGs/gau19e2.yml
@@ -35,6 +35,7 @@
           - SmartGunBattery
   - type: GunIFF
     enabled: false
+    preventFriendlyFire: false
   - type: IFFToggle
     showToggleAction: false
 

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/LMGs/qyj_72.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/LMGs/qyj_72.yml
@@ -155,7 +155,7 @@
   - type: Projectile
     damage:
       types:
-        Piercing: 35
+        Piercing: 40
   - type: RMCProjectileDamageFalloff
     thresholds:
     - range: 22

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/LMGs/qyj_72.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/LMGs/qyj_72.yml
@@ -104,9 +104,6 @@
   - type: Corrodible
     isCorrodible: false
   - type: SmartGun
-  - type: GunIFF
-    enabled: true
-    preventFriendlyFire: true
   - type: RMCMagneticItem
 
 - type: entity


### PR DESCRIPTION
## About the PR
increased QYJ damage from 35 to 40 and removed IFF lockout

## Why / Balance
with a 5.1 firerate and need to bipod to be used effectively (1.9 per second if no bipod), there are not much reasons to pick QYJ over RVS

increased damage to see if the 5 increase in damage will be enough to improve QYJ lethality to give autoriflemen a reason to pick it over RVS

also, QYJ is a non-smart GPMG so i removed its IFF that's supposed to be for smartguns
GAU-19 should also not have IFF since its own description says so. As such, no IFF lock

## Technical details
like, a few yaml lines

## Media
uh, nothing really

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: upped QYJ damage from 35 to 40
- tweak: removed QYJ IFF lockout since it's a non-smart gun
- tweak: stopped GAU-19 from locking up due to IFF
