### PR TITLE
Removing Greenos from Insurgency

### DIFF
--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Fills/Crates/weyu_experiments.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Fills/Crates/weyu_experiments.yml
@@ -36,7 +36,6 @@
     contents:
       - id: RMCBottleMindbreaker
         amount: 7
-      - id: CMUYautjaHivebreaker
       - id: RMCTentUNMCStandardMedicalFolded
       - id: AU14TentBigFoldedSurgical
       - id: AU14DrugDealerDrugBottle
@@ -95,8 +94,6 @@
       children:
       - id: XenoEgg
       - id: XenoEgg
-      - id: CMUYautjaHivebreaker
-        prob: 0.1
       weight: 1
     - !type:AllSelector
       children:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed Hivebreaker from Weyu crates, and thus for the most part insurgency greenos.

## Why / Balance
Was told to do so by @John F. Kennedy on discord, ask him for specifics.

## Technical details
Removed the relevant YAML for any times it spawns so the code is still there and useable, in addition to not damaging anything.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Removed hivebreaker and thus greenos from standard insurgency rounds