### PR TITLE
Updates Col synth loadouts

### DIFF
--- a/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
+++ b/Content.Client/Lobby/UI/Loadouts/LoadoutGroupContainer.xaml.cs
@@ -73,8 +73,13 @@ public sealed partial class LoadoutGroupContainer : BoxContainer
 
         LoadoutsContainer.DisposeAllChildren();
 
-        // Get all loadout prototypes for this group.
-        var validProtos = _groupProto.Loadouts.Select(id => protoMan.Index(id));
+        // Get all loadout prototypes for this group. Invalid content should not crash the menu.
+        var validProtos = new List<LoadoutPrototype>();
+        foreach (var id in _groupProto.Loadouts)
+        {
+            if (protoMan.TryIndex(id, out var proto))
+                validProtos.Add(proto);
+        }
 
         /*
          * Group the prototypes based on their GroupBy field.

--- a/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/LoadoutTests.cs
@@ -21,16 +21,39 @@ public sealed class LoadoutTests
   equipment:
     jumpsuit: ClothingUniformJumpsuitColorGrey
 
+- type: loadout
+  id: TestPointLoadoutThree
+  cost: 3
+
+- type: loadout
+  id: TestPointLoadoutFour
+  cost: 4
+
 - type: loadoutGroup
   id: LoadoutTesterJumpsuit
   name: generic-unknown
   loadouts:
   - TestJumpsuit
 
+- type: loadoutGroup
+  id: LoadoutTesterPoints
+  name: generic-unknown
+  minLimit: 0
+  maxLimit: 1
+  loadouts:
+  - TestPointLoadoutThree
+  - TestPointLoadoutFour
+
 - type: roleLoadout
   id: JobLoadoutTester
   groups:
   - LoadoutTesterJumpsuit
+
+- type: roleLoadout
+  id: JobLoadoutPointTester
+  points: 5
+  groups:
+  - LoadoutTesterPoints
 
 - type: job
   id: LoadoutTester
@@ -86,6 +109,77 @@ public sealed class LoadoutTests
             Assert.That(checkedCount, Is.EqualTo(_expectedEquipment.Count), "Number of items does not match expected!");
 
             entManager.DeleteEntity(tester);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Checks that changing a selection immediately updates its remaining points.
+    /// </summary>
+    [Test]
+    public async Task TestSelectionUpdatesPoints()
+    {
+        var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Dirty = true,
+        });
+        var server = pair.Server;
+        var protoManager = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var loadout = new RoleLoadout("JobLoadoutPointTester")
+            {
+                Points = 5,
+                SelectedLoadouts =
+                {
+                    ["LoadoutTesterPoints"] = new List<Loadout>(),
+                },
+            };
+
+            Assert.That(loadout.AddLoadout("LoadoutTesterPoints", "TestPointLoadoutThree", protoManager), Is.True);
+            Assert.That(loadout.Points, Is.EqualTo(2));
+
+            // Replacing an item at the group limit must refund the old item as well.
+            Assert.That(loadout.AddLoadout("LoadoutTesterPoints", "TestPointLoadoutFour", protoManager), Is.True);
+            Assert.That(loadout.Points, Is.EqualTo(1));
+
+            Assert.That(loadout.RemoveLoadout("LoadoutTesterPoints", "TestPointLoadoutFour", protoManager), Is.True);
+            Assert.That(loadout.Points, Is.EqualTo(5));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    /// <summary>
+    /// Checks that every loadout referenced by a group exists.
+    /// </summary>
+    [Test]
+    public async Task TestLoadoutGroupReferences()
+    {
+        var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Dirty = true,
+        });
+        var server = pair.Server;
+        var protoManager = server.ResolveDependency<IPrototypeManager>();
+
+        await server.WaitAssertion(() =>
+        {
+            var missing = new List<string>();
+
+            foreach (var group in protoManager.EnumeratePrototypes<LoadoutGroupPrototype>())
+            {
+                foreach (var loadout in group.Loadouts)
+                {
+                    if (!protoManager.HasIndex<LoadoutPrototype>(loadout))
+                        missing.Add($"{group.ID}: {loadout}");
+                }
+            }
+
+            Assert.That(missing, Is.Empty,
+                $"Loadout groups reference unknown loadouts:\n{string.Join('\n', missing)}");
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
+++ b/Content.Shared/Preferences/Loadouts/RoleLoadout.cs
@@ -207,6 +207,29 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
     }
 
     /// <summary>
+    /// Recalculates the remaining points after the selected loadouts are changed.
+    /// </summary>
+    private void RecalculatePoints(IPrototypeManager protoManager)
+    {
+        if (!protoManager.TryIndex(Role, out var roleProto))
+        {
+            Points = null;
+            return;
+        }
+
+        Points = roleProto.Points;
+
+        foreach (var groupLoadouts in SelectedLoadouts.Values)
+        {
+            foreach (var loadout in groupLoadouts)
+            {
+                if (protoManager.TryIndex(loadout.Prototype, out var loadoutProto))
+                    Apply(loadoutProto);
+            }
+        }
+    }
+
+    /// <summary>
     /// Resets the selected loadouts to default if no data is present.
     /// </summary>
     public void SetDefault(HumanoidCharacterProfile? profile, ICommonSession? session, IPrototypeManager protoManager, bool force = false)
@@ -340,6 +363,8 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
             Prototype = selectedLoadout,
         });
 
+        RecalculatePoints(protoManager);
+
         return true;
     }
 
@@ -360,6 +385,7 @@ public sealed partial class RoleLoadout : IEquatable<RoleLoadout>
                 continue;
 
             groupLoadouts.RemoveAt(i);
+            RecalculatePoints(protoManager);
             return true;
         }
 

--- a/Resources/Prototypes/_CMU14/Entities/Clothing/Pouches/Synth.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Clothing/Pouches/Synth.yml
@@ -51,7 +51,6 @@
   - type: StorageFill
     contents:
     - id: CMFlash
-    - id: AU14TeleBaton
     - id: RMCHandcuffs
     - id: RMCHandcuffs
     - id: RMCHandcuffs

--- a/Resources/Prototypes/_CMU14/Roles/Colony/Synthetics/AU14JobCivilianColonySynthetic.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Colony/Synthetics/AU14JobCivilianColonySynthetic.yml
@@ -110,7 +110,7 @@
 
 - type: roleLoadout
   id: JobAU14JobCivilianColonySynthetic
-  points: 7
+  points: 30 # while normally they would get 45, other things in the loadout arn't properly balanced with points right now, so we'll just steal 15 from them.
   groups:
   - ColonySynthSpecializationAU14
   - SynthBackpackAU14

--- a/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Synthetics/AuxSupportSynth.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Military/GovFor/Platoon/Synthetics/AuxSupportSynth.yml
@@ -169,7 +169,6 @@
   - SynthBackpackAU14
   - SynthUniformAU14
   - SynthUniformAccessoriesAU14
-  - SynthEquipmentAU14
   - SynthAccesoriesSpecialAU14
   - SynthSuitAU14
   - SynthSuitSpecialAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/ColonySynthPouchesLeftAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/ColonySynthPouchesLeftAU14.yml
@@ -9,3 +9,4 @@
   - PouchAutoinjectorFilledMilitaryDoctorAU14
   - PouchConstructionFillFullAU14
   - PouchMedkitPMCFilledAU14
+  - PouchPoliceEquipmentSupportSynthAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/ColonySynthPouchesRightAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/ColonySynthPouchesRightAU14.yml
@@ -9,4 +9,3 @@
   - PouchAutoinjectorFilledMilitaryDoctorRightAU14
   - PouchConstructionFillFullRightAU14
   - PouchMedkitPMCFilledRightAU14
-  - PouchPoliceEquipmentSupportSynthAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/ColonySynthPouchesRightAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/ColonySynthPouchesRightAU14.yml
@@ -9,3 +9,4 @@
   - PouchAutoinjectorFilledMilitaryDoctorRightAU14
   - PouchConstructionFillFullRightAU14
   - PouchMedkitPMCFilledRightAU14
+  - PouchPoliceEquipmentSupportSynthAU14

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/SynthAccesoriesSpecialAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/SynthAccesoriesSpecialAU14.yml
@@ -9,10 +9,10 @@
   - DropSurgicalGreenCMU14
   - DropSurgicalBlueCMU14
   - DropSurgicalBlackCMU14
-  - RMCToolWebbingFilled
-  - RMCWebbingDropPouch
-  - CMWebbingBlack
-  - CMWebbingBrown
+  - ToolWebbingFilledAU14
+  - WebbingDropPouchAU14
+  - WebbingBlackAU14
+  - WebbingBrownAU14
   # - AU14GOVFORIOHeadset # I dont see OPFOR loadouts so use AU14OPFORIOHeadset for OPFOR
 
 # Doctor

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/SynthAccesoriesSpecialAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/SynthAccesoriesSpecialAU14.yml
@@ -9,6 +9,10 @@
   - DropSurgicalGreenCMU14
   - DropSurgicalBlueCMU14
   - DropSurgicalBlackCMU14
+  - RMCToolWebbingFilled
+  - RMCWebbingDropPouch
+  - CMWebbingBlack
+  - CMWebbingBrown
   # - AU14GOVFORIOHeadset # I dont see OPFOR loadouts so use AU14OPFORIOHeadset for OPFOR
 
 # Doctor

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/SynthEquipmentAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Groups/SynthEquipmentAU14.yml
@@ -1,11 +1,15 @@
 - type: loadoutGroup
   id: SynthEquipmentAU14
   name: au14-loadout-group-synth-equipment
-  minLimit: 1
-  maxLimit: 1
+  minLimit: 0
+  maxLimit: 9
   loadouts:
   - SynthBreachingHammerAU14
   - MaintenanceJackAU14
   - PortableDialysisAU14
   - AU14SprayCleanerExperimentalAU14
   - AU14CMScalpelManager
+  - AU14telebatonloadout
+  - AU14CompactNailgunKit
+  - CMUDefibrillatorCompactSynthLoadout
+  - RMCWelderExperimentalLoadout

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14CMScalpelManager.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14CMScalpelManager.yml
@@ -1,5 +1,6 @@
 - type: loadout
   id: AU14CMScalpelManager
+  cost: 15
   inhand:
   - CMScalpelManager
 # Civilian Synth Specializations

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14CMTelebaton.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14CMTelebaton.yml
@@ -1,0 +1,5 @@
+- type: loadout
+  id: AU14telebatonloadout
+  cost: 15
+  inhand:
+  - AU14TeleBaton

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14CompactNailgunkit.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14CompactNailgunkit.yml
@@ -1,0 +1,5 @@
+- type: loadout
+  id: AU14CompactNailgunKit
+  cost: 15
+  inhand:
+  - RMCVendorBundleCompactNailgunKit

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14CompactSynthDefib.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14CompactSynthDefib.yml
@@ -1,0 +1,5 @@
+- type: loadout
+  id: CMUDefibrillatorCompactSynthLoadout
+  cost: 15
+  inhand:
+  - CMUDefibrillatorCompactSynth

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14SprayCleanerExperimentalAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/AU14SprayCleanerExperimentalAU14.yml
@@ -1,5 +1,6 @@
 - type: loadout
   id: AU14SprayCleanerExperimentalAU14
+  cost: 2
   inhand:
   - AU14SprayCleanerExperimental
 # Civilian Synth Specializations

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/CMUExperimentalWelderLoadout.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/CMUExperimentalWelderLoadout.yml
@@ -1,0 +1,5 @@
+- type: loadout
+  id: RMCWelderExperimentalLoadout
+  cost: 15
+  inhand:
+  - RMCWelderExperimental

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/MaintenanceJackAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/MaintenanceJackAU14.yml
@@ -1,4 +1,5 @@
 - type: loadout
   id: MaintenanceJackAU14
+  cost: 15
   inhand:
   - AU14MaintenanceJackSpecial

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/PortableDialysisAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/PortableDialysisAU14.yml
@@ -1,4 +1,5 @@
 - type: loadout
   id: PortableDialysisAU14
+  cost: 15
   inhand:
   - RMCPortableDialysis

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/SynthBreachingHammerAU14.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/RoleSpecific/Synthetic/SynthBreachingHammerAU14.yml
@@ -1,4 +1,5 @@
 - type: loadout
   id: SynthBreachingHammerAU14
+  cost: 15
   inhand:
   - RMCSynthBreachingHammer

--- a/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/accessories.yml
+++ b/Resources/Prototypes/_CMU14/Roles/Shared/Loadouts/Items/Slots/accessories.yml
@@ -22,3 +22,18 @@
   id: DropSurgicalBlackCMU14
   inhand:
   - CMU14DropSurgicalBlack
+
+- type: loadout
+  id: ToolWebbingFilledAU14
+  inhand:
+  - RMCToolWebbingFilled
+
+- type: loadout
+  id: WebbingBlackAU14
+  inhand:
+  - CMWebbingBlack
+
+- type: loadout
+  id: WebbingBrownAU14
+  inhand:
+  - CMWebbingBrown

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Medical/defib.yml
@@ -122,6 +122,20 @@
   - type: PowerCellDraw
     useRate: 350
 
+- type: entity
+  id: CMUDefibrillatorCompactSynth
+  parent: CMDefibrillator
+  name: advanced automated external defibrillator
+  description: A modificatied version of a normal automated external defibrillator, it uses a experimental battery to retain its compact size, while still holding considerably more charge then traditional compact defibrillator. Unfortunately, due to technology still being in the early stages, the metals within are so dense and heavy that only a synthetic can reasonably carry and use the device.
+  components:
+  - type: PowerCellDraw
+    useRate: 132
+  - type: WhitelistPickupBy
+    whitelist:
+      components:
+        - Synth
+  - type: RMCSynthItemRestriction
+
 # TODO RMC14: synth reset key sprites currently all use a makeshift_key placeholder.
 # Replace them with original art that does not include Alien media logos.
 - type: entity


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Changes what the col synth can have in their pockets, and lets them use more varied equipment like their govfor counterpart.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Becuase col synth dosn't typically have access to the point buy vendors like gov synth does, I used the point loadout system to make them able to actually spend points on neat equipment. Gov synths however no longer get one free ADDITIONAL equipment ONTOP of their point vendor. I've also allowed col synths to use the policing tools pouch like gov synth, since everything in there is something that the col synth would ALREADY easily have access to. Finally, expanded the range of of available webbings both can select.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added most experimental tools to the col synth loadout, along with a proper point amount and cost
- remove: Removed govfor synths free extra synth equipment via loadout piece (sorrrrry)
- tweak: Expanded a few webbings and pouch options for synths