### PR TITLE
M68 thermal cloak (Distress Signal unnerfed)

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Clothing/Back/satchels.yml
@@ -275,6 +275,18 @@
       components:
       - Xeno
       - CMUPathogenWalker
+  - type: DestroyOnPreset
+    preset: DistressSignal
+
+- type: entity
+  parent: RMCBackpackScout
+  id: RMCBackpackScoutDS
+  components:
+  - type: ThermalCloak
+    movingOpacity: 0.025
+  - type: DestroyOnPreset
+    preset: DistressSignal
+    inverted: true
 
 - type: entity
   parent: RMCBackpackScout

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Cases/specialist_loadouts.yml
@@ -238,6 +238,7 @@
     - id: RMCMagazineRifleM4SPRA19Impact
       amount: 4
     - id: RMCBackpackScout
+    - id: RMCBackpackScoutDS
     - id: WeaponRifleM4SPRCustom
     - id: RMCThermalTarpFolded
       amount: 2
@@ -279,6 +280,7 @@
     - id: RMCAttachmentFlashlightGrip
     - id: RMCAttachmentS5RedDotSight
     - id: RMCBackpackScout
+    - id: RMCBackpackScoutDS
     - id: WeaponRifleM5SPR2
     - id: RMCThermalTarpFolded
       amount: 2


### PR DESCRIPTION
## About the PR
Added the unnerfed M68 thermal cloak for DS. Both cloaks are in the scout kits. The unnerfed cloak deletes itself if the gamemode isn't Distress Signal, and the nerfed cloak deletes itself if it is Distress Signal.

## Why / Balance
Players have been requesting the stealth cloak to be better in Distress Signal. It's not very complicated to split the cloak to balance for HvH or HvX.

## Technical details
Technically the cloak for Distress Signal is buffed since the stationary and moving opacity is 0.025 instead of 0.1 prenerf.

**Changelog**
:cl:
- add: DS: M68 thermal cloak (unnerfed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/AU-14/codesmith/ColonialMarinesUniverse/pr/1813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788925203&installation_model_id=431611&pr_number=1813&repository=AU-14%2FColonialMarinesUniverse&return_to=https%3A%2F%2Fgithub.com%2FAU-14%2FColonialMarinesUniverse%2Fpull%2F1813&signature=a17fd8712a2db2a2ca1006f0d0bc3ac8fbb51556ed23ac6aa659e785592d6016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->