### PR TITLE
SFX Engine updates & SquadLeaderTracker DoS fix

### DIFF
--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml
@@ -18,6 +18,7 @@
                 <CheckBox Name="ExplosionScreenShakeEnabledCheckBox" Text="{Loc 'ui-options-explosion-screen-shake-enabled'}" />
                 <CheckBox Name="ExplosionScreenShakeIgnoreFarCheckBox" Text="{Loc 'ui-options-explosion-screen-shake-ignore-far'}" />
                 <CheckBox Name="FirearmScreenShakeEnabledCheckBox" Text="{Loc 'ui-options-firearm-screen-shake-enabled'}" />
+                <CheckBox Name="MuteScriptedSoundsCheckBox" Text="{Loc 'ui-options-mute-scripted-sounds'}" />
                 <Label Text="{Loc 'ui-options-accessability-header-visuals'}"
                        StyleClasses="LabelKeyText"/>
                 <CheckBox Name="ReducedMotionCheckBox" Text="{Loc 'ui-options-reduced-motion'}" />

--- a/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/AccessibilityTab.xaml.cs
@@ -47,6 +47,7 @@ public sealed partial class AccessibilityTab : Control
         Control.AddOptionCheckBox(CCVars.ExplosionScreenShakeEnabled, ExplosionScreenShakeEnabledCheckBox);
         Control.AddOptionCheckBox(CCVars.ExplosionScreenShakeIgnoreFar, ExplosionScreenShakeIgnoreFarCheckBox);
         Control.AddOptionCheckBox(CCVars.FirearmScreenShakeEnabled, FirearmScreenShakeEnabledCheckBox);
+        Control.AddOptionCheckBox(CCVars.MuteScriptedSounds, MuteScriptedSoundsCheckBox);
 
         Control.AddOptionCheckBox(CCVars.AccessibilityClientCensorNudity, CensorNudityCheckBox);
 

--- a/Content.Client/_CMU14/Ops/Sfx/ScriptedSoundOverlaySystem.cs
+++ b/Content.Client/_CMU14/Ops/Sfx/ScriptedSoundOverlaySystem.cs
@@ -22,18 +22,29 @@ public sealed partial class ScriptedSoundOverlaySystem : EntitySystem
 
     private readonly List<(ExplosionFlashOverlay Overlay, TimeSpan Expires)> _flashes = new();
     private AlarmOverlay? _alarm;
+    private EntityUid? _alarmMap;
     private const float DefaultAlarmFrequency = 2f;
 
     public override void Initialize()
     {
         SubscribeNetworkEvent<ScriptedSequenceMarkerNetEvent>(OnMarker);
-        SubscribeLocalEvent<RoundRestartCleanupEvent>(_ => Cleanup());
+        SubscribeNetworkEvent<RoundRestartCleanupEvent>(_ => Cleanup());
         SubscribeLocalEvent<EvacuationProgressComponent, AfterAutoHandleStateEvent>(OnEvacuationHandleState);
     }
 
     private void OnEvacuationHandleState(EntityUid uid, EvacuationProgressComponent comp, ref AfterAutoHandleStateEvent args)
     {
-        if (!comp.Enabled || comp.SelfDestructed || _alarm != null)
+        if (comp.SelfDestructAt == null || comp.SelfDestructed || !comp.Enabled)
+        {
+            if (_alarmMap == uid)
+            {
+                _alarmMap = null;
+                DisableAlarm();
+            }
+            return;
+        }
+
+        if (_alarm != null)
             return;
 
         var player = _plyMan.LocalEntity;
@@ -47,6 +58,7 @@ public sealed partial class ScriptedSoundOverlaySystem : EntitySystem
         if (!PlayerShouldReceiveMarker(uid, playerMap.Value))
             return;
 
+        _alarmMap = uid;
         EnableAlarm(DefaultAlarmFrequency);
     }
 
