### PR TITLE
Additional HAZOP's req tweaks, Vehicle ammo fix, Added Mk86 & ammo in catalog.

### DIFF
--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/cmbciu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/cmbciu_requisitions_catalog.yml
@@ -253,6 +253,8 @@
         crate: RMCCrateML66D
       - cost: 1000
         crate: RMCCrateM2C
+      - cost: 1700
+        crate: CMUCrateMk86
     - name: Ammo
       entries:
       - cost: 400
@@ -283,6 +285,12 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
+      - cost: 300
+        crate: CMUCrateMk86MagazineHornet
+      - cost: 600
+        crate: CMUCrateMk86MagazineFrag
+      - cost: 200
+        crate: CMUCrateMk86MagazineSmoke
       - cost: 200
         crate: RMCCrateMagazineNapthalUT
       - cost: 350

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/cmbciu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/cmbciu_requisitions_catalog.yml
@@ -285,9 +285,9 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
-      - cost: 300
+      - cost: 700
         crate: CMUCrateMk86MagazineHornet
-      - cost: 600
+      - cost: 400
         crate: CMUCrateMk86MagazineFrag
       - cost: 200
         crate: CMUCrateMk86MagazineSmoke

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -257,6 +257,8 @@
         crate: RMCCrateML66D
       - cost: 1000
         crate: RMCCrateM2C
+      - cost: 1700
+        crate: CMUCrateMk86
     - name: Ammo
       entries:
       - cost: 400
@@ -291,6 +293,12 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
+      - cost: 300
+        crate: CMUCrateMk86MagazineHornet
+      - cost: 600
+        crate: CMUCrateMk86MagazineFrag
+      - cost: 200
+        crate: CMUCrateMk86MagazineSmoke
       - cost: 200
         crate: RMCCrateMagazineNapthalUT
       - cost: 350

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/hazops_requisitions_catalog.yml
@@ -293,9 +293,9 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
-      - cost: 300
+      - cost: 700
         crate: CMUCrateMk86MagazineHornet
-      - cost: 600
+      - cost: 400
         crate: CMUCrateMk86MagazineFrag
       - cost: 200
         crate: CMUCrateMk86MagazineSmoke

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/lacn_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/lacn_requisitions_catalog.yml
@@ -287,9 +287,9 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
-      - cost: 300
+      - cost: 700
         crate: CMUCrateMk86MagazineHornet
-      - cost: 600
+      - cost: 400
         crate: CMUCrateMk86MagazineFrag
       - cost: 200
         crate: CMUCrateMk86MagazineSmoke

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/lacn_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/lacn_requisitions_catalog.yml
@@ -255,6 +255,8 @@
         crate: RMCCrateML66D
       - cost: 1000
         crate: RMCCrateM2C
+      - cost: 1700
+        crate: CMUCrateMk86
     - name: Ammo
       entries:
       - cost: 400
@@ -285,6 +287,12 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
+      - cost: 300
+        crate: CMUCrateMk86MagazineHornet
+      - cost: 600
+        crate: CMUCrateMk86MagazineFrag
+      - cost: 200
+        crate: CMUCrateMk86MagazineSmoke
       - cost: 200
         crate: RMCCrateMagazineNapthalUT
       - cost: 350

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/prodigy_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/prodigy_requisitions_catalog.yml
@@ -287,9 +287,9 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
-      - cost: 300
+      - cost: 700
         crate: CMUCrateMk86MagazineHornet
-      - cost: 600
+      - cost: 400
         crate: CMUCrateMk86MagazineFrag
       - cost: 200
         crate: CMUCrateMk86MagazineSmoke

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/prodigy_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/prodigy_requisitions_catalog.yml
@@ -255,6 +255,8 @@
         crate: RMCCrateML66D
       - cost: 1000
         crate: RMCCrateM2C
+      - cost: 1700
+        crate: CMUCrateMk86
     - name: Ammo
       entries:
       - cost: 400
@@ -285,6 +287,12 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
+      - cost: 300
+        crate: CMUCrateMk86MagazineHornet
+      - cost: 600
+        crate: CMUCrateMk86MagazineFrag
+      - cost: 200
+        crate: CMUCrateMk86MagazineSmoke
       - cost: 200
         crate: RMCCrateMagazineNapthalUT
       - cost: 350

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/rmc_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/rmc_requisitions_catalog.yml
@@ -261,6 +261,8 @@
         crate: RMCCrateML66D
       - cost: 1000
         crate: RMCCrateM2C
+      - cost: 1700
+        crate: CMUCrateMk86
       - cost: 1500
         crate: AU14KitWeaponRXFM
     - name: Ammo
