### PR TITLE
Added M41AE2 HPR to HAZOP/USCM catalog; gave LO their Missing Approval Stamp

### DIFF
--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -249,6 +249,10 @@
         crate: RMCCrateBoxMagazinePistolMK80
       - cost: 800
         crate: RMCCrateBoxAmmo458
+      - cost: 300
+        crate: RMCCrateMagazineRifleM54CE2
+      - cost: 300
+        crate: RMCCrateMagazineRifleM54CE2HT
       - cost: 600
         crate: RMCCrateBoxMagazineSentry
       - cost: 600

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -225,6 +225,8 @@
         crate: RMCCrateXM88
       - cost: 800
         crate: RMCCrateMOU53
+      - cost: 1000
+        crate: RMCCrateM54CE2
       - cost: 400
         crate: RMCCrateM85A1
       - cost: 100

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -225,7 +225,7 @@
         crate: RMCCrateXM88
       - cost: 800
         crate: RMCCrateMOU53
-      - cost: 1000
+      - cost: 800
         crate: RMCCrateM54CE2
       - cost: 400
         crate: RMCCrateM85A1

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -235,6 +235,8 @@
         crate: RMCCrateXM88
       - cost: 800
         crate: RMCCrateMOU53
+      - cost: 1000
+        crate: RMCCrateM54CE2
       - cost: 400
         crate: RMCCrateM85A1
       - cost: 100

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -235,7 +235,7 @@
         crate: RMCCrateXM88
       - cost: 800
         crate: RMCCrateMOU53
-      - cost: 1000
+      - cost: 800
         crate: RMCCrateM54CE2
       - cost: 400
         crate: RMCCrateM85A1

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -259,6 +259,10 @@
         crate: RMCCrateBoxMagazinePistolMK80
       - cost: 800
         crate: RMCCrateBoxAmmo458
+      - cost: 300
+        crate: RMCCrateMagazineRifleM54CE2
+      - cost: 300
+        crate: RMCCrateMagazineRifleM54CE2HT
       - cost: 600
         crate: RMCCrateBoxMagazineSentry
       - cost: 600

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Command/Officer_Logistics.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Command/Officer_Logistics.yml
@@ -115,6 +115,7 @@
     jumpsuit: CMJumpsuitOrdnanceTech
     back: CMSatchelMarine
     pocket1: AU14StampLO
+    pocket2: CMStampApproved
 
 - type: startingGear
   id: AU14GearOPFOROfficerLogistics
@@ -127,6 +128,7 @@
     jumpsuit: CMJumpsuitOrdnanceTech
     back: CMSatchelMarine
     pocket1: AU14StampLO
+    pocket2: CMStampApproved
 
 - type: roleLoadout
   id: JobAU14JobGOVFOROfficerLogistics

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/magazine_boxes.yml
@@ -30,7 +30,7 @@
 - type: entity
   parent: RMCCrateAmmo
   id: RMCCrateMagazineRifleM54CE2
-  name: M54CE2 HAR Magazines crate (HAR ammo box x2)
+  name: M41AE2 HPR Magazines crate (HPR ammo box x2) #M54CE2 HAR Magazines crate (HAR ammo box x2) CMU change, inline with CM13.
   components:
   - type: StorageFill
     contents:
@@ -40,7 +40,7 @@
 - type: entity
   parent: RMCCrateAmmo
   id: RMCCrateMagazineRifleM54CE2HT
-  name: M54CE2 HAR Magazines crate (HAR HT ammo box x2)
+  name: M41AE2 HPR Holo-Target Magazines crate #M54CE2 HAR Magazines crate (HAR HT ammo box x2): same as above,
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapons.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapons.yml
@@ -13,7 +13,7 @@
 - type: entity
   parent: RMCCrateWeapons
   id: RMCCrateM54CE2
-  name: M54CE2 HAR crate (HAR x2, HAR ammo box x2)
+  name: M41AE2 crate (x2) #M54CE2 HAR crate (HAR x2, HAR ammo box x2): figured I'd just rename it the proper inline name, commented out to play it safe.
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapons.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/weapons.yml
@@ -13,7 +13,7 @@
 - type: entity
   parent: RMCCrateWeapons
   id: RMCCrateM54CE2
-  name: M41AE2 crate (x2) #M54CE2 HAR crate (HAR x2, HAR ammo box x2): figured I'd just rename it the proper inline name, commented out to play it safe.
+  name: M41AE2 HPR crate (x2) #M54CE2 HAR crate (HAR x2, HAR ammo box x2): CMU change, figured I'd just rename it the proper inline name, commented out to play it safe.
   components:
   - type: StorageFill
     contents:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added the M41AE2 heavy pulse rifle crate to both HAZOPs and USCMs requestions catalog, as well the magazine crates for them. Gave both OPFOR and GOVFOR LO's their missing approval stamp. 

## Why / Balance
I figured they were sorely missed, and since we have most of the restricted req catalog weapons, such as the MOU, M2C, and XM88, why not the HPR as well? (Do let me know if the price needs to be raised). Also gave LO's their approval stamp for stamping invoices since they were missing 'em.

## Technical details
Commented out `M54CE2` for both the name of the gun crate: `RMCCrateM54CE2` and the magazine crate: `RMCCrateMagazineRifleM54CE2` & `RMCCrateMagazineRifleM54CE2HT`. This is just an in game description change, didn't touch anything else outside of what players would read from looking at em, since for the most part, the gun and mags for it is already the proper name.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: USCM and HAZOP's will now find the M41AE2 HPR and its magazines orderable through their ASRS console!
- fix: Both GOVFOR and OPFOR Logistics Officers will have their missing approval stamp.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AU-14/codesmith/ColonialMarinesUniverse/pr/1812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788912262&installation_model_id=431611&pr_number=1812&repository=AU-14%2FColonialMarinesUniverse&return_to=https%3A%2F%2Fgithub.com%2FAU-14%2FColonialMarinesUniverse%2Fpull%2F1812&signature=f8e63d63b15083cf50dfeb706d067565022c00c08c7e469921dfc4a2274bbc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->