@@ -129,6 +141,8 @@ public sealed partial class ScriptedSoundOverlaySystem : EntitySystem
 
     private void Cleanup()
     {
+        _alarmMap = null;
+
         if (_alarm != null)
         {
             _overlay.RemoveOverlay(_alarm);

--- a/Content.Client/_CMU14/Ops/Sfx/ScriptedSoundSystem.cs
+++ b/Content.Client/_CMU14/Ops/Sfx/ScriptedSoundSystem.cs
@@ -1,0 +1,141 @@
+using Content.Shared._CMU14.Ops.Sfx;
+using Content.Shared.CCVar;
+using Content.Shared.GameTicking;
+using Robust.Client.Player;
+using Robust.Shared.Audio.Systems;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
+using Robust.Shared.Timing;
+
+namespace Content.Client._CMU14.Ops.Sfx;
+
+public sealed partial class ScriptedSoundSystem : EntitySystem
+{
+    [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly IPlayerManager _plyMan = default!;
+
+    private bool _muted;
+    private EntityUid? _lastResyncMap;
+    private readonly Dictionary<(int Handle, string Layer), EntityUid> _loops = new();
+    private readonly List<(EntityUid Entity, TimeSpan StopAt)> _scheduledStops = new();
+
+    public override void Initialize()
+    {
+        SubscribeNetworkEvent<PlayScriptedSoundNetEvent>(OnPlaySound);
+        SubscribeNetworkEvent<StopScriptedSoundLayersNetEvent>(OnStopLayers);
+        SubscribeNetworkEvent<RoundRestartCleanupEvent>(_ => StopAll());
+        Subs.CVar(_cfg, CCVars.MuteScriptedSounds, OnMuteChanged, true);
+    }
+
+    public override void Update(float frameTime)
+    {
+        var map = _plyMan.LocalEntity is { } player ? Transform(player).MapUid : null;
+        if (map != _lastResyncMap)
+        {
+            _lastResyncMap = map;
+            if (map != null)
+                RaiseNetworkEvent(new RequestScriptedSoundResyncNetEvent());
+        }
+
+        for (var i = _scheduledStops.Count - 1; i >= 0; i--)
+        {
+            var (entity, stopAt) = _scheduledStops[i];
+            if (_timing.CurTime < stopAt)
+                continue;
+
+            _audio.Stop(entity);
+            _scheduledStops.RemoveAt(i);
+        }
+    }
+
+    private void OnMuteChanged(bool muted)
+    {
+        var wasMuted = _muted;
+        _muted = muted;
+        if (muted)
+        {
+            StopAll();
+            return;
+        }
+
+        if (wasMuted)
+            RaiseNetworkEvent(new RequestScriptedSoundResyncNetEvent());
+    }
+
+    private void OnPlaySound(PlayScriptedSoundNetEvent ev)
+    {
+        if (_muted)
+            return;
+
+        var played = ev.Global
+            ? _audio.PlayGlobal(ev.Sound, Filter.Local(), false, ev.Params)
+            : ev.AnchorCoords is { } coords
+                ? _audio.PlayPvs(ev.Sound, EntityManager.GetCoordinates(coords), ev.Params)
+                : null;
+
+        if (played is not { } stream)
+            return;
+
+        if (ev.Layer != null)
+            ReplaceLoop(ev.Handle, ev.Layer, stream.Entity);
+
+        if (ev.DurationSeconds is { } dur)
+            _scheduledStops.Add((stream.Entity, _timing.CurTime + TimeSpan.FromSeconds(dur)));
+    }
+
+    private void ReplaceLoop(int handle, string layer, EntityUid entity)
+    {
+        var key = (handle, layer);
+        if (_loops.Remove(key, out var old))
+            _audio.Stop(old);
+        _loops[key] = entity;
+    }
+
+    private void OnStopLayers(StopScriptedSoundLayersNetEvent ev)
+    {
+        if (ev.Layers == null)
+        {
+            RemoveSequence(ev.Handle);
+            return;
+        }
+
+        foreach (var layer in ev.Layers)
+        {
+            if (_loops.Remove((ev.Handle, layer), out var stream))
+                _audio.Stop(stream);
+        }
+    }
+
+    private void RemoveSequence(int handle)
+    {
+        List<(int Handle, string Layer)>? dead = null;
+        foreach (var key in _loops.Keys)
+        {
+            if (key.Handle == handle)
+                (dead ??= new List<(int Handle, string Layer)>()).Add(key);
+        }
+
+        if (dead == null)
+            return;
+
+        foreach (var key in dead)
+        {
+            if (_loops.Remove(key, out var stream))
+                _audio.Stop(stream);
+        }
+    }
+
+    private void StopAll()
+    {
+        foreach (var (_, stream) in _loops)
+            _audio.Stop(stream);
+        _loops.Clear();
+
+        foreach (var (entity, _) in _scheduledStops)
+            _audio.Stop(entity);
+        _scheduledStops.Clear();
+    }
+}

--- a/Content.Server/Toolshed/Commands/PrototypeContainsCommand.cs
+++ b/Content.Server/Toolshed/Commands/PrototypeContainsCommand.cs
@@ -1,6 +1,7 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Server.Administration;
 using Content.Shared.Administration;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Toolshed;
 
 namespace Content.Server.Toolshed.Commands;
@@ -14,7 +15,5 @@ public sealed class PrototypeContainsCommand : ToolshedCommand
         [CommandArgument] string prototype,
         [CommandInverted] bool inverted
     )
-    {
-        return input.Where(x => (MetaData(x).EntityPrototype?.ID.Contains(prototype) ?? false) ^ inverted);
-    }
+        => input.Where(x => !Deleted(x) && ((MetaData(x).EntityPrototype?.ID.Contains(prototype) ?? false) ^ inverted));
 }

--- a/Content.Server/_CMU14/Ops/Sfx/ActiveScriptedSound.cs
+++ b/Content.Server/_CMU14/Ops/Sfx/ActiveScriptedSound.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Audio;
+
 namespace Content.Server._CMU14.Ops.Sfx;
 
 public sealed class ActiveScriptedSound
@@ -6,10 +8,12 @@ public sealed class ActiveScriptedSound
     public TimeSpan StartTime;
     public int NextEntryIndex;
     public EntityUid? AnchorEntity;
-    public bool WarnedEmptyFilter;
 
-    public Dictionary<string, EntityUid> ActiveLoops = new();
-    public List<(TimeSpan StopAt, EntityUid Entity)> ScheduledLoopStops = new();
     public Dictionary<int, TimeSpan> JitteredDelays = new();
     public List<(int Index, TimeSpan NextFire)> RepeatingEntries = new();
+
+    /// <summary>Named loop layers currently playing</summary>
+    public readonly Dictionary<string, TrackedLoop> Loops = new();
 }
+
+public sealed record TrackedLoop(SoundSpecifier Sound, AudioParams Params, bool Global, TimeSpan FiredAt, float? Duration);

--- a/Content.Server/_CMU14/Ops/Sfx/EvacuationSequenceSystem.cs
+++ b/Content.Server/_CMU14/Ops/Sfx/EvacuationSequenceSystem.cs
@@ -4,7 +4,12 @@ using Content.Shared._RMC14.Evacuation;
 using Content.Shared._RMC14.OrbitalCannon;
 using Content.Shared.CCVar;
 using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
 
 namespace Content.Server._CMU14.Ops.Sfx;
 
