### PR TITLE
feat(clf): fix earpieces, add standing orders, comms kill switch for CLF

### DIFF
--- a/Content.Server/CharacterInfo/CharacterInfoSystem.cs
+++ b/Content.Server/CharacterInfo/CharacterInfoSystem.cs
@@ -83,6 +83,7 @@ public sealed partial class CharacterInfoSystem : EntitySystem
 
         var isThreatRole = mind != null && IsThreatMind(mind);
         PopulateLorePrimerLines(lorePrimerLines, jobId, isThreatRole);
+        AddCLFStandingOrders(lorePrimerLines, entity);
 
         // Check inventory and hands for JobTitleChangerComponent
         if (TryComp(entity, out InventoryComponent? _))

--- a/Content.Server/_AU14/Callsigns/AU14CallsignSystem.cs
+++ b/Content.Server/_AU14/Callsigns/AU14CallsignSystem.cs
@@ -1,3 +1,4 @@
+using Content.Server._AU14.Radio;
 using Content.Server._RMC14.Marines.Roles.Ranks;
 using Content.Server.Chat.Systems;
 using Content.Server.Radio.EntitySystems;
@@ -28,6 +29,7 @@ public sealed partial class AU14CallsignSystem : EntitySystem
     [Dependency] private IPrototypeManager _prototype = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private AU14CommsToggleSystem _comms = default!;
 
     private static readonly Dictionary<string, string> DefaultCommandWords = new()
     {
@@ -401,7 +403,9 @@ public sealed partial class AU14CallsignSystem : EntitySystem
     // handler runs first wins safely
     private void OnCallsignSpeak(Entity<AU14CallsignComponent> ent, ref EntitySpokeEvent args)
     {
-        if (!_commsEnabled || args.Channel == null || string.IsNullOrEmpty(ent.Comp.Callsign))
+        // the CLF nets can be dropped back to stock radio on their own, and stock radio
+        // puts a speaker on air under their own name
+        if (!_comms.EnabledOn(args.Channel) || args.Channel == null || string.IsNullOrEmpty(ent.Comp.Callsign))
             return;
 
         // the callsign only holds on the callsign factions' nets. on an open named

--- a/Content.Server/_AU14/Insurgency/Orders/CLFStandingOrdersSystem.cs
+++ b/Content.Server/_AU14/Insurgency/Orders/CLFStandingOrdersSystem.cs
@@ -1,0 +1,200 @@
+using System.Text.RegularExpressions;
+using Content.Server.Popups;
+using Content.Server.Roles.Jobs;
+using Content.Shared._AU14.Insurgency.Orders;
+using Content.Shared._CMU14.Threats.Mobs.CLF;
+using Content.Shared._RMC14.Chat;
+using Content.Shared.GameTicking;
+using Content.Shared.Mind;
+using Content.Shared.Paper;
+using Content.Shared.Popups;
+using Content.Shared.Verbs;
+using Robust.Shared.Timing;
+
+namespace Content.Server._AU14.Insurgency.Orders;
+
+/// <summary>
+///     The cell leader writes their intent on a sheet once and passes the word. From then on
+///     it sits in every cell member's character brief, including anyone recruited later.
+///
+///     Deliberately not an item drop: the orders live in the brief, not on paper, so they
+///     cannot be looted off a body, faxed, or found by a patrol searching the right satchel.
+/// </summary>
+public sealed partial class CLFStandingOrdersSystem : EntitySystem
+{
+    [Dependency] private JobSystem _jobs = default!;
+    [Dependency] private SharedMindSystem _mind = default!;
+    [Dependency] private PopupSystem _popup = default!;
+    [Dependency] private SharedCMChatSystem _cmChat = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    private static readonly Regex Whitespace = new(@"[ \t]+", RegexOptions.Compiled);
+
+    /// <summary>
+    ///     What is standing this round, or null if nothing has been passed down yet.
+    /// </summary>
+    public string? Orders { get; private set; }
+
+    /// <summary>
+    ///     Who issued it, for the byline on the brief.
+    /// </summary>
+    public string? IssuedBy { get; private set; }
+
+    // budget and cooldown are round state, not sheet state - otherwise a second pad is a
+    // second allowance and the whole thing becomes a chat channel with extra steps
+    private int _issues;
+    private TimeSpan _nextIssue;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<CLFStandingOrdersComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        Orders = null;
+        IssuedBy = null;
+        _issues = 0;
+        _nextIssue = TimeSpan.Zero;
+    }
+
+    private void OnGetVerbs(Entity<CLFStandingOrdersComponent> ent, ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (!CanIssue(ent, args.User))
+            return;
+
+        var user = args.User;
+        var blocked = GetBlockReason(ent);
+
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Text = Loc.GetString("clf-standing-orders-verb"),
+            Message = blocked ?? Loc.GetString(
+                "clf-standing-orders-verb-tooltip",
+                ("left", Math.Max(ent.Comp.MaxIssues - _issues, 0))),
+            Disabled = blocked != null,
+            Act = () => TryIssue(ent, user),
+        });
+    }
+
+    /// <summary>
+    ///     Why the word cannot go round right now, or null if it can.
+    /// </summary>
+    private string? GetBlockReason(Entity<CLFStandingOrdersComponent> ent)
+    {
+        if (_issues >= ent.Comp.MaxIssues)
+            return Loc.GetString("clf-standing-orders-spent");
+
+        var remaining = _nextIssue - _timing.CurTime;
+
+        if (remaining <= TimeSpan.Zero)
+            return null;
+
+        return remaining < TimeSpan.FromMinutes(1)
+            ? Loc.GetString("clf-standing-orders-cooldown-soon")
+            : Loc.GetString(
+                "clf-standing-orders-cooldown",
+                ("minutes", (int) Math.Ceiling(remaining.TotalMinutes)));
+    }
+
+    private bool CanIssue(Entity<CLFStandingOrdersComponent> ent, EntityUid user)
+    {
+        if (!HasComp<CLFMemberComponent>(user))
+            return false;
+
+        if (!_mind.TryGetMind(user, out var mindId, out _))
+            return false;
+
+        foreach (var job in ent.Comp.AuthorJobs)
+        {
+            if (_jobs.MindHasJobWithId(mindId, job.Id))
+                return true;
+        }
+
+        return false;
+    }
+
+    private void TryIssue(Entity<CLFStandingOrdersComponent> ent, EntityUid user)
+    {
+        // re-check on act: the verb list is built a tick before the click lands, and the
+        // sheet can change hands or the cooldown can lapse in between
+        if (!CanIssue(ent, user))
+            return;
+
+        if (GetBlockReason(ent) is { } blocked)
+        {
+            _popup.PopupEntity(blocked, user, user, PopupType.SmallCaution);
+            return;
+        }
+
+        if (!TryComp(ent.Owner, out PaperComponent? paper))
+            return;
+
+        var orders = Tidy(paper.Content, ent.Comp.MaxLength);
+
+        if (string.IsNullOrEmpty(orders))
+        {
+            // a blank sheet costs nothing - the budget is for what actually went round
+            _popup.PopupEntity(Loc.GetString("clf-standing-orders-blank"), user, user, PopupType.SmallCaution);
+            return;
+        }
+
+        var reissued = Orders != null;
+
+        Orders = orders;
+        IssuedBy = Name(user);
+
+        _issues++;
+        _nextIssue = _timing.CurTime + ent.Comp.Cooldown;
+
+        _popup.PopupEntity(Loc.GetString("clf-standing-orders-issued"), user, user, PopupType.Medium);
+
+        // everyone already in the cell hears it come round. anyone recruited later picks
+        // it up from their brief instead
+        var message = Loc.GetString(
+            reissued ? "clf-standing-orders-notify-changed" : "clf-standing-orders-notify",
+            ("orders", orders));
+
+        var query = EntityQueryEnumerator<CLFMemberComponent>();
+
+        while (query.MoveNext(out var member, out _))
+        {
+            _cmChat.ChatMessageToOne(message, member);
+        }
+    }
+
+    /// <summary>
+    ///     Flattens the sheet's line breaks and runs of whitespace into one plain line. The
+    ///     brief carries what was said, not the leader's paper layout.
+    /// </summary>
+    private static string Tidy(string content, int maxLength)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return string.Empty;
+
+        var text = content.Replace("\r\n", "\n").Replace('\r', '\n');
+        text = Whitespace.Replace(text, " ");
+
+        var lines = new List<string>();
+
+        foreach (var line in text.Split('\n'))
+        {
+            var trimmed = line.Trim();
+
+            if (trimmed.Length > 0)
+                lines.Add(trimmed);
+        }
+
+        var joined = string.Join(" ", lines);
+
+        return joined.Length > maxLength
+            ? joined[..maxLength].TrimEnd() + "..."
+            : joined;
+    }
+}