@@ -293,6 +295,12 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
+      - cost: 300
+        crate: CMUCrateMk86MagazineHornet
+      - cost: 600
+        crate: CMUCrateMk86MagazineFrag
+      - cost: 200
+        crate: CMUCrateMk86MagazineSmoke
       - cost: 200
         crate: RMCCrateMagazineNapthalUT
       - cost: 350

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/rmc_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/rmc_requisitions_catalog.yml
@@ -295,9 +295,9 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
-      - cost: 300
+      - cost: 700
         crate: CMUCrateMk86MagazineHornet
-      - cost: 600
+      - cost: 400
         crate: CMUCrateMk86MagazineFrag
       - cost: 200
         crate: CMUCrateMk86MagazineSmoke

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -267,6 +267,8 @@
         crate: RMCCrateML66D
       - cost: 1000
         crate: RMCCrateM2C
+      - cost: 1700
+        crate: CMUCrateMk86
     - name: Ammo
       entries:
       - cost: 400
@@ -301,6 +303,12 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
+      - cost: 300
+        crate: CMUCrateMk86MagazineHornet
+      - cost: 600
+        crate: CMUCrateMk86MagazineFrag
+      - cost: 200
+        crate: CMUCrateMk86MagazineSmoke
       - cost: 200
         crate: RMCCrateMagazineNapthalUT
       - cost: 350

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/uscm_requisitions_catalog.yml
@@ -303,9 +303,9 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
-      - cost: 300
+      - cost: 700
         crate: CMUCrateMk86MagazineHornet
-      - cost: 600
+      - cost: 400
         crate: CMUCrateMk86MagazineFrag
       - cost: 200
         crate: CMUCrateMk86MagazineSmoke

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/vaipo_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/vaipo_requisitions_catalog.yml
@@ -287,9 +287,9 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
-      - cost: 300
+      - cost: 700
         crate: CMUCrateMk86MagazineHornet
-      - cost: 600
+      - cost: 400
         crate: CMUCrateMk86MagazineFrag
       - cost: 200
         crate: CMUCrateMk86MagazineSmoke

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/vaipo_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/vaipo_requisitions_catalog.yml
@@ -255,6 +255,8 @@
         crate: RMCCrateML66D
       - cost: 1000
         crate: RMCCrateM2C
+      - cost: 1700
+        crate: CMUCrateMk86
     - name: Ammo
       entries:
       - cost: 400
@@ -285,6 +287,12 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
+      - cost: 300
+        crate: CMUCrateMk86MagazineHornet
+      - cost: 600
+        crate: CMUCrateMk86MagazineFrag
+      - cost: 200
+        crate: CMUCrateMk86MagazineSmoke
       - cost: 200
         crate: RMCCrateMagazineNapthalUT
       - cost: 350

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/weyu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/weyu_requisitions_catalog.yml
@@ -257,6 +257,8 @@
         crate: RMCCrateML66D
       - cost: 1000
         crate: RMCCrateM2C
+      - cost: 1700
+        crate: CMUCrateMk86
     - name: Ammo
       entries:
       - cost: 400
@@ -287,6 +289,12 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
+      - cost: 300
+        crate: CMUCrateMk86MagazineHornet
+      - cost: 600
+        crate: CMUCrateMk86MagazineFrag
+      - cost: 200
+        crate: CMUCrateMk86MagazineSmoke
       - cost: 200
         crate: RMCCrateMagazineNapthalUT
       - cost: 350

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/weyu_requisitions_catalog.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Cargo/weyu_requisitions_catalog.yml
@@ -289,9 +289,9 @@
         crate: RMCCrateMagazineML66DDrum
       - cost: 500
         crate: RMCCrateMagazineM2C
-      - cost: 300
+      - cost: 700
         crate: CMUCrateMk86MagazineHornet
-      - cost: 600
+      - cost: 400
         crate: CMUCrateMk86MagazineFrag
       - cost: 200
         crate: CMUCrateMk86MagazineSmoke

--- a/Resources/Prototypes/_CMU14/Economy/Catalog/Fills/Crates/misc.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Catalog/Fills/Crates/misc.yml
@@ -214,6 +214,50 @@
 
 - type: entity
   parent: RMCCrateWeapons