@@ -13,10 +18,18 @@ public sealed partial class EvacuationSequenceSystem : EntitySystem
     [Dependency] private OrbitalCannonSystem _orbitalCannon = default!;
     [Dependency] private ScriptedSoundSystem _scriptedSound = default!;
     [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private readonly SharedMapSystem _map = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
 
     private static readonly ProtoId<ScriptedSoundSequencePrototype> SelfDestructSequence = "SelfDestructSequence";
     private static readonly ProtoId<ScriptedSoundSequencePrototype> SelfDestructEngineSequence = "SelfDestructEngineSequence";
     private static readonly EntProtoId SelfDestructWarhead = "CMUSelfDestructWarheadExplosion";
+    private static readonly EntProtoId ScatterWarhead = "CMUSelfDestructScatterExplosion";
+
+    private static readonly int[] VolleyDelays = [15, 27, 37];
+    private const int WarheadsPerVolley = 3;
+    private const float EdgePickChance = 0.6f;
+    private const float EdgeMargin = 8f;
 
     public override void Initialize()
     {
@@ -29,6 +42,9 @@ public sealed partial class EvacuationSequenceSystem : EntitySystem
     private void OnEnabled(ref EvacuationEnabledEvent ev)
     {
         if (!_cfg.GetCVar(CCVars.EnableEvacSfx)) return;
+
+        if (TryComp<EvacuationProgressComponent>(ev.Map, out var progress) && progress.DropShipCrashed)
+            return;
 
         if (!_scriptedSound.TryGetActiveSequence(SelfDestructSequence, ev.Map, out _))
             _scriptedSound.StartSequence(SelfDestructSequence, ev.Map);
@@ -49,7 +65,71 @@ public sealed partial class EvacuationSequenceSystem : EntitySystem
     }
 
     private void OnSelfDestruct(ref ShipSelfDestructEvent ev)
-        => _orbitalCannon.SpawnExplosion(SelfDestructWarhead, Transform(ev.Map).Coordinates);
+    {
+        if (TryGetShipTiles(ev.Map, out var tiles, out _))
+            _orbitalCannon.SpawnExplosion(SelfDestructWarhead, _random.Pick(tiles));
+
+        for (var i = 0; i < VolleyDelays.Length; i++)
+        {
+            var map = ev.Map;
+            var delay = VolleyDelays[i];
+            Timer.Spawn(TimeSpan.FromSeconds(delay), () => ScatterVolley(map));
+        }
+    }
+
+    private bool TryGetShipTiles(EntityUid map, out List<EntityCoordinates> tiles, out List<EntityCoordinates> edgeTiles)
+    {
+        tiles = new List<EntityCoordinates>();
+        edgeTiles = new List<EntityCoordinates>();
+        if (TerminatingOrDeleted(map))
+            return false;
+
+        var mapId = Transform(map).MapID;
+        Entity<MapGridComponent>? ship = null;
+        var bestArea = 0f;
+        foreach (var grid in _map.GetAllGrids(mapId))
+        {
+            var aabb = grid.Comp.LocalAABB;
+            var area = aabb.Width * aabb.Height;
+            if (area <= bestArea)
+                continue;
+
+            bestArea = area;
+            ship = grid;
+        }
+
+        if (ship is not { } target)
+            return false;
+
+        var bounds = target.Comp.LocalAABB;
+        foreach (var tile in _map.GetAllTiles(target, target.Comp))
+        {
+            var coords = new EntityCoordinates(target, tile.GridIndices);
+            tiles.Add(coords);
+
+            var p = tile.GridIndices;
+            if (bounds.Width > EdgeMargin * 2 && bounds.Height > EdgeMargin * 2
+                && (bounds.Left + EdgeMargin > p.X || p.X > bounds.Right - EdgeMargin
+                || bounds.Bottom + EdgeMargin > p.Y || p.Y > bounds.Top - EdgeMargin))
+            {
+                edgeTiles.Add(coords);
+            }
+        }
+
+        return tiles.Count > 0;
+    }
+
+    private void ScatterVolley(EntityUid map)
+    {
+        if (!TryGetShipTiles(map, out var tiles, out var edgeTiles))
+            return;
+
+        for (var i = 0; i < WarheadsPerVolley; i++)
+        {
+            var pool = edgeTiles.Count > 0 && _random.Prob(EdgePickChance) ? edgeTiles : tiles;
+            _orbitalCannon.SpawnExplosion(ScatterWarhead, _random.Pick(pool));
+        }
+    }
 
     private void OnCVarChanged(bool enabled)
     {

--- a/Content.Server/_CMU14/Ops/Sfx/ScriptedSoundSystem.cs
+++ b/Content.Server/_CMU14/Ops/Sfx/ScriptedSoundSystem.cs
@@ -6,7 +6,7 @@ using Content.Server._RMC14.Announce;
 using Content.Shared._RMC14.Announce;
 using Content.Shared.GameTicking;
 using Robust.Shared.Audio.Systems;
-using Robust.Shared.Audio.Components;
+using Robust.Shared.Audio;
 using Robust.Shared.Map;
 using Robust.Shared.Player;
 using Robust.Shared.Prototypes;
@@ -36,6 +36,7 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
         SubscribeLocalEvent<StartScriptedSequenceEvent>(OnStart);
         SubscribeLocalEvent<StopScriptedSequenceEvent>(OnStop);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestartCleanup);
+        SubscribeNetworkEvent<RequestScriptedSoundResyncNetEvent>(OnResyncRequest);
         SubscribeLocalEvent<PrototypesReloadedEventArgs>(OnPrototypesReloaded);
         SubscribeLocalEvent<MapCreatedEvent>(OnMapCreated);
         SubscribeLocalEvent<MapRemovedEvent>(OnMapRemoved);
@@ -43,7 +44,7 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
 
         foreach (var proto in _proto.EnumeratePrototypes<ScriptedSoundSequencePrototype>())
         {
-            ValidateSequenceOrder(proto.ID, proto);
+            ValidateSequence(proto.ID, proto);
             Logger.GetSawmill("cmu-sfx").Debug($"[SFX] Loaded sequence prototype '{proto.ID}' with {proto.Entries.Count} entries");
         }
     }
@@ -71,7 +72,7 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
         if (!ev.WasModified<ScriptedSoundSequencePrototype>()) return;
         foreach (var proto in _proto.EnumeratePrototypes<ScriptedSoundSequencePrototype>())
         {
-            ValidateSequenceOrder(proto.ID, proto);
+            ValidateSequence(proto.ID, proto);
             Logger.GetSawmill("cmu-sfx").Debug($"[SFX] Reloaded prototype '{proto.ID}'");
         }
     }
