### PR TITLE
Adds minimum xeno playtime requirement to evolve to greeno queen

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using Content.Shared._CMU14.Yautja;
 using Content.Shared._RMC14.CCVar;
+using Content.Shared._RMC14.Roles;
 using Content.Shared._RMC14.Rules;
 using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Egg;
@@ -24,6 +25,7 @@ using Content.Shared.Jittering;
 using Content.Shared.Mind;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
+using Content.Shared.Players.PlayTimeTracking;
 using Content.Shared.Popups;
 using Content.Shared.Prototypes;
 using Robust.Shared.Audio.Systems;
@@ -65,6 +67,7 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedXenoWeedsSystem _xenoWeeds = default!;
     [Dependency] private IMapManager _map = default!;
+    [Dependency] private ISharedPlaytimeManager _playtime = default!;
 
     private TimeSpan _evolutionPointsRequireOvipositorAfter;
     private TimeSpan _evolutionAccumulatePointsBefore;
@@ -74,6 +77,8 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
     private readonly HashSet<EntityUid> _climbable = new();
     private readonly HashSet<EntityUid> _doors = new();
     private readonly HashSet<EntityUid> _intersecting = new();
+
+    private static readonly TimeSpan CorruptedHiveQueenPlaytime = TimeSpan.FromHours(30);
 
     private EntityQuery<MobStateComponent> _mobStateQuery;
 
@@ -249,6 +254,44 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
 
         var afterEv = new AfterNewXenoEvolvedEvent();
         RaiseLocalEvent(newXeno, ref afterEv);
+    }
+
+    private bool CanCorruptedHiveEvolveToQueen(EntityUid xeno, bool doPopup)
+    {
+        if (_net.IsClient)
+            return true;
+
+        if (!TryComp(xeno, out ActorComponent? actor))
+            return false;
+
+        var requirement = new TotalJobsTimeRequirement
+        {
+            Group = "CMJobsXeno",
+            Time = CorruptedHiveQueenPlaytime,
+        };
+
+        var playTimes = _playtime.GetPlayTimes(actor.PlayerSession);
+
+        if (requirement.Check(
+                EntityManager,
+                _prototypes,
+                null,
+                playTimes,
+                out _))
+        {
+            return true;
+        }
+
+        if (doPopup)
+        {
+            _popup.PopupEntity(
+                Loc.GetString("rmc-xeno-corruptedevolution-failed-insufficient-hours"),
+                xeno,
+                xeno,
+                PopupType.MediumCaution);
+        }
+
+        return false;
     }
 
     private void OnXenoDevolveBui(Entity<XenoDevolveComponent> xeno, ref XenoDevolveBuiMsg args)
@@ -428,10 +471,18 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
         if (!_prototypes.TryIndex(newXeno, out var prototype))
             return true;
 
+        var hive = _xenoHive.GetHive(xeno.Owner);
+
+        if (newXeno == "CMXenoQueen" &&
+            hive is { } corruptedHive &&
+            corruptedHive.Comp.Corrupted &&
+            !CanCorruptedHiveEvolveToQueen(xeno.Owner, doPopup))
+        {
+            return false;
+        }
+
         if (!ContainedCheckPopup(xeno, doPopup))
             return false;
-
-        EntityUid? hive = _xenoHive.GetHive(xeno.Owner);
 
         if (prototype.HasComponent<XenoEvolutionGranterComponent>(_compFactory) && HiveHasLivingQueen(xeno.Owner))
         {

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-abilities.ftl
@@ -77,6 +77,7 @@ rmc-xeno-evolution-failed-marines-dropped = The sky talls have already landed, w
 rmc-xeno-evolution-failed-queen-exists = The hive already has a Queen!
 rmc-xeno-evolution-start-self = We begin to twist and contort.
 rmc-xeno-evolution-start-others = {$xeno} begins to twist and contort.
+rmc-xeno-corruptedevolution-failed-insufficient-hours = You do not have enough playtime to evolve into a Corrupted Queen.
 
 # Insight
 rmc-xeno-insight-empower = We have gained sufficient insight in our prey to empower our next Deploy Traps!


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds minimum xeno playtime requirement to evolve to greeno queen.

## Why / Balance
Shitters and people taking a HRP role with no relevant playtime nor experience was a problem and severely bogged down RP. We have enough threat players for the 30 hour requirement to not be an issue.
Admin tools can still bypass this by putting a mind into the queen body if it's an event, this is mostly meant for organic greenos that came about naturally.

Prime hive and other evolutions for the corrupted hive still work fine, this is strictly for queen.

## Media
<img width="598" height="262" alt="image" src="https://github.com/user-attachments/assets/d7a919fd-703a-4a80-b071-1f2f9fdeebfe" />

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Evolving into a Corrupted Hive Queen now requires a minimum of 30 hours of xeno playtime.