+  id: CMUCrateMk86
+  name: Mk86 Automatic Grenade Launcher crate (x1)
+  description: A crate containing one Mk86 case, a deployable mag-fed emplacement capable of firing airburst grenades.
+  components:
+  - type: StorageFill
+    contents:
+    - id: AU14Mk86Case
+      amount: 1
+
+- type: entity
+  parent: RMCCrateAmmo
+  id: CMUCrateMk86MagazineHornet
+  name: Mk86 AGM-H Magazine crate (x2)
+  description: A crate containing two magazines for the Mk86, loaded with AGM-H 40mm hornet airburst grenades.
+  components:
+  - type: StorageFill
+    contents:
+    - id: AU14MagazineMk86Hornet
+      amount: 2
+
+- type: entity
+  parent: RMCCrateAmmo
+  id: CMUCrateMk86MagazineFrag
+  name: Mk86 AGM-F Magazine crate (x2)
+  description: A crate containing two magazines for the Mk86, loaded with AGM-F 40mm frag airburst grenades.
+  components:
+  - type: StorageFill
+    contents:
+    - id: AU14MagazineMk86Frag
+      amount: 2
+
+- type: entity
+  parent: RMCCrateAmmo
+  id: CMUCrateMk86MagazineSmoke
+  name: Mk86 AGM-S Magazine crate (x2)
+  description: A crate containing two magazines for the Mk86, loaded with AGM-S 40mm smoke airburst grenades.
+  components:
+  - type: StorageFill
+    contents:
+    - id: AU14MagazineMk86Smoke
+      amount: 2
+
+- type: entity
+  parent: RMCCrateWeapons
   id: AU14CrateM7SLAW
   name: M7-SMAW anti-tank launcher crate (x1 M7-SMAW, x2 84mm AP rocket, x2 84mm HE rocket)
   components:

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
@@ -721,7 +721,7 @@
       entries:
       - id: RMCAttachmentM54CStockCollapsible
         amount: 30
-      - id: RMCAttachmentM42A2CollapsibleStock
+      - id: RMCAttachmentM42A1WoodenStock
         amount: 3
       - id: RMCAttachmentM44MagnumSharpshooterStock
         amount: 2

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
@@ -641,6 +641,8 @@
       entries:
       - id: CMUBoxMagazineSMGXMP5A6
         amount: 2
+      - id: CMUBoxMagazineRifleXM20A2
+        amount: 2
       - id: RMCBoxMagazinePistolM1984
         amount: 2
     - name: Ammo Boxes

--- a/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
+++ b/Resources/Prototypes/_CMU14/Economy/Vendors/hazopsvendors.yml
@@ -599,6 +599,8 @@
       entries:
       - id: AU14MagazineXMP5A6
         amount: 200
+      - id: AU14MagazineRifleXM20A2
+        amount: 100
       - id: CMMagazineRifleM54C
         amount: 100
       - id: CMMagazineRifleM54CAP

--- a/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/vehicle_ammo.yml
+++ b/Resources/Prototypes/_RMC14/Catalog/Fills/Crates/vehicle_ammo.yml
@@ -101,7 +101,7 @@
 - type: entity
   parent: RMCCrateAmmo
   id: RMCCrateVehicleAmmoFrontalCannon
-  name: RE-RE700 frontal cannon magazines crate (x2)
+  name: APC frontal cannon magazines crate (x2)
   components:
   - type: StorageFill
     contents:
@@ -121,7 +121,7 @@
 - type: entity
   parent: RMCCrateAmmo
   id: RMCCrateVehicleAmmoRotaryCannon
-  name: RE700 rotary cannon magazines crate (x3)
+  name: RE-RE700 rotary cannon magazines crate (x3)
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -3545,6 +3545,51 @@
         tags:
         - AU14MagazineXMP5A6
 
+#
+- type: entity
+  parent: RMCBoxMagazineRifleBase
+  id: CMUBoxMagazineRifleXM20A2Empty
+  name: magazine box (XM20A2 x 8)
+  components:
+  - type: Sprite
+    layers:
+    - state: rifle_box
+      color: "#5c4a2e"
+    - state: rifle_ammo_full_mags_base
+      map: [ "enum.CMItemSlotsLayers.Fill" ]
+    - state: rifle_ammo_full_mags_color
+      map: [ "enum.CMItemSlotsLayers2.Fill" ]
+      color: "#ffc000"
+    - state: rifle_box_generic
+      color: "#5c4a2e"
+    - state: rifle_box_marking
+      color: "#7c4c1b"
+    - state: rifle_lid
+      map: [ "lid" ]
+      color: "#5c4a2e"
+    - state: rifle_lid_marking
+      map: [ "lid_marking" ]
+      color: "#7c4c1b"
+  - type: CMItemSlots
+    count: 8
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazineRifleXM20A2
+
+- type: entity
+  parent: CMUBoxMagazineRifleXM20A2Empty
+  id: CMUBoxMagazineRifleXM20A2
+  suffix: Full
+  components:
+  - type: CMItemSlots
+    startingItem: AU14MagazineXMP5A6
+    count: 8
+    slot:
+      whitelist:
+        tags:
+        - AU14MagazineRifleXM20A2
+
 # L90A2 SMG (RMC/TWE)
 - type: entity
   parent: RMCBoxMagazineRifleBase

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml
@@ -3583,7 +3583,7 @@
   suffix: Full
   components:
   - type: CMItemSlots