@@ -90,24 +91,12 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
         {
             if (!_activeSequences.TryGetValue(uid, out var active))
                 continue;
-            List<string>? deadKeys = null;
-            foreach (var kv in active.ActiveLoops)
+
+            if (active.AnchorEntity is { } anchor && TerminatingOrDeleted(anchor))
             {
-                if (!TerminatingOrDeleted(kv.Value))
-                    continue;
-
-                deadKeys ??= new List<string>();
-                deadKeys.Add(kv.Key);
-            }
-
-            if (deadKeys != null)
-                foreach (var key in deadKeys)
-                    active.ActiveLoops.Remove(key);
-
-            if (!active.WarnedEmptyFilter && active.AnchorEntity is { } anchor && TerminatingOrDeleted(anchor))
-            {
-                active.WarnedEmptyFilter = true;
-                Logger.GetSawmill("cmu-sfx").Warning($"[SFX] Sequence '{active.SequenceId}' anchor entity was deleted. Remaining audio/announcements and markers will not reach any players!");
+                Logger.GetSawmill("cmu-sfx").Warning($"[SFX] Sequence '{active.SequenceId}' anchor entity was deleted; stopping sequence {uid}.");
+                StopSequence(uid);
+                continue;
             }
 
             if (!_proto.TryIndex<ScriptedSoundSequencePrototype>(active.SequenceId, out var seq))
@@ -127,7 +116,7 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
                 if (elapsed < effectiveDelay)
                     break;
 
-                PlayEntry(uid, active, seq, entry);
+                PlayEntry(uid, active, seq, entry, i);
                 if (entry.RepeatSeconds is { } rep)
                     active.RepeatingEntries.Add((i, effectiveDelay + TimeSpan.FromSeconds(rep)));
                 active.NextEntryIndex = i + 1;
@@ -146,44 +135,17 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
                 if (elapsed < nextFire)
                     continue;
 
-                PlayEntry(uid, active, seq, entry);
+                PlayEntry(uid, active, seq, entry, index);
                 var seconds = interval;
                 if (entry.DelayJitterSeconds is { } jitter and > 0)
                     seconds += _random.NextFloat(-jitter, jitter);
                 active.RepeatingEntries[i] = (index, nextFire + TimeSpan.FromSeconds(MathF.Max(seconds, 0.1f)));
             }
 
-            for (var i = active.ScheduledLoopStops.Count - 1; i >= 0; i--)
-            {
-                var (stopAt, loopEnt) = active.ScheduledLoopStops[i];
-                if (_timing.CurTime < stopAt) continue;
-                _audio.Stop(loopEnt);
-                RemoveLoopByEntity(active, loopEnt);
-                active.ScheduledLoopStops.RemoveAt(i);
-            }
-
             if (active.NextEntryIndex >= seq.Entries.Count
-                    && active.ActiveLoops.Count == 0
-                    && active.ScheduledLoopStops.Count == 0
-                    && active.RepeatingEntries.Count == 0)
+                && active.RepeatingEntries.Count == 0)
                 StopSequence(uid);
         }
-    }
-
-    private static void RemoveLoopByEntity(ActiveScriptedSound active, EntityUid entity)
-    {
-        string? key = null;
-        foreach (var (k, v) in active.ActiveLoops)
-        {
-            if (v != entity)
-                continue;
-
-            key = k;
-            break;
-        }
-
-        if (key != null)
-            active.ActiveLoops.Remove(key);
     }
 
     public bool TryGetActiveSequence(int handle, out ActiveScriptedSound active)
@@ -217,15 +179,53 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
         if (anchor is { } a && !TerminatingOrDeleted(a))
             netCoords = GetNetCoordinates(Transform(a).Coordinates);
 
-        StopLoops(active);
-        var filter = GetMapFilter(anchor);
+        StopLoops(handle, active);
         RaiseNetworkEvent(new ScriptedSequenceMarkerNetEvent(
                 active.SequenceId,
                 ScriptedSoundMarkers.SequenceStopped,
                 netCoords),
-            filter);
+            Filter.Broadcast());
         active.JitteredDelays.Clear();
         active.RepeatingEntries.Clear();
+        active.Loops.Clear();
+    }
+
+    private void OnResyncRequest(RequestScriptedSoundResyncNetEvent ev, EntitySessionEventArgs args)
+    {
+        var session = args.SenderSession;
+        if (session.AttachedEntity is not { } player)
+            return;
+
+        var playerMapId = Transform(player).MapID;
+        var filter = Filter.SinglePlayer(session);
+
+        foreach (var (handle, active) in _activeSequences)
+        {
+            if (active.AnchorEntity is not { } anchor || TerminatingOrDeleted(anchor))
+                continue;
+
+            if (Transform(anchor).MapUid is not { } anchorMap || !GetConnectedMaps(anchorMap).Contains(playerMapId))
+                continue;
+
+            foreach (var (layer, loop) in active.Loops)
+            {
+                if (loop.Duration is { } dur && _timing.CurTime > loop.FiredAt + TimeSpan.FromSeconds(dur))
+                    continue;
+
+                NetCoordinates? coords = null;
+                if (!loop.Global)
+                    coords = GetNetCoordinates(Transform(anchor).Coordinates);
+
+                RaiseNetworkEvent(new PlayScriptedSoundNetEvent(
+                    handle,
+                    _audio.ResolveSound(loop.Sound),
+                    loop.Params,
+                    loop.Global,
+                    layer,
+                    loop.Duration,
+                    coords), filter);
+            }
+        }
     }
 
     public int? StartSequence(ProtoId<ScriptedSoundSequencePrototype> id, EntityUid? anchor = null)
@@ -243,7 +243,7 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
             Logger.GetSawmill("cmu-sfx").Error($"[SFX] Tried to start unknown scripted sound sequence '{id}'");
             return null;
         }
