### PR TITLE
Update qyj_72.yml

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/LMGs/qyj_72.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/LMGs/qyj_72.yml
@@ -88,6 +88,7 @@
         startingAttachable: RMCAttachmentTwoPointSling
         whitelist:
           tags:
+          - RMCAttachmentS42xTelescopicMiniscope
           - RMCAttachmentRailFlashlight
           - RMCAttachmentMagneticHarness
       rmc-aslot-underbarrel:


### PR DESCRIPTION

## About the PR
allowed qyj to take a 2x scope so it can actually be used properly in its niche of dealing relatively accurate and powerful suppressing fire from some distance away

## Why / Balance
QYJ fires 5.1 rounds per sec when deployed. Damage doesn't fall off until 22 tiles and accuracy until 14. It's hard to use it to its full potential without being able to see far enough to know what you're shooting at

this allows a 2x scope to be put on but brings the downside of lowering fire rate to 2.9 when magnified

now, you can either go for more precise, slower rate of fire suppression when magnified or less precise, higher rate of suppression when not magnified. that or you could just magnify to check for targets and then turn it off when you're going to shoot idk

## Technical details
1 line yaml

## Media
<img width="431" height="204" alt="image" src="https://github.com/user-attachments/assets/83ffbca7-8a93-42d8-8112-0f57c0496264" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: QYJ can now use an S4 2x mini-scope