--- a/Content.Server/_AU14/Insurgency/Orders/CharacterInfoSystem.StandingOrders.cs
+++ b/Content.Server/_AU14/Insurgency/Orders/CharacterInfoSystem.StandingOrders.cs
@@ -1,0 +1,24 @@
+using Content.Server._AU14.Insurgency.Orders;
+using Content.Shared._CMU14.Threats.Mobs.CLF;
+
+namespace Content.Server.CharacterInfo;
+
+// the cell leader's standing orders ride in the character brief rather than on paper.
+// see CLFStandingOrdersSystem for why
+public sealed partial class CharacterInfoSystem
+{
+    [Dependency] private CLFStandingOrdersSystem _clfOrders = default!;
+
+    private void AddCLFStandingOrders(List<string> lines, EntityUid entity)
+    {
+        if (!HasComp<CLFMemberComponent>(entity))
+            return;
+
+        if (_clfOrders.Orders is not { } orders || string.IsNullOrWhiteSpace(orders))
+            return;
+
+        lines.Add(string.IsNullOrWhiteSpace(_clfOrders.IssuedBy)
+            ? Loc.GetString("clf-standing-orders-primer", ("orders", orders))
+            : Loc.GetString("clf-standing-orders-primer-signed", ("orders", orders), ("leader", _clfOrders.IssuedBy)));
+    }
+}

--- a/Content.Server/_AU14/Radio/ANPRCGarbleSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCGarbleSystem.cs
@@ -2,12 +2,10 @@ using System.Numerics;
 using System.Text;
 using Content.Server.Radio;
 using Content.Server.Radio.EntitySystems;
-using Content.Shared._AU14.CCVar;
 using Content.Shared._AU14.Radio;
 using Content.Shared.Chat;
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
-using Robust.Shared.Configuration;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -20,7 +18,7 @@ public sealed partial class ANPRCGarbleSystem : EntitySystem
     [Dependency] private ANPRCCryptoSystem _crypto = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private IGameTiming _timing = default!;