-        if (!ValidateSequenceOrder(id, seq))
+        if (!ValidateSequence(id, seq))
         {
             Logger.GetSawmill("cmu-sfx").Error($"[SFX] Sequence Prototype Order is invalid '{id}'");
             return null;
@@ -268,64 +268,55 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
         return handle;
     }
 
-    private void PlayEntry(int handle, ActiveScriptedSound active, ScriptedSoundSequencePrototype seq, ScriptedSoundEntry entry)
+    private void PlayEntry(int handle, ActiveScriptedSound active, ScriptedSoundSequencePrototype seq, ScriptedSoundEntry entry, int index)
     {
-        if (entry.StopAllLoops)
-            StopLoops(active);
-        else if (entry.StopLoops is { } stopLayers)
-            foreach (var layer in stopLayers)
-                StopLoop(active, layer);
+        if (entry.StopAllLoops || entry.StopLoops is { })
+        {
+            if (entry.StopAllLoops)
+                active.Loops.Clear();
+            else
+                foreach (var stopped in entry.StopLoops!)
+                    active.Loops.Remove(stopped);
+
+            RaiseNetworkEvent(new StopScriptedSoundLayersNetEvent(
+                handle,
+                entry.StopAllLoops ? null : entry.StopLoops!.ToArray()),
+                Filter.Broadcast());
+        }
 
         if (entry.Sound != null)
         {
-            var audioParams = entry.AudioParams ?? entry.Sound.Params;
-            if (entry.VolumeJitter is { } vj and > 0)
-                audioParams = audioParams.AddVolume(_random.NextFloat(-vj, vj));
-            if (entry.Loop)
-                audioParams = audioParams.WithLoop(true);
-            (EntityUid Entity, AudioComponent Component)? played;
-
-            if (entry.GlobalAudio)
+            var skip = false;
+            NetCoordinates? netCoords = null;
+            if (!entry.GlobalAudio)
             {
-                var filter = GetMapFilter(active.AnchorEntity);
-                if (filter.Count == 0)
+                if (active.AnchorEntity is { Valid: true } anchor && !TerminatingOrDeleted(anchor))
+                    netCoords = GetNetCoordinates(Transform(anchor).Coordinates);
+                else
                 {
-                    Logger.GetSawmill("cmu-sfx").Warning($"[SFX] Sequence '{active.SequenceId}' has no valid anchor; skipping global audio.");
-                    return;
+                    skip = true;
+                    Logger.GetSawmill("cmu-sfx").Warning($"[SFX] Sequence '{active.SequenceId}' anchor entity is invalid for local audio. Skipping sound.");
                 }
-
-                var resolved = _audio.ResolveSound(entry.Sound);
-                played = _audio.PlayGlobal(resolved, filter, false, audioParams);
-            }
-            else
-            {
-                if (active.AnchorEntity == null || TerminatingOrDeleted(active.AnchorEntity.Value))
-                {
-                    Logger.GetSawmill("cmu-sfx").Warning($"[SFX] Sequence '{active.SequenceId}' anchor entity is invalid for non-global audio. Skipping sound.");
-                    return;
-                }
-                played = _audio.PlayPvs(entry.Sound, active.AnchorEntity.Value, audioParams);
             }
 
-            if (played != null)
+            if (!skip)
             {
+                var audioParams = entry.AudioParams ?? entry.Sound.Params;
+                if (entry.VolumeJitter is { } vj and > 0)
+                    audioParams = audioParams.AddVolume(_random.NextFloat(-vj, vj));
                 if (entry.Loop)
-                {
-                    var layer = entry.Layer ?? $"__anon_{active.NextEntryIndex}";
-                    if (active.ActiveLoops.Remove(layer, out var old))
-                    {
-                        _audio.Stop(old);
-                        for (var i = active.ScheduledLoopStops.Count - 1; i >= 0; i--)
-                        {
-                            if (active.ScheduledLoopStops[i].Entity == old)
-                                active.ScheduledLoopStops.RemoveAt(i);
-                        }
-                    }
-                    active.ActiveLoops[layer] = played.Value.Entity;
-                }
+                    audioParams = audioParams.WithLoop(true);
+                if (entry.Loop && entry.Layer is { } tracked)
+                    active.Loops[tracked] = new TrackedLoop(entry.Sound, audioParams, entry.GlobalAudio, _timing.CurTime, entry.DurationSeconds);
 
-                if (entry.DurationSeconds is { } dur)
-                    active.ScheduledLoopStops.Add((_timing.CurTime + TimeSpan.FromSeconds(dur), played.Value.Entity));
+                RaiseNetworkEvent(new PlayScriptedSoundNetEvent(
+                    handle,
+                    _audio.ResolveSound(entry.Sound),
+                    audioParams,
+                    entry.GlobalAudio,
+                    entry.Loop ? entry.Layer ?? $"__anon_{index}" : null,
+                    entry.DurationSeconds,
+                    netCoords), GetMapFilter(active.AnchorEntity));
             }
         }
 
@@ -334,7 +325,7 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
             var filter = GetMapFilter(active.AnchorEntity);
             _generalAnnounce.AnnounceAdvanced(new AnnouncementRequest
             {
-                Preset = announcement.Preset ?? seq.DefaultAnnouncementPreset ?? "SelfDestructAnnouncement",
+                Preset = announcement.Preset ?? seq.DefaultAnnouncementPreset,
                 Message = announcement.Message,
                 Target = AnnouncementTarget.All,
                 Speaker = active.AnchorEntity,
@@ -370,27 +361,8 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
         Logger.GetSawmill("cmu-sfx").Debug($"[SFX] Sequence {active.SequenceId} fired marker '{entry.Marker}' at {_timing.CurTime}");
     }
 
-    private void StopLoops(ActiveScriptedSound active)
-    {
-        foreach (var (_, entity) in active.ActiveLoops)
-            _audio.Stop(entity);
-
-        active.ActiveLoops.Clear();
-        active.ScheduledLoopStops.Clear();
-    }
-
-    private void StopLoop(ActiveScriptedSound active, string layer)
-    {
-        if (!active.ActiveLoops.Remove(layer, out var entity))
-            return;
-
-        _audio.Stop(entity);
-        for (var i = active.ScheduledLoopStops.Count - 1; i >= 0; i--)
-        {
-            if (active.ScheduledLoopStops[i].Entity == entity)
-                active.ScheduledLoopStops.RemoveAt(i);
-        }
-    }
+    private void StopLoops(int handle, ActiveScriptedSound active)
+        => RaiseNetworkEvent(new StopScriptedSoundLayersNetEvent(handle, null), Filter.Broadcast());
 
     private Filter GetMapFilter(EntityUid? reference)
     {
@@ -468,7 +440,7 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
         }
     }
 
-    private static bool ValidateSequenceOrder(string id, ScriptedSoundSequencePrototype seq)
+    private static bool ValidateSequence(string id, ScriptedSoundSequencePrototype seq)
     {
         for (var i = 0; i < seq.Entries.Count; i++)
         {
@@ -487,6 +459,28 @@ public sealed partial class ScriptedSoundSystem : EntitySystem
                 $"[SFX] Sequence '{id}' entry={i} has delay {seq.Entries[i].DelaySeconds}s < prev entry delay {seq.Entries[i - 1].DelaySeconds}s." +
                 " Entries must be sorted by ascending delay!");
             return false;
+        }
+
+        HashSet<string>? stopped = null;
+        var stopAll = false;
+        foreach (var entry in seq.Entries)
+        {
+            if (entry.StopAllLoops)
+                stopAll = true;
+            if (entry.StopLoops is { } layers)
+                (stopped ??= new HashSet<string>()).UnionWith(layers);
+        }
+
+        for (var i = 0; i < seq.Entries.Count; i++)
+        {
+            var entry = seq.Entries[i];
+            if (entry.Layer != null && !entry.Loop)
+                Logger.GetSawmill("cmu-sfx").Warning($"[SFX] Sequence '{id}' entry={i} sets layer '{entry.Layer}' but not loop; the layer is ignored.");
+            if (!entry.Loop || entry.DurationSeconds != null || stopAll)
+                continue;
+            if (entry.Layer != null && stopped?.Contains(entry.Layer) == true)
+                continue;
+            Logger.GetSawmill("cmu-sfx").Warning($"[SFX] Sequence '{id}' entry={i} loop '{entry.Layer ?? "anonymous"}' has no stopLoop/stopAllLoops/duration; it plays until the sequence stops.");
         }
         return true;
     }

