### PR TITLE
Removes ability to build cades and other structures inside vehicles

### DIFF
--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
@@ -6,6 +6,7 @@ using Content.Shared._RMC14.Entrenching;
 using Content.Shared._RMC14.Ladder;
 using Content.Shared._RMC14.Map;
 using Content.Shared._RMC14.Marines.Skills;
+using Content.Shared._RMC14.Vehicle;
 using Content.Shared.Construction;
 using Content.Shared.Construction.Components;
 using Content.Shared.Coordinates;
@@ -453,6 +454,13 @@ public sealed partial class RMCConstructionSystem : EntitySystem
     public bool CanBuildAt(EntityCoordinates coordinates, EntProtoId prototype, out string? popup, bool anchoring = false, Direction direction = Direction.Invalid, CollisionGroup? collision = null, EntityUid? user = null)
     {
         popup = default;
+
+        if (user != null && HasComp<VehicleInteriorOccupantComponent>(user.Value))
+        {
+            popup = Loc.GetString("construction-system-inside-container");
+            return false;
+        }
+
         if (!_prototype.TryIndex<EntityPrototype>(prototype, out var proto))
             return false;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Unintended feature. Chip wanted this.
Other structures refers to girders and such.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Barricades and some other structures can no longer be built inside vehicles.