-    [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private AU14CommsToggleSystem _comms = default!;
 
     private static readonly string[] LightNoise = ["~~~~", "~~~~", "~~~~", "---"];
     private static readonly string[] MediumNoise = ["~~~~", "*static*", "kzzkt", "---", "~~~~"];
@@ -29,12 +27,8 @@ public sealed partial class ANPRCGarbleSystem : EntitySystem
     private GameTick _jamCacheTick;
     private readonly Dictionary<EntityUid, RadioJamIntensity> _jamCache = new();
 
-    private bool _commsEnabled;
-
     public override void Initialize()
     {
-        Subs.CVar(_config, AU14CCVars.NewCommsSystem, v => _commsEnabled = v, true);
-
         SubscribeLocalEvent<TunableHeadsetComponent, RadioReceiveEvent>(
             OnRadioReceive,
             before: [typeof(HeadsetSystem)]);
@@ -42,7 +36,7 @@ public sealed partial class ANPRCGarbleSystem : EntitySystem
 
     private void OnRadioReceive(Entity<TunableHeadsetComponent> receiver, ref RadioReceiveEvent args)
     {
-        if (!_commsEnabled)
+        if (!_comms.EnabledOn(args.Channel))
             return;
 
         RadioMode? txMode = null;
@@ -332,6 +326,9 @@ public sealed partial class ANPRCGarbleSystem : EntitySystem
         RadioChannelPrototype channel,
         string message)
     {
+        if (!_comms.EnabledOn(channel))
+            return message;
+
         if (string.IsNullOrEmpty(channel.Faction))
             return message;
 

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
@@ -5,6 +5,7 @@ using Content.Shared._AU14.Callsigns;
 using Content.Shared._AU14.Radio;
 using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Marines;
+using Content.Shared.AU14.Radio;
 using Content.Shared.Chat;
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
@@ -254,12 +255,13 @@ public sealed partial class ANPRCRadioSystem
         // callsigns are procedure on the callsign factions' nets only. a pack tuned
         // to an open channel - colony, WEYU, CMB - puts the speaker on air under
         // their own name and rank, and the log records what actually went out
-        var callsignNet = _commsEnabled && AU14Callsigns.IsCallsignChannel(channel);
+        var callsignNet = _comms.EnabledOn(channel) && AU14Callsigns.IsCallsignChannel(channel);
 
         if (!callsignNet)
             senderName = Name(speaker);
 
-        var unsecured = !string.IsNullOrEmpty(channel.Faction) &&
+        var unsecured = _comms.EnabledOn(channel) &&
+                        !string.IsNullOrEmpty(channel.Faction) &&
                         radio.Mode != RadioMode.PlainText &&
                         !_crypto.HasMatchingCrypto(pack.Owner, channel);
 
@@ -336,7 +338,7 @@ public sealed partial class ANPRCRadioSystem
         RadioChannelPrototype channel,
         bool unsecured)
     {
-        if (!_commsEnabled || string.IsNullOrEmpty(channel.Faction))
+        if (!_comms.EnabledOn(channel) || string.IsNullOrEmpty(channel.Faction))
             return;
 
         var plainText = radio.Mode == RadioMode.PlainText;
@@ -474,6 +476,35 @@ public sealed partial class ANPRCRadioSystem
 
             AddStation(ent.Owner, wearerUid, gated, channelId.Id, senderPos, fullRange, partialRange,
                 label, clear, degraded);
+        }
+
+        // earpieces grant the net to the wearer directly rather than through a worn
+        // headset, so the queries above miss them. a cell of earpieces and one manpack
+        // would otherwise report nothing heard while the whole cell is listening
+        var earpieceQuery = EntityQueryEnumerator<AccessoryHeadsetComponent>();
+
+        while (earpieceQuery.MoveNext(out _, out var earpiece))
+        {
+            if (earpiece.RadioGrantedTo is not { } earpieceWearer ||
+                earpieceWearer == senderWearer ||
+                !Exists(earpieceWearer))
+            {
+                continue;
+            }
+
+            if (!earpiece.Channels.Contains(channelId))
+                continue;
+
+            if (!_range.InVerticalReach(Transform(earpieceWearer).MapID, senderMap, 1))
+                continue;
+
+            var earpieceLabel = TryComp(earpieceWearer, out AU14CallsignComponent? earpieceCallsign) &&
+                                !string.IsNullOrEmpty(earpieceCallsign.Callsign)
+                ? earpieceCallsign.Callsign
+                : Name(earpieceWearer);
+
+            AddStation(ent.Owner, earpieceWearer, gated, channelId.Id, senderPos, fullRange, partialRange,
+                earpieceLabel, clear, degraded);
         }
 
         var nothingHeard = Loc.GetString("anprc-radio-check-nothing-heard");

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
@@ -56,6 +56,7 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
     [Dependency] private ANPRCGarbleSystem _garble = default!;
     [Dependency] private ANPRCRangeSystem _range = default!;
     [Dependency] private ANPRCSweepSystem _sweep = default!;
+    [Dependency] private AU14CommsToggleSystem _comms = default!;
     [Dependency] private PaperSystem _paper = default!;
     [Dependency] private PowerCellSystem _powerCell = default!;
     [Dependency] private ItemSlotsSystem _itemSlots = default!;

--- a/Content.Server/_AU14/Radio/ANPRCRangeSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRangeSystem.cs
@@ -2,7 +2,6 @@ using Content.Server._RMC14.Telephone;
 using Content.Server.Power.Components;
 using Content.Server.Radio;
 using Content.Server.Radio.EntitySystems;
-using Content.Shared._AU14.CCVar;
 using Content.Shared._CMU14.ZLevels.Core.Components;
 using Content.Shared._AU14.Radio;
 using Content.Shared.Ghost;
@@ -10,9 +9,9 @@ using Content.Shared._RMC14.Chat;
 using Content.Shared._RMC14.Radio;
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
-using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Physics.Components;
+using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._AU14.Radio;
@@ -22,20 +21,16 @@ public sealed partial class ANPRCRangeSystem : EntitySystem
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedCMChatSystem _cmChat = default!;
     [Dependency] private ANPRCGarbleSystem _garble = default!;
-    [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private SharedMapSystem _map = default!;
+    [Dependency] private AU14CommsToggleSystem _comms = default!;
 
     public const float FullSignalRange = 30f;
     public const float PartialSignalRange = 45f;
 
     private const float StationaryVelocityThresholdSquared = 0.01f;
 
-    private bool _commsEnabled;
-
     public override void Initialize()
     {
-        Subs.CVar(_config, AU14CCVars.NewCommsSystem, v => _commsEnabled = v, true);
-
         SubscribeLocalEvent<RadioSendAttemptEvent>(
             OnSendAttempt,
             after: [typeof(RMCTelephoneSystem), typeof(JammerSystem)]);
@@ -47,12 +42,24 @@ public sealed partial class ANPRCRangeSystem : EntitySystem
 
     private void OnSendAttempt(ref RadioSendAttemptEvent args)
     {
-        if (!_commsEnabled)
+        if (!_comms.Enabled)
             return;
 
         if (TryComp(args.RadioSource, out RMCRadioFilterComponent? sourceFilter) &&
             sourceFilter.DisabledChannels.Contains(args.Channel.ID))
         {
+            return;
+        }
+
+        // the CLF nets can be handed back to stock radio on their own. clear the cancel
+        // rather than yielding - the telecom gate has already killed this for want of a
+        // comms tower the cell never had, so yielding would silence them, not free them.
+        // jamming still applies
+        if (!_comms.EnabledOn(args.Channel))
+        {
+            if (_garble.GetJamIntensity(args.RadioSource) == RadioJamIntensity.None)
+                args.Cancelled = false;
+
             return;
         }
 
@@ -78,7 +85,13 @@ public sealed partial class ANPRCRangeSystem : EntitySystem
             {
                 args.Cancelled = true;
 
-                var wearer = Transform(args.RadioSource).ParentUid;
+                // a headset or pack is an item in someone's inventory, but an earpiece
+                // grants intrinsic radio and the source is the wearer themselves - whose
+                // parent is the map. without this the earpiece user gets silence and no
+                // explanation for it
+                var wearer = HasComp<ActorComponent>(args.RadioSource)
+                    ? args.RadioSource
+                    : Transform(args.RadioSource).ParentUid;
 
                 if (wearer.IsValid())
                 {
@@ -107,12 +120,20 @@ public sealed partial class ANPRCRangeSystem : EntitySystem
 
     private void OnReceiveAttempt(ref RadioReceiveAttemptEvent args)
     {
-        if (!_commsEnabled)
+        if (!_comms.Enabled)
             return;
 
         if (TryComp(args.RadioReceiver, out RMCRadioFilterComponent? receiverFilter) &&
             receiverFilter.DisabledChannels.Contains(args.Channel.ID))
         {
+            return;
+        }
+
+        // as above - stock radio for the cell has to mean everyone on the net hears it,
+        // not everyone waiting on a tower that does not exist
+        if (!_comms.EnabledOn(args.Channel))
+        {
+            args.Cancelled = false;
             return;
         }
 

--- a/Content.Server/_AU14/Radio/AU14ClfCommsCommand.cs
+++ b/Content.Server/_AU14/Radio/AU14ClfCommsCommand.cs
@@ -1,0 +1,110 @@
+using Content.Server.Administration;
+using Content.Server.Chat.Managers;
+using Content.Shared._AU14.CCVar;
+using Content.Shared.Administration;
+using Robust.Shared.Configuration;
+using Robust.Shared.Console;
+
+namespace Content.Server._AU14.Radio;
+
+/// <summary>
+///     Turns the comms overhaul off over the CLF/INSFOR nets and back on, without touching
+///     GOVFOR or OPFOR. Exists because the cvar behind it is host-only, and the admin who
+///     needs this is whoever is watching a cell that cannot talk to itself.
+/// </summary>
+[AdminCommand(AdminFlags.Fun)]
+public sealed partial class AU14ClfCommsCommand : IConsoleCommand
+{
+    [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private IChatManager _chat = default!;
+
+    public string Command => "clfcomms";
+
+    public string Description =>
+        "Toggles the AU14 comms system over the CLF/INSFOR nets. Off means the cell's channels " +
+        "work like stock radio: no coverage requirement, no static, no callsigns.";
+
+    public string Help => "Usage: clfcomms [on|off]. With no argument, reports the current state.";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        if (args.Length > 1)
+        {
+            shell.WriteError(Help);
+            return;
+        }
+
+        var current = _config.GetCVar(AU14CCVars.NewCommsSystemClf);
+
+        if (args.Length == 0)
+        {
+            shell.WriteLine(current
+                ? "CLF comms: ON. The cell's nets are anchor-gated and run under the full comms system."
+                : "CLF comms: OFF. The cell's nets are running as stock radio.");
+
+            if (!_config.GetCVar(AU14CCVars.NewCommsSystem))
+                shell.WriteLine("Note: the master switch (au14.new_comms_system) is off, so this does nothing right now.");
+
+            return;
+        }
+
+        if (!TryParseState(args[0], out var wanted))
+        {
+            shell.WriteError($"Could not read '{args[0]}'. Use on or off.");
+            return;
+        }
+
+        if (wanted == current)
+        {
+            shell.WriteLine($"CLF comms are already {(current ? "on" : "off")}.");
+            return;
+        }
+
+        _config.SetCVar(AU14CCVars.NewCommsSystemClf, wanted);
+
+        // the rest of the admin team should not have to work out why the insurgents
+        // suddenly hear each other across the whole map
+        var who = shell.Player?.Name ?? "The server";
+
+        _chat.SendAdminAnnouncement(wanted
+            ? $"{who} turned the comms system back on for CLF/INSFOR."
+            : $"{who} turned the comms system off for CLF/INSFOR - their nets are stock radio now.");
+
+        shell.WriteLine(wanted
+            ? "CLF comms ON. The cell is back under coverage rules, static and callsigns."
+            : "CLF comms OFF. The cell's nets now reach anywhere, unmasked and unjammed.");
+    }
+
+    public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+    {
+        return args.Length == 1
+            ? CompletionResult.FromHintOptions(["on", "off"], "on|off")
+            : CompletionResult.Empty;
+    }
+
+    private static bool TryParseState(string arg, out bool state)
+    {
+        switch (arg.ToLowerInvariant())
+        {
+            case "on":
+            case "true":
+            case "1":
+            case "enable":
+            case "enabled":
+                state = true;
+                return true;
+
+            case "off":
+            case "false":
+            case "0":
+            case "disable":
+            case "disabled":
+                state = false;
+                return true;
+
+            default:
+                state = false;
+                return false;
+        }
+    }
+}

--- a/Content.Server/_AU14/Radio/AU14CommsToggleSystem.cs
+++ b/Content.Server/_AU14/Radio/AU14CommsToggleSystem.cs
@@ -1,0 +1,52 @@
+using Content.Shared._AU14.CCVar;
+using Content.Shared.Radio;
+using Robust.Shared.Configuration;
+
+namespace Content.Server._AU14.Radio;
+
+/// <summary>
+///     One place to ask whether the comms overhaul applies. There is the master switch and
+///     a separate one for the CLF/INSFOR nets, so an admin can hand the cell back stock
+///     radio mid-round without taking the system off GOVFOR and OPFOR as well.
+/// </summary>
+public sealed partial class AU14CommsToggleSystem : EntitySystem
+{
+    [Dependency] private IConfigurationManager _config = default!;
+
+    public const string ClfFaction = "clf";
+
+    private bool _enabled;
+    private bool _clfEnabled;
+
+    public override void Initialize()
+    {
+        Subs.CVar(_config, AU14CCVars.NewCommsSystem, v => _enabled = v, true);
+        Subs.CVar(_config, AU14CCVars.NewCommsSystemClf, v => _clfEnabled = v, true);
+    }
+
+    /// <summary>
+    ///     The master switch on its own, for behaviour that belongs to no particular net.
+    /// </summary>
+    public bool Enabled => _enabled;
+
+    public bool ClfEnabled => _clfEnabled;
+
+    /// <summary>
+    ///     Whether the overhaul governs traffic on this channel. A null channel is treated
+    ///     as faction-less - direct frequencies and sentinel channels answer to the master
+    ///     switch alone.
+    /// </summary>
+    public bool EnabledOn(RadioChannelPrototype? channel)
+    {
+        if (!_enabled)
+            return false;
+
+        return _clfEnabled || !IsClf(channel);
+    }
+
+    public static bool IsClf(RadioChannelPrototype? channel)
+    {
+        return channel != null &&
+               string.Equals(channel.Faction, ClfFaction, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/Content.Server/_AU14/Radio/AccessoryHeadsetSystem.cs
+++ b/Content.Server/_AU14/Radio/AccessoryHeadsetSystem.cs
@@ -109,23 +109,27 @@ public sealed partial class AccessoryHeadsetSystem : EntitySystem
     }
 
     /// <summary>
-    ///     Tries to find the entity wearing a uniform item via the inventory system.
+    ///     Tries to find the entity wearing a garment via the inventory system.
     /// </summary>
     private bool TryGetWearer(EntityUid uniform, out EntityUid wearer)
     {
         wearer = default;
 
-        // The uniform's parent in the transform tree is the entity wearing it (if equipped)
-        var parent = Transform(uniform).ParentUid;
-        if (!parent.IsValid())
+        // earpieces clip to anything with an accessory holder, not just jumpsuits - vests,
+        // coats, webbing and armour all take the Utility category. resolve the wearer from
+        // whichever clothing slot the garment is actually in, or clipping the earpiece to
+        // a vest silently leaves the wearer off the net
+        if (!_container.TryGetContainingContainer((uniform, null, null), out var container))
             return false;
 
-        // Verify the uniform is actually equipped in an inventory slot
-        if (!_inventory.TryGetSlotEntity(parent, "jumpsuit", out var jumpsuit) || jumpsuit != uniform)
+        if (!_inventory.TryGetContainingSlot((uniform, null, null), out var slot))
             return false;
 
-        wearer = parent;
-        return true;
+        if ((slot.SlotFlags & (SlotFlags.INNERCLOTHING | SlotFlags.OUTERCLOTHING)) == SlotFlags.NONE)
+            return false;
+
+        wearer = container.Owner;
+        return wearer.IsValid();
     }
 
     /// <summary>

--- a/Content.Shared/_AU14/CCVar/AU14CCVars.cs
+++ b/Content.Shared/_AU14/CCVar/AU14CCVars.cs
@@ -18,7 +18,15 @@ public sealed partial class AU14CCVars : CVars
     // master switch for the AU14 comms overhaul, off = stock radio behavior
     public static readonly CVarDef<bool> NewCommsSystem =
         CVarDef.Create("au14.new_comms_system", true, CVar.SERVERONLY);
-        
+
+    // same switch scoped to the CLF/INSFOR nets. off = their channels fall back to stock
+    // radio (no anchor gating, distance garble, COMSEC static or callsign masking) while
+    // GOVFOR and OPFOR keep the system. flip it with the clfcomms command, not cvar - the
+    // cvar command is host-only and admins need this mid-round
+    public static readonly CVarDef<bool> NewCommsSystemClf =
+        CVarDef.Create("au14.new_comms_system_clf", true, CVar.SERVERONLY);
+
+
     /// <summary>
     /// With the "Separated" HUD layout the chat panel sits to the right of the viewport, which pushes the
     /// game view left of the monitor centre. When on, the viewport pane is padded so the game view sits in

--- a/Content.Shared/_AU14/Insurgency/InsurgencyBuiltinFactions.cs
+++ b/Content.Shared/_AU14/Insurgency/InsurgencyBuiltinFactions.cs
@@ -108,8 +108,13 @@ public static class InsurgencyBuiltinFactions
 
     private static FactionVendorDefinition ToolVendor() => Vendor("CLF tool cache",
         Section("Field Tools",
+            // keep in step with the Radio Operator Issue section in clfstuff.yml and the
+            // AU14CrateCLFinitalTools crate. the CLF nets are anchorGated, so a cell that
+            // deploys without a manpack, a base station and a splice kit has no comms
             Entry("ANPRC117GRadioCLFFilled", 1),
             Entry("AU14CLFBaseStation", 1),
+            Entry("AU14CLFNetSpliceKit", 1),
+            Entry("AU14CLFClandestineRelay", 2),
             Entry("AU14GunCaseRifleMar30"),
             Entry("RMCGunCasePistolZHNK72", 1),
             Entry("RMCGunCasePistolMK80", 1),

--- a/Content.Shared/_AU14/Insurgency/Orders/CLFStandingOrdersComponent.cs
+++ b/Content.Shared/_AU14/Insurgency/Orders/CLFStandingOrdersComponent.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._AU14.Insurgency.Orders;
+
+/// <summary>
+///     An order sheet the cell leader can pass down to the whole cell. Passing the word does
+///     not spawn anything - the orders land in every member's character brief instead, so
+///     there is nothing to drop and nothing for a patrol to find on a body.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CLFStandingOrdersComponent : Component
+{
+    /// <summary>
+    ///     Jobs allowed to pass the word down. Anyone else can read and write on the sheet,
+    ///     but only the cell's leadership speaks for the cell.
+    /// </summary>
+    [DataField]
+    public List<ProtoId<JobPrototype>> AuthorJobs = new() { "AU14JobCLFCellLeader" };
+
+    /// <summary>
+    ///     Orders longer than this are trimmed. A few lines a runner can carry in their
+    ///     head, not a full operations order.
+    /// </summary>
+    [DataField]
+    public int MaxLength = 700;
+
+    /// <summary>
+    ///     How many times the word can go round in a round. Spent budget is tracked per
+    ///     round rather than per sheet, so a second pad does not buy a second allowance.
+    /// </summary>
+    [DataField]
+    public int MaxIssues = 3;
+
+    /// <summary>
+    ///     How long the cell leader waits between passing the word down. Together with
+    ///     <see cref="MaxIssues"/> this is what stops the brief being used as a private
+    ///     radio net: it carries intent set before the operation, not running commentary.
+    /// </summary>
+    [DataField]
+    public TimeSpan Cooldown = TimeSpan.FromMinutes(10);
+}

--- a/Resources/Locale/en-US/_AU14/insurgency/standing_orders.ftl
+++ b/Resources/Locale/en-US/_AU14/insurgency/standing_orders.ftl
@@ -1,0 +1,15 @@
+clf-standing-orders-verb = Pass the word
+clf-standing-orders-verb-tooltip = Send the orders. The whole cell will know it. {$left} left this operation.
+
+clf-standing-orders-blank = There's nothing on this sheet worth passing on.
+clf-standing-orders-issued = You read it out and the word is being passed around.
+
+clf-standing-orders-spent = You've said your piece. The cell isn't going to sit through another briefing.
+clf-standing-orders-cooldown = The last word is still going round. Give it another {$minutes} minutes.
+clf-standing-orders-cooldown-soon = The last word is still going round. Give it a minute.
+
+clf-standing-orders-notify = [color=#059705][bold]Word from the cell leader:[/bold] {$orders}[/color]
+clf-standing-orders-notify-changed = [color=#059705][bold]New word from the cell leader:[/bold] {$orders}[/color]
+
+clf-standing-orders-primer = The word from the cell leader: {$orders}
+clf-standing-orders-primer-signed = The word, passed down by {$leader}: {$orders}

--- a/Resources/Prototypes/_CMU14/Economy/Misc/clfstuff.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Misc/clfstuff.yml
@@ -356,14 +356,10 @@
       - id: CMUGasMaskFilterHAZOPS
         amount: 3
         points: 5
-    # the cell's starting comms: one manpack, one base station, one splice kit and one
-    # relay on the house, so a round-start cell has its net and one attempt at somebody
-    # else's mast without waiting on a sapper's bench. everything past that is crafted at
-    # the workbench or paid for under Special Equipment. gated to the radio operator, who
-    # is the only one trained to use any of it
     - name: Radio Operator Issue
       jobs:
       - AU14JobCLFRadioOperator
+      - AU14JobCLFCellLeader
       entries:
       - id: ANPRC117GRadioCLFFilled
         amount: 1
@@ -375,7 +371,7 @@
         amount: 1
         points: 0
       - id: AU14CLFClandestineRelay
-        amount: 1
+        amount: 2
         points: 0
     - name: Special Equipment
       entries:
@@ -548,7 +544,7 @@
     - id: AU14CLFNetSpliceKit
       amount: 1
     - id: AU14CLFClandestineRelay
-      amount: 1
+      amount: 2
     - id:  AU14GunCaseRifleMar30
       amount: 2
     - id: RMCGunCasePistolZHNK72
@@ -588,6 +584,19 @@
       amount: 6
     - id: AU14TattooGun
       amount: 1
+
+- type: entity
+  parent: CMPaper
+  id: AU14CLFStandingOrdersPad
+  name: cell standing orders
+  description: >-
+    Cheap colony notepaper. Write down what the cell is for, pass the word, then get rid of
+    it. Nobody can search a body for something everyone already knows.
+  suffix: CLF
+  components:
+  - type: Paper
+    contentSize: 2000
+  - type: CLFStandingOrders
 
 - type: entity
   parent: CMFax

--- a/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Objects/anprc117g.yml
@@ -190,6 +190,12 @@
   id: ANPRC117GRadioCLFFilled
   suffix: CLF, Filled
   components:
+  - type: ANPRCRadio
+    defaultSlots:
+    - label: CELL
+      channel: radioCLF
+    - label: CMD
+      channel: radioCLFCommand
   - type: ContainerFill
     containers:
       fill_card:

--- a/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFCellLeader.yml
+++ b/Resources/Prototypes/_CMU14/Roles/CLF/AU14JobCLFCellLeader.yml
@@ -92,6 +92,7 @@
   storage:
     back:
     - ANPRCFillCardCLF
+    - AU14CLFStandingOrdersPad
 
 - type: entity
   parent: CMSpawnPointJobBase

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsANPRC.xml
@@ -66,7 +66,7 @@
 
   The handset:
 
-  - Reaches approximately two tiles.
+  - Reaches about two and a half tiles.
   - Disconnects when the user moves out of range.
   - Uses the handset user's own callsign.
   - Can be used by one person at a time.
@@ -543,7 +543,7 @@
 
   [bold]RADIO CHECK, HOW COPY, OVER[/bold]
 
-  The operator receives a private report listing stations in clear or degraded coverage.
+  The operator receives a private report listing stations in clear or degraded coverage. Every station on the net counts: other packs, headsets, and clipped earpieces alike.
 
   When performed inside enemy jamming, the report also includes a bearing to the strongest jammer.
 
@@ -587,6 +587,10 @@
   - [bold]CLF Command[/bold] - carried only on AN/PRC sets, not on any earpiece. The cell leader reaches it through a set's handset or panel.
 
   Both nets are relay-gated. The CLF have no fixed array or command-post mast, so coverage comes from CLF AN/PRC sets: the operator's manpack in the field and the cell's base station at the safehouse.
+
+  The issued CLF manpack is not a bare set. It comes up with both nets already in its slots, labelled [bold]CELL[/bold] and [bold]CMD[/bold], because a militia has no schoolhouse and whoever picks the pack up cannot afford to be learning the panel at H-hour. A captured GOVFOR or OPFOR set comes up empty as usual.
+
+  Both the Cell Leader and the Radio Operator draw the cell's comms kit, and both can stake down the base station and the relays. Most rounds nobody takes the operator slot, and a cell that had its only radios gated behind a man who never spawned is a cell that spends the round shouting.
 
   Losing all coverage does not silence the cell. The [bold]Colony[/bold] channel on every CLF earpiece is not gated, so a cell cut off its own nets drops back to colony chatter - which is unencrypted and can be found and read by anyone sweeping the band.
 

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsFirstNet.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsFirstNet.xml
@@ -12,7 +12,7 @@
 
   ## Step 1: Work out what you are carrying
 
-  Almost everybody spawns with a [bold]field headset[/bold] in their ears slot. This is your personal radio and it is all most roles ever need.
+  Almost everybody spawns with a [bold]field headset[/bold] in their ears slot. This is your personal radio and it is all most roles ever need. The CLF are the exception: they wear a concealable earpiece clipped into their clothing instead, which works the same way but has no slot to examine. See [textlink="Field Headsets" link="AU14CommsHeadsets"] for the differences.
 
   A small number of roles also spawn with an [bold]AN/PRC-117G[/bold] manpack radio in their back slot. It is large, it is obvious in your inventory, and it is the thing that makes everyone else's headset work.
 
@@ -81,6 +81,8 @@
   ### If you are with the CLF
 
   The CLF has no communications array and never gets one. Your coverage is either something you build, or something the enemy already built that you tap.
+
+  The cell starts with a manpack, a base station, a splice kit and two relay sets, drawn by the Cell Leader or the Radio Operator - whoever is actually there. The issued manpack comes up already tuned to the cell net and cell command, so it works the moment somebody puts it on. Everything past that is built at the sapper's workbench or paid for out of Special Equipment.
 
   <Box>
     <GuideEntityEmbed Entity="AU14CLFNetSpliceKit" Caption="Splice Kit"/>
@@ -237,7 +239,7 @@
 
   Do not assume. Select [bold]RADIO CHECK[/bold] on the panel.
 
-  The radio sends [bold]RADIO CHECK, HOW COPY, OVER[/bold] on the active net, then gives you a private report listing which stations hear you clearly and which hear you degraded.
+  The radio sends [bold]RADIO CHECK, HOW COPY, OVER[/bold] on the active net, then gives you a private report listing which stations hear you clearly and which hear you degraded. That includes everyone on a headset or a clipped earpiece, not only other pack operators, so a CLF cell of earpieces and one manpack still comes back as a full list.
 
   This is the fastest way to answer "is my net working" without bothering anyone, and you should run it before you move somewhere new and after you set up.
 

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsHeadsets.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsHeadsets.xml
@@ -1,245 +1,191 @@
 <Document>
   # Field Headsets
 
-  Field headsets are the standard personal radios issued to ground forces. They provide access to assigned faction nets and, on supported models, one tunable direct frequency.
+  Your headset is the radio you were issued, the one in your ears slot, and for most roles it is the only radio you will ever touch. This page covers what it does, what it will not do, and the one thing about it that gets people killed.
 
   <Box>
     <GuideEntityEmbed Entity="AU14HeadsetGovforMarineFTL" Caption="Squad Headset"/>
     <GuideEntityEmbed Entity="AU14HeadsetGovforCommand" Caption="Command Headset"/>
+    <GuideEntityEmbed Entity="AU14CLFHeadset" Caption="CLF Earpiece"/>
   </Box>
 
-  ## Named Nets
+  ## Talking on it
 
-  Use [color=#a4885c]:h[/color] to transmit on the headset's default net.
+  Wear it in your ears slot, then type a colon, the letter h, a space, and what you want to say:
 
-  Some headsets contain additional keyed nets. Examine the headset to view its available nets and chat prefixes.
+  [color=#a4885c]:h Contact front, wait out.[/color]
 
-  For example:
+  That goes out on the headset's default net. Most headsets carry more than one. Examine yours to see which, and which letter reaches each:
 
-  - [color=#a4885c]:v[/color] transmits on command when the headset contains the command key.
-  - [color=#a4885c]:a[/color] transmits on Alpha when the headset contains the Alpha key.
+  - [color=#a4885c]:v[/color] for command, if you have the command key.
+  - [color=#a4885c]:a[/color] for Alpha, if you have the Alpha key.
 
-  Named faction nets are secured by keys installed in the headset. A headset cannot transmit on or receive a named net without its matching key.
+  A headset can only use a net it holds the key for, and you cannot fit keys in the field. If you need a net you do not have, borrow somebody's handset. There is no other way.
 
-  ## Net Coverage
+  Your name does not go out on the air. Everyone on the net, friendly or otherwise, sees your callsign instead. Talking face to face is unaffected.
 
-  Combat nets require coverage from a radio relay or fixed communications infrastructure.
+  ## The thing that gets people killed
 
-  Coverage can be provided by:
+  A headset is not a phone. On its own it reaches nobody.
 
-  - A powered [textlink="AN/PRC-117G" link="AU14CommsANPRC"] worn by a trained operator.
+  Combat nets are [bold]anchor-gated[/bold]: your headset only works while it is standing near something that holds the net up. Any of these will do it:
+
+  - A powered AN/PRC worn by a trained operator, usually your Fireteam Leader.
   - A deployed retransmission station.
-  - A powered shipboard communications array.
   - A command-post antenna mast.
+  - A powered shipboard communications array.
+  - A vehicle radio, covering little more than the hull it is bolted into.
+  - A CLF base station or relay set, staked down, for CLF nets.
+  - Any mast or array the CLF have spliced a tap into, again for CLF nets.
 
-  A worn AN/PRC does not relay while carried by an untrained wearer.
+  With none of those in reach your net is not weak. It is dead. You will speak and nothing at all will happen.
 
-  Coverage reaches one level above or below the anchor, so deep tunnels need their own relay. Shipboard arrays cover every deck.
+  Walk away from whoever carries the pack and you have walked off the net. That is the whole of it.
 
-  Support nets, including MILP and colony channels, are not relay-gated and remain available without an anchor.
+  Colony and civilian channels are the exception - nothing anchors them, they work anywhere, and anybody at all can listen to them.
 
-  ### Standard relay range
+  ### How near is near enough
 
   <Table Columns="2" MinForcedColumnWidth="120">
     <ColorBox Color="#263238">
-      <Box Margin="4">[bold]Distance from relay[/bold]</Box>
+      <Box Margin="4">[bold]Distance from the anchor[/bold]</Box>
     </ColorBox>
     <ColorBox Color="#263238">
-      <Box Margin="4">[bold]Signal[/bold]</Box>
+      <Box Margin="4">[bold]What you get[/bold]</Box>
     </ColorBox>
 
     <ColorBox>
       <Box Margin="4">0-30 tiles</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Clear transmission and reception.</Box>
+      <Box Margin="4">Clear both ways.</Box>
     </ColorBox>
 
     <ColorBox>
       <Box Margin="4">30-45 tiles</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Lightly degraded.</Box>
+      <Box Margin="4">Readable, but words go missing.</Box>
     </ColorBox>
 
     <ColorBox>
       <Box Margin="4">Beyond 45 tiles</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">No relay signal.</Box>
+      <Box Margin="4">Nothing.</Box>
     </ColorBox>
   </Table>
 
-  These ranges assume standard transmit power and a whip antenna.
+  Those numbers assume a whip antenna at normal transmit power. Turning an operator's set up, or fitting a mast antenna and standing still, buys more. Turning it down buys less. A command-post mast is worth about 75 tiles on its own, and a powered shipboard array covers its whole ship, every deck.
 
-  Relay range is affected by the radio's transmit power and antenna:
+  Everything else reaches one level up or down and no further, so a tunnel or a lower deck normally wants its own relay.
 
-  - Low transmit power reduces range.
-  - High transmit power increases range.
-  - A stationary mast antenna provides greater range than a whip antenna.
-  - Command-post antenna masts cover approximately 75 tiles.
-  - Shipboard communications arrays cover the connected ship.
+  ## Clipped earpieces
 
-  If no relay or fixed anchor is available, relay-gated nets cannot be used in that area.
+  Some people are not issued a headset at all. The CLF wear a [bold]concealable earpiece[/bold] instead, and it works differently in ways worth knowing.
 
-  ## Using the Command Net
+  An earpiece is a uniform accessory. Clip it to a garment you are wearing and it puts the net straight into your ears - there is no headset in your ears slot to examine, and nothing an enemy can see. Take the garment off, or pull the earpiece out of it, and you are off the net immediately.
 
-  Squad leader headsets contain the squad and JTAC nets, but not the command net.
+  It will clip to anything that takes accessories, and it works from any of them: a jumpsuit, a vest, a militia coat, webbing, body armour. What matters is that the garment is actually being worn, not which slot it sits in.
 
-  A squad leader can use a Fireteam Leader's AN/PRC handset to communicate on command:
-
-  - Stand near the Fireteam Leader or a deployed radio.
-  - Alt-click the wearer or radio.
-  - Select [bold]Take Handset[/bold].
-  - Transmit with [color=#a4885c]:r[/color].
-
-  The handset reaches approximately two tiles and disconnects when the user moves out of range.
-
-  Handset transmissions use the handset user's own callsign rather than the radio operator's callsign.
+  Otherwise it behaves as a headset does. [color=#a4885c]:h[/color] transmits on the cell net, the colony channel is there as well, and both are subject to everything above about anchors and range. An earpiece answers a radio check like any other station, so an operator running one will see the whole cell come back even when nobody in it carries a pack.
 
   ## Jamming
 
-  Enemy jammers affect headset traffic.
+  Enemy jammers cut into headset traffic. Inside a jammer field:
 
-  While the wearer is inside a jammer field:
+  - Nothing you send goes out at all.
+  - What comes in arrives broken.
+  - The closer the jammer, the worse both get.
 
-  - Outgoing headset transmissions are blocked.
-  - Incoming traffic may become degraded.
-  - Stronger nearby jamming causes more severe degradation.
+  Direct frequencies are jammed the same way. An AN/PRC in FH mode can still push traffic out of a jammer field; a headset cannot, and there is nothing you can do about it from the headset end except leave.
 
-  Direct-frequency traffic is affected in the same way.
+  ## Direct frequencies
 
-  The AN/PRC can continue transmitting from inside a jammer field while using FH mode. Standard headsets cannot.
+  Some headsets hold one frequency of their own alongside their keyed nets. Transmit on it with [color=#a4885c]:x[/color].
 
-  ## Direct Frequency Tuning
+  A direct frequency:
 
-  Some headsets can store one additional direct frequency.
+  - Belongs to no net and needs no key.
+  - Needs no anchor, mast or array.
+  - Is heard by anything tuned to the same number, including whoever finds it by accident or by searching for it.
 
-  Use [color=#a4885c]:x[/color] to transmit on the tuned frequency.
+  To set one, right-click the headset, select [bold]Tune Frequency[/bold], and enter something between [color=#a4885c]30.000[/color] and [color=#a4885c]87.999[/color] MHz. The decimal point is optional, so [color=#a4885c]30750[/color] and [color=#a4885c]30.750[/color] are the same frequency.
 
-  Direct-frequency traffic:
+  Without a relay, direct traffic is clear to 30 tiles, degraded to 50, and gone past that. A powered AN/PRC carrying the same frequency in a slot will bridge between users, as long as both of them are inside 50 tiles of the radio.
 
-  - Does not use a named net.
-  - Does not require a headset encryption key.
-  - Does not require fixed communications infrastructure.
-  - Can be received by any compatible radio tuned to the same frequency.
+  [bold]Clear Tuned Frequency[/bold] empties it again. Headsets issued with a preset also offer [bold]Reset to Default Frequency[/bold].
 
-  To tune the headset:
+  ## Using a net you do not have
 
-  - Right-click the headset.
-  - Select [bold]Tune Frequency[/bold].
-  - Enter a frequency between [color=#a4885c]30.000[/color] and [color=#a4885c]87.999[/color] MHz.
+  Squad leader headsets carry the squad and JTAC nets but not command. The way round it is somebody else's handset, normally the Fireteam Leader's.
 
-  Frequencies may be entered with or without a decimal point.
+  - Stand within about [bold]two and a half tiles[/bold] of them or of a deployed radio.
+  - Alt-click the wearer or the radio.
+  - Select [bold]Take Handset[/bold].
+  - Transmit with [color=#a4885c]:r[/color].
 
-  For example:
+  While you hold it, anything you say out loud goes out on the net whether you meant it to or not. Whisper if you need to say something privately. Walk too far and the cord pulls out of your hand.
 
-  - [color=#a4885c]30750[/color]
-  - [color=#a4885c]30.750[/color]
+  Handset traffic goes out under [bold]your[/bold] callsign, not the operator's.
 
-  Both values select the same frequency.
-
-  The headset must be worn in the ears slot to transmit or receive.
-
-  ## Direct Frequency Range
-
-  Without an AN/PRC relay:
+  ## When it does not work
 
   <Table Columns="2" MinForcedColumnWidth="120">
     <ColorBox Color="#263238">
-      <Box Margin="4">[bold]Distance[/bold]</Box>
-    </ColorBox>
-    <ColorBox Color="#263238">
-      <Box Margin="4">[bold]Signal[/bold]</Box>
-    </ColorBox>
-
-    <ColorBox>
-      <Box Margin="4">0-30 tiles</Box>
-    </ColorBox>
-    <ColorBox>
-      <Box Margin="4">Clear.</Box>
-    </ColorBox>
-
-    <ColorBox>
-      <Box Margin="4">30-50 tiles</Box>
-    </ColorBox>
-    <ColorBox>
-      <Box Margin="4">Lightly degraded.</Box>
-    </ColorBox>
-
-    <ColorBox>
-      <Box Margin="4">Beyond 50 tiles</Box>
-    </ColorBox>
-    <ColorBox>
-      <Box Margin="4">No signal.</Box>
-    </ColorBox>
-  </Table>
-
-  A powered AN/PRC can bridge direct-frequency traffic when the same frequency is loaded into one of its slots.
-
-  Both headset users must be within [bold]50 tiles[/bold] of the radio.
-
-  ## Clearing a Direct Frequency
-
-  To remove the tuned frequency:
-
-  - Right-click the headset.
-  - Select [bold]Clear Tuned Frequency[/bold].
-
-  Headsets issued with a preset frequency may also provide [bold]Reset to Default Frequency[/bold].
-
-  ## Troubleshooting
-
-  <Table Columns="2" MinForcedColumnWidth="120">
-    <ColorBox Color="#263238">
-      <Box Margin="4">[bold]Problem[/bold]</Box>
+      <Box Margin="4">[bold]Symptom[/bold]</Box>
     </ColorBox>
     <ColorBox Color="#263238">
       <Box Margin="4">[bold]Check[/bold]</Box>
     </ColorBox>
 
     <ColorBox>
-      <Box Margin="4">[bold]No frequency set[/bold] when using [color=#a4885c]:x[/color]</Box>
+      <Box Margin="4">Nobody answers on a combat net</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Tune a direct frequency before transmitting.</Box>
-    </ColorBox>
-
-    <ColorBox>
-      <Box Margin="4">Named-net traffic is garbled</Box>
-    </ColorBox>
-    <ColorBox>
-      <Box Margin="4">Check relay distance and nearby jamming.</Box>
+      <Box Margin="4">There is no anchor in reach. This is the answer most of the time. Find the pack, the mast or the array.</Box>
     </ColorBox>
 
     <ColorBox>
-      <Box Margin="4">AN/PRC traffic is received as static</Box>
+      <Box Margin="4">Traffic arrives in pieces</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">The transmitting or receiving radio may not have matching COMSEC fill.</Box>
-    </ColorBox>
-
-    <ColorBox>
-      <Box Margin="4">A named net cannot be heard</Box>
-    </ColorBox>
-    <ColorBox>
-      <Box Margin="4">Examine the headset and confirm that it contains the matching net key.</Box>
+      <Box Margin="4">You are at the edge of coverage, or you are being jammed. Close the distance.</Box>
     </ColorBox>
 
     <ColorBox>
-      <Box Margin="4">Direct-frequency traffic cannot be heard</Box>
+      <Box Margin="4">AN/PRC traffic arrives as pure static</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Confirm that both users have entered the same frequency and are within range.</Box>
+      <Box Margin="4">One of the two radios does not have matching COMSEC fill. Headsets do not use fill cards at all - only the AN/PRC does.</Box>
     </ColorBox>
 
     <ColorBox>
-      <Box Margin="4">No traffic is received on a combat net</Box>
+      <Box Margin="4">A net is missing entirely</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Confirm that a powered relay or fixed net anchor is available.</Box>
+      <Box Margin="4">Examine the headset. If the key is not in it, it never will be. Use a handset.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">[bold]No frequency set[/bold] on [color=#a4885c]:x[/color]</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Tune one first.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">Direct-frequency traffic goes nowhere</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Confirm both of you typed the same number, and that you are inside range of each other or of the bridging radio.</Box>
+    </ColorBox>
+
+    <ColorBox>
+      <Box Margin="4">An earpiece user hears nothing</Box>
+    </ColorBox>
+    <ColorBox>
+      <Box Margin="4">Confirm the earpiece is clipped into a garment they are actually wearing, then check coverage as above.</Box>
     </ColorBox>
   </Table>
-
-  Headsets do not use COMSEC fill cards. Fill cards are used only by the AN/PRC.
 </Document>

--- a/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsQuickRef.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/Comms/AU14CommsQuickRef.xml
@@ -151,7 +151,7 @@
       <Box Margin="4">Handset cord</Box>
     </ColorBox>
     <ColorBox>
-      <Box Margin="4">Approximately two tiles from the radio.</Box>
+      <Box Margin="4">About two and a half tiles from the radio.</Box>
     </ColorBox>
     <ColorBox>
       <Box Margin="4">Disconnects when the user moves out of range.</Box>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR

This PR contains four related changes that address the same underlying problem: CLF cells can frequently spawn without functional communications, which builds frustration

**Clipped earpieces were broken in three separate ways**

* `TryGetWearer` only checked the `jumpsuit` slot. As a result, an earpiece clipped to a vest, militia coat, webbing, or armour granted no radio access. It now resolves the wearer from the clothing slot that actually contains the garment
* The out-of-range message was sent to the transform parent of the radio source. Earpieces grant *intrinsic* radio, so the source is the player and its parent is the map, meaning the message was effectively discarded. It is now sent directly to the actor
* `RADIO CHECK` enumerated packs and headsets, but not earpieces. A cell using earpieces with a single manpack could therefore report `NOTHING HEARD` even while the entire cell was listening

**The cell now starts with communications equipment it can reliably use.** The Cell Leader can draw the communications kit alongside the Radio Operator, including through the vendor, requisitions rack, and starting crate. The number of issued relays has increased from one to two. The issued CLF manpack also starts pre-tuned to the cell and command nets rather than with an empty configuration

**Standing orders.** The Cell Leader is issued a sheet on which they can write the cell's intent and pass the word. The order is added to every cell member's character brief, including members recruited later in the round. Orders can be issued three times per round, with a ten-minute cooldown

**An admin kill switch for CLF communications.** `au14.new_comms_system_clf`, together with a `clfcomms [on|off]` command gated behind `AdminFlags.Fun`, allows admins to return CLF and INSFOR channels to stock radio behaviour mid-round without disabling the full communications system for GOVFOR and OPFOR

The communications guidebook has also been updated to reflect the new behaviour

## Why / Balance

`radioCLF` and `radioCLFCommand` both use `anchorGated: true`. A cell without anything to anchor its network does not have reduced communications; it has no communications at all. Transmissions are sent, but nothing is received

That makes each of the earpiece bugs above a complete communications failure rather than a minor inconvenience. It also makes the round-start equipment issue a core dependency rather than a balance detail

**On the round-start kit.** The Radio Operator slot is frequently unfilled. Restricting the cell's only manpack, base station, and splice kit to a role that nobody selected can leave the entire cell shouting across the map for the duration of the round. That is not a meaningful player decision, nor is it something the opposing side can interact with

Allowing the Cell Leader to draw the same kit does not add a new capability. Both roles already carry `ANPRCRadioUserComponent`, and they are already the two roles permitted to deploy a relay

The second relay prevents one poor placement or early loss from permanently ending the cell's coverage. Pre-tuning the issued manpack follows the same reasoning: this is a militia without a formal signals pipeline, and the person who picks up the pack is at least as likely to be the Cell Leader as the Radio Operator. They should not be learning the control panel at H-hour

Captured GOVFOR and OPFOR equipment is unchanged and still starts untuned

**On standing orders.** This is intended as a coordination tool, not an alternative communications system. The limits are what preserve that distinction

Orders are limited to three issues per round with a ten-minute cooldown. Both limits are tracked **per round rather than per sheet**, so obtaining another pad does not provide another allowance. Without those constraints, the feature would effectively become a private, unjammable, map-wide radio channel with extra steps, undermining the anchor-gated communications design this repository has been moving toward

Blank orders do not consume an issue, so an accidental interaction does not waste one of the limited uses

The order is deliberately stored in the character brief rather than on a physical document. It cannot be looted from a body, faxed, or discovered by a patrol searching the correct satchel. That is intentional: it represents information conveyed during a cell briefing, not a persistent intelligence item

The limit of three issues is an initial tuning value. If leaders regularly use all three within the first ten minutes, the cooldown is providing the actual constraint and the issue count is only adding friction. If leaders rarely reach three, the count may be unnecessary

Both values are exposed as `DataField`s on the component and can be adjusted in YAML without a code change. We should observe which limit actually binds in practice before changing either

**On the kill switch.** `au14.new_comms_system` is currently all or nothing, and its only runtime control is the `cvar` console command, which is gated behind `HOST` in `engineCommandPerms.yml`

An admin observing a CLF cell that cannot communicate currently has no practical way to intervene. The only available option disables the communications overhaul for GOVFOR and OPFOR as well, and even that requires host-level permissions

This switch provides a targeted escape hatch when the communications system fails specifically on the insurgent side during a live round, which directly addresses a problem that has occurred before

The CLF-specific system remains enabled by default. Nothing changes unless an admin explicitly disables it, and any change is announced in admin chat

## Technical details

**All changes are under `_AU14` / `_CMU14`.** The only modified file outside those trees is `Content.Server/CharacterInfo/CharacterInfoSystem.cs`, which gains a single call into a partial-class extension defined under `_AU14`

### Earpiece fixes

* `AccessoryHeadsetSystem.TryGetWearer` now resolves the wearer using `_container.TryGetContainingContainer` and `_inventory.TryGetContainingSlot`, accepting `INNERCLOTHING | OUTERCLOTHING` instead of hardcoding the `jumpsuit` slot. Outer clothing already supports the `Utility` accessory category in the same way as a jumpsuit, so the previous restriction served no functional purpose
* `ANPRCRangeSystem.OnSendAttempt` selects the message recipient using `HasComp<ActorComponent>(args.RadioSource) ? args.RadioSource : Transform(...).ParentUid`
* `ANPRCRadioSystem.OnRadioCheck` now includes a pass over `AccessoryHeadsetComponent`, keyed by `RadioGrantedTo`. It skips the sender and evaluates each wearer through the same `AddStation` path used for every other station type

### Standing orders

* `CLFStandingOrdersComponent` (shared) — defines `AuthorJobs`, `MaxLength`, `MaxIssues`, and `Cooldown`, all as `DataField`s
* `CLFStandingOrdersSystem` (server) — handles the verb, issuing orders, and round resets
* `CharacterInfoSystem.StandingOrders.cs` — partial-class extension that appends standing orders to the lore primer lines

### Kill switch

* `AU14CommsToggleSystem` is now the single source of truth for whether the communications overhaul applies to a channel. `Enabled` represents the master switch, while `EnabledOn(channel)` additionally checks the CLF-specific switch when the channel's `Faction` is `clf`. Systems responsible for range, garbling, callsign masking, and ANPRC transmission now query this system instead of independently caching `AU14CCVars.NewCommsSystem`
* `AU14ClfCommsCommand` uses `[AdminCommand(AdminFlags.Fun)]`, allowing ordinary event admins to access it. When invoked without an argument, it reports the current state and warns when the master switch is disabled, since the CLF-specific toggle is inert in that configuration

**The one non-obvious detail:** `ANPRCRangeSystem` must actively *clear* the cancellation state for a disabled network rather than simply returning

Both CLF channels use `tower: true`. By the time this handler runs, the upstream `RMCTelephoneSystem` has already cancelled the transmission because no communications tower is available, and CLF cells were never expected to own one

Simply returning would therefore leave the transmission cancelled and silence the cell, which is the opposite of the kill switch's intended behaviour. Clearing the cancellation allows the channel to fall back to stock radio behaviour

Jamming continues to apply in either mode because it is an RMC feature rather than part of this communications overhaul

### Guidebook

The Field Headsets page did not mention clipped earpieces and used a flat manual style that was inconsistent with the rest of the section. It has been rewritten to align with *Getting On The Net*

Additional corrections include:

* The handset cord reaches two and a half tiles (`HandsetRange = 2.5f`), not two
* The cell receives two relays, drawable by either leadership role
* The issued manpack starts pre-tuned
* Radio checks include headsets and earpieces rather than only radio packs

## Media

<!-- TODO: attach before/after of an earpiece clipped to a vest reaching the cell net, the greyed-out "Pass the word" verb showing its cooldown reason, and the standing orders line in the character brief. -->

## Requirements

* [x] I have read and am following the [[Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)
* [x] I have added media to this PR or it does not require an ingame showcase
* [x] I have included a **brief** detail of the major changes for this PR in the changelog below
* [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials

**Changelog**
:cl:

* fix: CLF earpieces now work when clipped to a vest, coat, webbing, or armour, rather than only to a jumpsuit
* fix: Earpiece users are now notified when no relay is in range instead of receiving no feedback
* fix: RADIO CHECK now includes headsets and earpieces, preventing a cell with one manpack from incorrectly reporting NOTHING HEARD
* tweak: The CLF Cell Leader can now draw the cell's communications kit alongside the Radio Operator
* tweak: The CLF now receives two clandestine relay sets at round start instead of one
* tweak: The issued CLF manpack now starts tuned to the cell and command nets
* add: The CLF Cell Leader now receives a standing orders sheet. Writing the cell's intent and passing the word adds it to every member's character brief, including members recruited later. Orders may be issued three times per round with a ten-minute cooldown
* admin: Added the clfcomms command, which disables the new communications system for CLF and INSFOR without affecting GOVFOR or OPFOR
* code: AU14CommsToggleSystem is now the single source of truth for whether the communications overhaul applies to a channel