--- a/Content.Shared/_CMU14/CCVar/CMUCCVars.Game.cs
+++ b/Content.Shared/_CMU14/CCVar/CMUCCVars.Game.cs
@@ -6,4 +6,7 @@ public sealed partial class CCVars
 {
     public static readonly CVarDef<bool> EnableEvacSfx =
         CVarDef.Create("cmu.game.enable_evac_sfx", false, CVar.SERVERONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<bool> MuteScriptedSounds =
+        CVarDef.Create("cmu.game.mute_scripted_sfx", false, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/_CMU14/Ops/Sfx/PlayScriptedSoundNetEvent.cs
+++ b/Content.Shared/_CMU14/Ops/Sfx/PlayScriptedSoundNetEvent.cs
@@ -1,0 +1,39 @@
+using Robust.Shared.Audio;
+using Robust.Shared.Map;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._CMU14.Ops.Sfx;
+
+[Serializable, NetSerializable]
+public sealed class PlayScriptedSoundNetEvent(
+    int handle,
+    ResolvedSoundSpecifier sound,
+    AudioParams audioParams,
+    bool global,
+    string? layer,
+    float? durationSeconds,
+    NetCoordinates? anchorCoords) : EntityEventArgs
+{
+    public int Handle { get; } = handle;
+    public ResolvedSoundSpecifier Sound { get; } = sound;
+    public AudioParams Params { get; } = audioParams;
+    public bool Global { get; } = global;
+    public string? Layer { get; } = layer;
+    public float? DurationSeconds { get; } = durationSeconds;
+    public NetCoordinates? AnchorCoords { get; } = anchorCoords;
+}
+
+/// <summary>Sent by the client when it (re-)gains a body, changes map, unmutes, or to receive currently playing loop layers.</summary>
+[Serializable, NetSerializable]
+public sealed class RequestScriptedSoundResyncNetEvent : EntityEventArgs;
+
+[Serializable, NetSerializable]
+public sealed class StopScriptedSoundLayersNetEvent(
+    int handle,
+    string[]? layers) : EntityEventArgs
+{
+    public int Handle { get; } = handle;
+
+    /// <summary>Null stops every layer of the sequence.</summary>
+    public string[]? Layers { get; } = layers;
+}

--- a/Content.Shared/_RMC14/Marines/Squads/SquadLeaderHeadsetComponent.cs
+++ b/Content.Shared/_RMC14/Marines/Squads/SquadLeaderHeadsetComponent.cs
@@ -9,7 +9,7 @@ namespace Content.Shared._RMC14.Marines.Squads;
 public sealed partial class SquadLeaderHeadsetComponent : Component
 {
     [DataField, AutoNetworkedField]
-    public HashSet<ProtoId<RadioChannelPrototype>> Channels; // SquadSystem.UpdateSquadLeaderHeadsetChannels handles it
+    public HashSet<ProtoId<RadioChannelPrototype>> Channels = []; // SquadSystem.UpdateSquadLeaderHeadsetChannels fills it
 
     [DataField, AutoNetworkedField]
     public EntityUid Leader;

--- a/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
+++ b/Content.Shared/_RMC14/Marines/Squads/SquadSystem.cs
@@ -270,7 +270,7 @@ public sealed partial class SquadSystem : EntitySystem
 
     private void OnSquadLeaderHeadsetChannelsChanged(Entity<SquadLeaderHeadsetComponent> ent, ref EncryptionChannelsChangedEvent args)
     {
-        if (TerminatingOrDeleted(ent) || args.Component == null || ent.Comp.Channels == null)
+        if (TerminatingOrDeleted(ent) || args.Component == null)
             return;
 
         foreach (var channel in ent.Comp.Channels)

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -376,6 +376,7 @@ ui-options-screen-shake-intensity = Screen shake intensity
 ui-options-explosion-screen-shake-enabled = Screen shake from nearby explosions
 ui-options-explosion-screen-shake-ignore-far = Ignore explosions more than 25 tiles away
 ui-options-firearm-screen-shake-enabled = Screen shake from firing weapons
+ui-options-mute-scripted-sounds = Mute scripted sounds from events
 
 ui-options-chat-window-opacity = Chat window opacity
 ui-options-speech-bubble-text-opacity = Speech bubble text opacity

--- a/Resources/Prototypes/_CMU14/Audio/Collections/ship.yml
+++ b/Resources/Prototypes/_CMU14/Audio/Collections/ship.yml
@@ -1,0 +1,7 @@
+- type: soundCollection
+  id: CMUShipEngineRumbles
+  files:
+    - /Audio/_CMU14/Private/Ambience/ship/ship_engine_rumble1.ogg
+    - /Audio/_CMU14/Private/Ambience/ship/ship_engine_rumble2.ogg
+    - /Audio/_CMU14/Private/Ambience/ship/ship_engine_rumble4.ogg
+    - /Audio/_CMU14/Private/Ambience/ship/ship_engine_rumble5.ogg

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Shared/scuttle.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Shared/scuttle.yml
@@ -31,3 +31,29 @@
       delay: 15
     - fire: CMUTileFireOBAegis
       fireRange: 75
+
+- type: entity
+  parent: CMUSelfDestructWarheadExplosion
+  id: CMUSelfDestructScatterExplosion
+  name: explosive Warship Scuttle Fragment
+  suffix: CMU, WARSHIP SCUTTLE SCATTER! MULTIZ
+  components:
+  - type: OrbitalCannonExplosion
+    multiZ: true
+    steps:
+    # Stage 1 - t=0s, initial breach
+    - type: RMCOBXenoTunnel
+      total: 80000
+      slope: 4000
+      max: 400
+      delay: 0
+    - fire: CMUTileFireOBAegis
+      fireRange: 30
+    # Stage 2 - t=15s, the hull gives
+    - type: RMCOBXenoTunnel
+      total: 120000
+      slope: 40
+      max: 500
+      delay: 15
+    - fire: CMUTileFireOBAegis
+      fireRange: 45

--- a/Resources/Prototypes/_CMU14/RoundSetup/Scenario/distress_signal/self_destruct.yml
+++ b/Resources/Prototypes/_CMU14/RoundSetup/Scenario/distress_signal/self_destruct.yml
@@ -147,6 +147,26 @@
     marker: "Explode"
     markerData: { shakeIntensity: 12, duration: 5, color: "#FFFFFF" }
 
+  # T+0:32 - total failure
+  - delay: 932
+    announcement: { message: "WARNING. Multiple catastrophic structural failures detected throughout the vessel." }
+  # T+0:37 / +0:52 / +1:05 - scattered warhead volleys
+  - delay: 937
+    marker: "Explode"
+    markerData: { shakeIntensity: 10, duration: 3 }
+    sound: /Audio/_CMU14/Private/Ambience/claxon/claxon_ambience_explosions.ogg
+    audioParams: { volume: -3 }
+  - delay: 952
+    marker: "Explode"
+    markerData: { shakeIntensity: 11, duration: 3, color: "#FFF3C4" }
+    sound: /Audio/_CMU14/Private/Ambience/claxon/claxon_ambience_explosions2.ogg
+    audioParams: { volume: -3 }
+  - delay: 965
+    marker: "Explode"
+    markerData: { shakeIntensity: 14, duration: 6, color: "#FFFFFF" }
+    sound: /Audio/_CMU14/Private/Ambience/claxon/claxon_ambience_explosions3_distant.ogg
+    audioParams: { volume: -2 }
+
 #
 # ├──[ ENGINE SEQUENCE ]─────────────────────────────────────────────┤
 #
@@ -154,13 +174,16 @@
   id: SelfDestructEngineSequence
   entries:
   - delay: 20
+    layer: engineBreath
     loop: true
     sound: /Audio/_CMU14/Private/Ambience/engine/engine_ambience_breathing.ogg
     audioParams: { volume: -7 }
 
     # T-05:00 - engine goes critical & abort disabled
   - delay: 600
+    layer: engineHeart
     loop: true
+    stopLoop: [engineBreath]
     sound: /Audio/_CMU14/Private/Ambience/engine/engine_soft_heartbeat_rumble_intense.ogg
     audioParams: { volume: -4 }
 
@@ -169,9 +192,11 @@
 
   # T-02:00 - engine overloading
   - delay: 780
+    layer: engineGrind
     loop: true
+    stopLoop: [engineHeart]
     sound: /Audio/_CMU14/Private/Ambience/engine/engine_ominous_grind_long.ogg
-    audioParams: { volume: -2 }
+    audioParams: { volume: -6 }
   - delay: 790
     sound: /Audio/_CMU14/Private/Ambience/engine/engine_kick_rumble3.ogg
     jitterInterval: true
@@ -191,9 +216,11 @@
 
   # T-0:30 - very intense
   - delay: 870
+    layer: engineCrit
     loop: true
+    stopLoop: [engineGrind]
     sound: /Audio/_CMU14/Private/Ambience/engine/engine_crit_woosh2_long.ogg
-    audioParams: { volume: 0 }
+    audioParams: { volume: -2 }
 
   # T+0:00 - explosions every 15s like in the movie
   - delay: 900
@@ -203,3 +230,10 @@
     sound: /Audio/_CMU14/Private/Ambience/engine/engine_explosion2.ogg
   - delay: 930
     sound: /Audio/_CMU14/Private/Ambience/engine/engine_explosion7_loud_kick.ogg
+  # T+0:37 / +0:52 / +1:05 - match the scattered warhead volleys
+  - delay: 937
+    sound: /Audio/_CMU14/Private/Ambience/engine/engine_explosion5_afterkick_distant.ogg
+  - delay: 952
+    sound: /Audio/_CMU14/Private/Ambience/engine/engine_explosion6_deep_rumble.ogg
+  - delay: 965
+    sound: /Audio/_CMU14/Private/Ambience/engine/engine_explosion8_spaced.ogg

--- a/Resources/Prototypes/_CMU14/RoundSetup/Scenario/distress_signal/ship_draft.yml
+++ b/Resources/Prototypes/_CMU14/RoundSetup/Scenario/distress_signal/ship_draft.yml
@@ -1,0 +1,114 @@
+# ├──[ Ship Ambience | Draft Playground ]────────────────────────────┤
+#
+# test: `scriptedsound start ShipAmbienceDraft <mapUid>` (sounds are silent without an anchor)
+# stop: `scriptedsound list` then `scriptedsound stop <handle>` (you can use the auto-completions too)
+#
+# This sound sequence is more of an example, read the comments about certain parts and how it works.
+#
+- type: scriptedSoundSequence
+  id: ShipAmbienceDraft
+  defaultSender: "APOLLO"
+  defaultAnnouncementColor: "#9EE8FF"
+  defaultAnnouncementPreset: MarineCommand
+  entries:
+  # main engine bed, a named layer so that it can be stopped by a later entry
+  - delay: 0
+    layer: engineBed
+    loop: true
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_ambience_long_engine.ogg
+    audioParams: { volume: -8 }
+  # second bed that kills itself -> duration = auto stop a loop after X passed in sec
+  - delay: 0
+    layer: engineDistant
+    loop: true
+    duration: 600
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_engine_rumble_distant.ogg
+    audioParams: { volume: -11 }
+  # creaks on repeat, delayJitter wiggles every interval so it never sounds metronomic (randoms)
+  - delay: 20
+    repeat: 45
+    delayJitter: 15
+    volumeJitter: 2
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_move_creaky_noise.ogg
+    audioParams: { volume: -9, variation: 0.15 }  # variation = random pitch per fire
+  # jitterInterval: delay counts from the `previous` entry instead of sequence start
+  - delay: 60
+    jitterInterval: true
+    delayJitter: 10
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_move_hiss_echo.ogg
+    audioParams: { volume: -10 }
+  # collection pick, grabs a random rumble out of the pool
+  - delay: 90
+    repeat: 55
+    delayJitter: 25
+    sound: !type:SoundCollectionSpecifier
+      collection: CMUShipEngineRumbles
+    audioParams: { volume: -10 }
+  # globalAudio false = positional at the `anchor coords`, only players near it hear it -> PVS
+  - delay: 120
+    globalAudio: false
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_door_noise_ominous.ogg
+    audioParams: { volume: -4 }
+  # pitch stretches a too familiar clip, common way to make 1 sound feel unique everytime
+  - delay: 150
+    repeat: 120
+    delayJitter: 40
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_move_crane1.ogg
+    audioParams: { volume: -10, pitch: 0.85 }
+  - delay: 210
+    repeat: 120
+    delayJitter: 40
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_move_crane2.ogg
+    audioParams: { volume: -10, pitch: 1.15 }
+  # heavy kick, volumeJitter adds +/- 3db per kick
+  - delay: 240
+    repeat: 80
+    delayJitter: 30
+    volumeJitter: 3
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_engine_kick_heavy.ogg
+    audioParams: { volume: -6 }
+  # announcement, the three fields here override the defaults at the top of the file
+  - delay: 300
+    announcement:
+      message: "Atmospheric processors back to nominal. Hull integrity reading is at 94 percent."
+      sender: "Executive Officer"
+      color: "#FFD27F"
+      preset: SelfDestructAnnouncement
+  - delay: 360
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_pumps_engaged.ogg
+    audioParams: { volume: -7 }
+  # red vignette on, frequency = pulses per second
+  - delay: 420
+    marker: "RedAlarmOn"
+    markerData: { frequency: 1.5 }
+  - delay: 425
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_horn_loud.ogg
+    audioParams: { volume: -3, pitch: 0.9 }
+  # explode marker with no sound, flash and shake only
+  - delay: 480
+    marker: "Explode"
+    markerData: { shakeIntensity: 4, duration: 1.5, flashDuration: 0.4, color: "#BFD8FF" }
+  - delay: 520
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_lights_flicker_into_distance.ogg
+    audioParams: { volume: -6 }
+  # red vignette off
+  - delay: 560
+    marker: "RedAlarmOff"
+  - delay: 600
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_orbital_bombardment_shot.ogg
+    audioParams: { volume: -4 }
+  # stopLoop kills just the named beds, repeats above keep going
+  - delay: 620
+    stopLoop: [engineBed, engineDistant]
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_explosion_space.ogg
+    audioParams: { volume: -4 }
+  # big finish, stopAllLoops nukes every layer of this sequence
+  - delay: 660
+    stopAllLoops: true
+    marker: "Explode"
+    markerData: { shakeIntensity: 10, duration: 3, flashDuration: 0.6, color: "#FFFFFF" }
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_explosion_space_ominous.ogg
+    audioParams: { volume: -2 }
+  - delay: 690
+    sound: /Audio/_CMU14/Private/Ambience/ship/ship_engine_shutoff.ogg
+    audioParams: { volume: -4 }


### PR DESCRIPTION
- **🔧 self-destruct sfx & client mute**
- **🩹 prototypecontains tolerates deleted entities mid pipe**
- **🩹 fix SquadLeaderHeadsetComponent errors causing full state  resyncs on clients (self-inflicted DoS)**

**Changelog**
:cl:
- fix: SquadLeaderHeadsetComponent causing DoS because of an empty/null channels list (NRE)
- tweak: Mute the scripted sound event(s) under Accessibility settings
- code: ship_draft.yml (ShipAmbienceDraft) is an example sound sequence with explanatory comments