### PR TITLE
Map maintenance

### DIFF
--- a/Resources/Maps/_AU14/StableGarrisonMultiZ/StableGarrisonMultiZ1.yml
+++ b/Resources/Maps/_AU14/StableGarrisonMultiZ/StableGarrisonMultiZ1.yml
@@ -5,7 +5,7 @@ meta:
   forkId: ""
   forkVersion: ""
   time: 08/16/2026 00:11:37
-  entityCount: 9271
+  entityCount: 9272
 maps:
 - 1
 grids:
@@ -17854,6 +17854,13 @@ entities:
     components:
     - type: Transform
       pos: 288.5,-90.5
+      parent: 1
+- proto: AU14SpawnPointCivilianCMBMarshal
+  entities:
+  - uid: 9272
+    components:
+    - type: Transform
+      pos: 273.5,-106.5
       parent: 1
 - proto: AU14SpawnPointCivilianScientist
   entities:


### PR DESCRIPTION
## About the PR

Restores the missing CMB Marshal spawn point on Stable Garrison’s z=+1 level.

## Why / Balance

A map resave removed the job-specific marker, causing the CMB Marshal to fall back to a generic spawn on the base level. This restores the intended placement and has no balance impact.

## Technical details

- Added `AU14SpawnPointCivilianCMBMarshal` at its previous z=+1 coordinates.
- Updated the map’s serialized entity count.
- Verified the full CMU integration-test shard passes: 229/229 tests.


## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**

:cl:
- fix: Restored the CMB Marshal spawn point to the intended upper level of Stable Garrison.