### PR TITLE
Crusher tweaks

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Charge/XenoChargeComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class XenoChargeComponent : Component
     public DamageSpecifier Damage = new();
 
     [DataField, AutoNetworkedField]
-    public float Range = 9;
+    public float Range = 5;
 
     [DataField, AutoNetworkedField]
     public float SlowRange = 1.5f;
@@ -30,7 +30,7 @@ public sealed partial class XenoChargeComponent : Component
     public TimeSpan StunTime = TimeSpan.FromSeconds(2);
 
     [DataField, AutoNetworkedField]
-    public TimeSpan ChargeDelay = TimeSpan.FromSeconds(0.6);
+    public TimeSpan ChargeDelay = TimeSpan.FromSeconds(1.2);
 
     [DataField, AutoNetworkedField]
     public SoundSpecifier? ChargeWindupSound;

--- a/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakingDamageComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Soak/XenoSoakingDamageComponent.cs
@@ -26,5 +26,5 @@ public sealed partial class XenoSoakingDamageComponent : Component
     public Color RageColor = Color.FromHex("#AD1313");
 
     [DataField, AutoNetworkedField]
-    public TimeSpan RageDuration = TimeSpan.FromSeconds(3);
+    public TimeSpan RageDuration = TimeSpan.FromSeconds(4);
 }

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/crusher.yml
@@ -59,10 +59,10 @@
     directionalTileEffect: RMCEffectXenoTelegraphRed
     damage:
       types:
-        Blunt: 80
+        Blunt: 65
     directionalMinDamage:
       types:
-        Blunt: 65
+        Blunt: 40
     selfEffect: CMEffectSelfStomp
   - type: XenoAnimateMovement
   - type: XenoPlasma
@@ -130,7 +130,7 @@
     damage:
       types:
         Blunt: 15
-    armorPiercing: 5
+    armorPiercing: 2
   - type: RMCSize
     size: Immobile
   - type: XenoChargerJockey
@@ -179,7 +179,7 @@
       path: /Audio/_RMC14/Xeno/crusher_windup_sound.ogg
     damage:
       types:
-        Blunt: 80
+        Blunt: 65
         Structural: 750
   - type: XenoShield
   - type: XenoEvolution


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adjusts Crusher's soak, charge, stomp, and brutalize.
(Please double check my changes, i hate editing yml)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Ever since Crusher's rework, it has been a monstrously good caste that is sometimes almost required to win games. However, as a side effect, this has made every other T3 look awful in comparison, with the exception of Boiler. Staple castes like Ravager and Praetorian are seldom picked and rendered nigh null nowadays due to Crusher's immense power. It can brawl, it can disrupt, it can tank, and retreat with ease. It is extremely forgiving, with no downsides to playing it. There is nothing it cant do, in combination with its low skill floor. 

I have asked GOVFOR players what they hate the most about it, and its charge seems to be the worst culprit. I've changed that and other values to my own discretion.
Charge has its range and damage reduced, and has a longer windup(reverted to value before rework). It was basically a get out of jail free card, and if a good crusher knew how to position and how long it could stay, crusher was unkillable. 
Directional stomp does less damage overall, both at point blank and from a distance.
Brutalize, its passive, does less AP. 
In essence, crusher's damage has been reduced across the board so it can do what it's meant to do: disrupt, spearhead, and tank. Damage should not be part of the equation. To compensate for the nerfs, Soak has gotten a slightly increased duration so it can heal off bullet damage just a little easier. 

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Crusher's charge has had its windup delay doubled. Range reduced to 5 tiles. Damage reduced.
- tweak: Soak duration lasts for 4 seconds instead of 3.
- tweak: Directional stomp's damage reduced.
- tweak: Brutalize's AP damage reduced.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AU-14/codesmith/ColonialMarinesUniverse/pr/1811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788905795&installation_model_id=431611&pr_number=1811&repository=AU-14%2FColonialMarinesUniverse&return_to=https%3A%2F%2Fgithub.com%2FAU-14%2FColonialMarinesUniverse%2Fpull%2F1811&signature=1cc8af79d5d261be58213067c25ae71ef5553674f48fd4c33af29e6ddd01faf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->