### PR TITLE
Fix flying powerloader and chairs

### DIFF
--- a/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.Movement.cs
+++ b/Content.Shared/_CMU14/ZLevels/Core/EntitySystems/CMUSharedZLevelsSystem.Movement.cs
@@ -3,6 +3,7 @@ using Content.Shared._CMU14.ZLevels;
 using Content.Shared._CMU14.ZLevels.Core.Components;
 using Content.Shared._CMU14.ZLevels.Vehicles;
 using Content.Shared._RMC14.Fireman;
+using Content.Shared.Buckle.Components; // RuMC edit
 using Content.Shared.Chasm;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Components;
@@ -191,7 +192,7 @@ public abstract partial class CMUSharedZLevelsSystem
 
         foreach (var victim in _fallImpactVictims)
         {
-            if (victim == ent.Owner)
+            if (victim == ent.Owner || IsBuckledTo(victim, ent.Owner)) // RuMC edit
                 continue;
 
             var knockdownTime = MathF.Min(args.ImpactPower * ent.Comp.Mass * 0.1f, 10f);
@@ -204,6 +205,12 @@ public abstract partial class CMUSharedZLevelsSystem
         }
     }
 
+    // RuMC edit start
+    private bool IsBuckledTo(EntityUid victim, EntityUid strap)
+    {
+        return TryComp<BuckleComponent>(victim, out var buckle) && buckle.BuckledTo == strap;
+    }
+    // RuMC edit end
 
 
     protected void UpdateZMovement(float frameTime)

--- a/Content.Shared/_CMU14/ZLevels/Vehicles/CMUVehicleZTraversalSystem.cs
+++ b/Content.Shared/_CMU14/ZLevels/Vehicles/CMUVehicleZTraversalSystem.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using Content.Shared._CMU14.ZLevels.Core.Components;
 using Content.Shared._CMU14.ZLevels.Core.EntitySystems;
 using Content.Shared._RMC14.Vehicle;
+using Content.Shared.Buckle.Components; // RuMC edit
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Robust.Shared.Audio;
@@ -195,6 +196,11 @@ public sealed partial class CMUVehicleZTraversalSystem : EntitySystem
         {
             if (TerminatingOrDeleted(target))
                 continue;
+
+            // RuMC edit start
+            if (TryComp<BuckleComponent>(target, out var buckle) && buckle.BuckledTo == ent.Owner)
+                continue;
+            // RuMC edit end
 
             _damage.TryChangeDamage(target, new DamageSpecifier(damageType, damageAmount), origin: ent.Owner);
         }

--- a/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/PowerLoader/rmc_power_loader.yml
@@ -36,6 +36,8 @@
   - type: Physics
     bodyType: KinematicController
   - type: Clickable
+  - type: CMUZPhysics # RuMC edit
+  - type: CMUVehicleZTraversal # RuMC edit
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Furniture/chairs.yml
@@ -9,6 +9,7 @@
   name: abstract chair
   suffix: RMC
   components:
+  - type: CMUZPhysics # RuMC edit
   - type: Corrodible
     timeToApply: 4
     structure: true


### PR DESCRIPTION
## About the PR

Ports the fixes from RussianCM PRs [#395](https://github.com/flex5hybrid/RussianCM/pull/395) and [#402](https://github.com/flex5hybrid/RussianCM/pull/402) into ColonialMarinesUniverse. Powerloaders and chairs now interact correctly with CMU z-level physics instead of remaining suspended or flying across z-levels.

## Why / Balance

Powerloaders and chairs could remain airborne when there was no supporting floor beneath them. This makes them fall as intended and prevents falling vehicles from damaging occupants buckled to the vehicle itself. No intentional balance changes are introduced.

## Technical details

- Added `CMUZPhysics` and `CMUVehicleZTraversal` to the RMC powerloader base prototype.
- Added `CMUZPhysics` to the RMC chair base prototype.
- Excluded occupants buckled to a falling entity from the shared fall impact area damage.
- Excluded buckled occupants from vehicle landing crush damage.

## Media

No media is required for these small bug fixes.

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I have included a brief detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Prevent powerloaders and chairs from flying across z-levels.
- fix: Prevent falling vehicles from damaging their buckled occupants.