-    startingItem: AU14MagazineXMP5A6
+    startingItem: AU14MagazineRifleXM20A2
     count: 8
     slot:
       whitelist:

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
@@ -288,6 +288,7 @@
   - CMUBoxMagazineRifleKramerEmptyBuild
   - RMCDividerConstruction
   - CMUBoxMagazineSMGXMP5A6EmptyBuild
+  - CMUBoxMagazineRifleXM20A2EmptyBuild
   - RMCBoxMagazineSMGM63EmptyBuild
   - RMCBoxMagazineSMGM63APEmptyBuild
   - RMCBoxMagazineSMGM63ExtEmptyBuild
@@ -477,6 +478,12 @@
   id: CMUBoxMagazineSMGXMP5A6EmptyBuild
   name: XMP5A6 magazine box
   prototype: CMUBoxMagazineSMGXMP5A6Empty
+
+- type: rmcConstruction
+  parent: RMCCardboardBuildBase
+  id: CMUBoxMagazineRifleXM20A2EmptyBuild
+  name: XM20A2 magazine box
+  prototype: CMUBoxMagazineRifleXM20A2Empty
 
 - type: rmcConstruction
   parent: RMCCardboardBuildBase

--- a/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
+++ b/Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml
@@ -280,6 +280,7 @@
   - RMCBoxMagazineRifleM54CEmptyBuild
   - RMCBoxMagazineRifleM54CAPEmptyBuild
   - RMCBoxMagazineRifleM54CExtEmptyBuild
+  - CMUBoxMagazineRifleXM20A2EmptyBuild
   - RMCDividerConstruction
   - RMCBoxMagazineRifleM4SPREmptyBuild
   - RMCBoxMagazineRifleM4SPRAPEmptyBuild
@@ -288,7 +289,6 @@
   - CMUBoxMagazineRifleKramerEmptyBuild
   - RMCDividerConstruction
   - CMUBoxMagazineSMGXMP5A6EmptyBuild
-  - CMUBoxMagazineRifleXM20A2EmptyBuild
   - RMCBoxMagazineSMGM63EmptyBuild
   - RMCBoxMagazineSMGM63APEmptyBuild
   - RMCBoxMagazineSMGM63ExtEmptyBuild


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
For HAZOPs, I added missing XM20A2 ammo that ought to have been stocked in standard ammunition in their automated req vendor, created a magazine box construction for XM20A2 (x 8), created a filled variant, stocked two of them in their vendor, replaced the incompatible M42A2 wire stock with the proper M42A1 wooden stock, as the shotguns they carry are the M42A1. 

On that vehicle ammo fix, prior to what I did, there were two crates listed; RE-RE700 Frontal Cannon ammo & RE700 Rotary Cannon ammo. The RE-RE700 Frontal is actually ammo for the APC's frontal cannon, so I renamed the crate to APC Frontal Cannon crate, and just had the RE700 Rotary changed to the proper RE-RE700 rotary cannon crate for the Humvee's RE-RE700 Cupola.

On the Mk86, I added both a crate for the case, priced at 1,700 and three crates for it's specific mag boxes which are priced at the following; AGM-H mag box 2x (700) AGM-F mag box 2x (400)  and AGM-S mag box 2x (200)

## Why / Balance
For the 2/3's much needed for the HAZOP's as there was no craft recipe or pre-filled XM20A2 mag boxes for req to dipense or pack, as well as a lack of XM20A2 in standard ammunition to vend in the first place. The vehicle naming issue was a much-needed bug fix. 

Now for the Mk86, I noticed for one thing, despite it being a special issue for LACN, RMC and Prodigy there was no ammo crates purchasable for it, meaning the user had 60 shots total (or 75 if we include the smoke AGM's) making it a very limited mountable gun, and then I figured there's just a plain lack of the case purchasable in the first place, where we already have the M56D and M2C purchasable by most platoons (except the UPP) so I figured why not tack it on as well?

## Technical details

- Created a Mk86 crate and it's ammo types under `Resources/Prototypes/_CMU14/Economy/Catalog/Fills/Crates/misc.yml` 
- Create XM20A2 mag box prototype under `Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Ammunition/Boxes/magazine_boxes.yml`
- Added XM20A2 mag box craft under `Resources/Prototypes/_RMC14/Recipes/Materials/cardboard.yml`

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: 100 XM20A2 magazines in HAZOP's Standard Ammunition within their requisition vendor, as well as two pre-filled mag boxes of XM20A2.
- add: a crafting recipe for the XM20A2s magazine box
- add: a Mk86 Automatic Grenade Launcher crate case, and it's respective ammo within Govfors ASRS catalog for every platoon (except the UPP)
- tweak: Replaced incompatible M42A2 collapsible stock with the proper M42A1 wooden stock for HAZOP's requestion vendor. 
- fix: A Spelling issue mixing up the APC Frontal Cannon ammo crate and the RE-RE700 Rotary Cannon ammo crate in the ASRS
