### PR TITLE
WYPMCCostChange

### DIFF
--- a/Resources/Prototypes/_CMU14/Entities/Structures/Machines/corporate_console.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Structures/Machines/corporate_console.yml
@@ -48,6 +48,6 @@
     state: terminal1_old
   - type: CorporateConsole
     callableParties:
-      WYPMCParty: 7500
+      WYPMCParty: 17500
       WYHT: 6000
       IPIESynth: 3500


### PR DESCRIPTION
Increases the price of the WYPMC 3rd Party to balance the call-in. This will ensure it is only called in as needed, and not at the start of a round.

## About the PR
Changed the Cost of WYPMC 3rd party from 7500 to 17500

## Why / Balance
The WYPMC 3rd party is overused, called-in before there are any threats to facility, and is too cheap for what it is; A squad leader (with high skills), combat technician, Sniper Specialist, and SGO.

## Technical details
A value in \Resources\Prototypes\_CMU14\Entities\Structures\Machines\corporate_console.yml was changed from 7500 to 17500

This is my First PR, If you see (technical) issues with it, please comment.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Changed the Cost of the WYPMC 3rd party from 7500 to 17500
