### PR TITLE
Tweaks SG damage and firerate values

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/SmartGuns/smart_gun.yml
@@ -64,7 +64,7 @@
     - FullAuto
     recoilWielded: 3
     scatterWielded: 10
-    baseFireRate: 9.6
+    baseFireRate: 8.5
     burstScatterMult: 4
     modifiers:
       FullAuto:
@@ -99,7 +99,7 @@
           components:
           - SmartGunBattery
   - type: GunDamageModifier
-    multiplier: 1
+    multiplier: 0.7
   - type: GunToggleableAmmo
     settings:
     - damage:
@@ -239,7 +239,7 @@
   - type: RMCSelectiveFire
     recoilWielded: 3
     scatterWielded: 10
-    baseFireRate: 18
+    baseFireRate: 16
     burstScatterMult: 1
     modifiers:
       FullAuto:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Firerate and damage changes were made in compensation for alt-IFF. They have proven to be too much, so I've reduced them.
**These values are still stronger than what we had before alt-IFF.**

## Why / Balance
If you have two or more SGs, which there are always guaranteed two minimum, they can just hold W + M1 with no consequence. This is not limited to threats; if you have a smartgunner on insurgency, you cannot trade shots as they melt humans immediately. Their nightvision means they can see you coming as well, so an ambush is out of the question.
They are no longer considered suppressive fire, just a protag role. Dialing it down should help with this.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Smartgun damage and firerate values reduced. These values are still stronger than what we had before.