### PR TITLE
updating req to match new standard issue

### DIFF
--- a/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
@@ -571,6 +571,8 @@
       entries:
       - id: AU14WeaponSMGXMP5A6HAZOPS
         amount: 30
+      - id: AUWeaponRifleXM20A2HAZOPS
+        amount: 20
     - name: standard issue secondaries
       entries:
       - id: CMWeaponPistolM1984Empty

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
@@ -992,7 +992,7 @@
         amount: 8
       - id: AU14WeaponRifleF44AA
         amount: 1
-      - id: RMCWeaponRifleSSG45
+      - id: RMCWeaponRifleSSG45NoLock
         amount: 3
       - id: WeaponShotgunM890
         amount: 3

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/wypmcvendors.yml
@@ -982,6 +982,8 @@
         amount: 30
       - id: RMCWeaponSMGM63B2
         amount: 20
+      - id: RMCWeaponRifleSSG45NoLockStripped
+        amount: 20
     - name: standard issue secondaries
       entries:
       - id: RMCWeaponPistolM77Empty


### PR DESCRIPTION
## About the PR
wypmc req has id locked NSG23's which will bind on the user taking it from vendor (req tech, MP, etc.) so swapped it out with non-ID locked variant

added xm20a2 to hazops req vendor

## Why / Balance
during hazops round, some people got the smg by accident and i couldn't help them because the xm20a2 wasn't in req but xm20a2 is supposed to be standard issue

during wypmc round, someone requested NSG23 because same reasoning. Dispensed an ID lock NSG23 which immediately binded to me so the ID lock is rendered useless. Might as well dispense the non-ID locked variant

## Technical details
yaml 2 lines

## Media
<img width="503" height="695" alt="image" src="https://github.com/user-attachments/assets/16eb7562-58e2-434c-8439-6ef61de3c193" />

<img width="374" height="352" alt="image" src="https://github.com/user-attachments/assets/cc003804-91b4-44e9-87d1-5eef866954e7" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: added twenty (20) units of XM20A2 Pulse Rifle to HAZOPS Requisitions Vendor
- tweak: replaced the NSG23 in WYPMC Requisitions Vendor to the non-ID locked variant due to the ID lock binding to the user who vends the rifle and not the actual user