### PR TITLE
Hotfix/anprc netlog frequency leak

### DIFF
--- a/Content.IntegrationTests/_AU14/Radio/ANPRCNetLogLeakTest.cs
+++ b/Content.IntegrationTests/_AU14/Radio/ANPRCNetLogLeakTest.cs
@@ -1,0 +1,203 @@
+using System;
+using System.Linq;
+using Content.Server._AU14.Radio;
+using Content.Server._RMC14.Language.Systems;
+using Content.Server.Chat.Systems;
+using Content.Server.Station.Systems;
+using Content.Shared._AU14.CCVar;
+using Content.Shared._AU14.Radio;
+using Content.Shared._RMC14.Language.Components;
+using Content.Shared._RMC14.Language.Prototypes;
+using Content.Shared.Inventory;
+using Content.Shared.Preferences;
+using Content.Shared.Radio;
+using Content.Shared.Roles;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests._AU14.Radio;
+
+// the AN/PRC net log used to write down the frequency of any net whose prefix the
+// wearer typed, whether or not they held the key and whether or not the message ever
+// left them. cycling :b :c :i off a pack in the back slot read the whole per-round
+// frequency plan straight off the panel
+[TestFixture]
+public sealed class ANPRCNetLogLeakTest
+{
+    private static readonly EntProtoId Pack = "ANPRC117GRadioFilled";
+    private static readonly EntProtoId Headset = "AU14HeadsetGovforCommand";
+    private static readonly ProtoId<JobPrototype> Rifleman = "AU14JobGOVFORSquadRifleman";
+
+    private static readonly ProtoId<RadioChannelPrototype> HeldChannel = "radioGovforCommand";
+    private static readonly ProtoId<RadioChannelPrototype> UnheldChannel = "radioOpforCommand";
+
+    private static readonly ProtoId<LanguagePrototype> Foreign = "Russian";
+    private static readonly ProtoId<LanguagePrototype> Common = "English";
+
+    private const string BackSlot = "back";
+    private const string EarsSlot = "ears";
+
+    [Test]
+    public async Task PackOnlyLogsNetsTheWearerActuallyTransmitsOn()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+
+        var config = server.ResolveDependency<IConfigurationManager>();
+        var wasEnabled = config.GetCVar(AU14CCVars.NewCommsSystem);
+
+        await server.WaitPost(() => config.SetCVar(AU14CCVars.NewCommsSystem, true));
+
+        await server.WaitAssertion(() =>
+        {
+            var entities = server.EntMan;
+            var spawning = server.System<StationSpawningSystem>();
+            var inventory = server.System<InventorySystem>();
+            var prototypes = server.ResolveDependency<IPrototypeManager>();
+            var radios = server.System<ANPRCRadioSystem>();
+
+            var wearer = spawning.SpawnPlayerMob(
+                testMap.GridCoords,
+                Rifleman,
+                new HumanoidCharacterProfile(),
+                station: null);
+
+            var pack = entities.SpawnEntity(Pack, testMap.GridCoords);
+            var headset = entities.SpawnEntity(Headset, testMap.GridCoords);
+
+            try
+            {
+                // whatever the job spawned with is in the way of the two slots we need
+                if (inventory.TryGetSlotEntity(wearer, BackSlot, out var oldBack))
+                    entities.DeleteEntity(oldBack.Value);
+
+                if (inventory.TryGetSlotEntity(wearer, EarsSlot, out var oldEars))
+                    entities.DeleteEntity(oldEars.Value);
+
+                Assert.That(inventory.TryEquip(wearer, pack, BackSlot, force: true), Is.True, BackSlot);
+                Assert.That(inventory.TryEquip(wearer, headset, EarsSlot, force: true), Is.True, EarsSlot);
+
+                var radio = entities.GetComponent<ANPRCRadioComponent>(pack);
+
+                Assert.That(radio.Enabled, Is.True);
+                Assert.That(radio.IsEquipped, Is.True);
+                Assert.That(entities.HasComponent<WearingANPRCComponent>(wearer), Is.True);
+
+                var held = prototypes.Index(HeldChannel);
+                var unheld = prototypes.Index(UnheldChannel);
+
+                // the exploit: a prefix for a net this headset holds no key for. the
+                // channel is still on the event at this point, the message never goes
+                // anywhere, and the log must not write the number down
+                var leak = new EntitySpokeEvent(wearer, "probing", unheld, null);
+                entities.EventBus.RaiseLocalEvent(wearer, leak);
+
+                Assert.That(radio.NetLog, Is.Empty, "traffic the wearer cannot transmit reached the net log");
+
+                // and if the number ever does reach the log by some other route, it is
+                // still not one this govfor set is entitled to print
+                Assert.That(radios.KnowsFrequency(radio, unheld), Is.False);
+                Assert.That(radios.KnowsFrequency(radio, held), Is.True);
+
+                // a net the headset really carries still logs, frequency and all
+                var real = new EntitySpokeEvent(wearer, "actual traffic", held, null);
+                entities.EventBus.RaiseLocalEvent(wearer, real);
+
+                Assert.That(radio.NetLog, Has.Count.EqualTo(1));
+
+                var entry = radio.NetLog.Single();
+                Assert.That(entry.Message, Is.EqualTo("actual traffic"));
+                Assert.That(entry.ChannelDisplay, Does.Contain("MHz"));
+            }
+            finally
+            {
+                entities.DeleteEntity(wearer);
+                entities.DeleteEntity(pack);
+                entities.DeleteEntity(headset);
+            }
+        });
+
+        await server.WaitPost(() => config.SetCVar(AU14CCVars.NewCommsSystem, wasEnabled));
+        await pair.CleanReturnAsync();
+    }
+    // the panel showed the log in clear while the same traffic reached chat obfuscated:
+    // a planted station read back Russian nobody at it spoke. the log stores what came
+    // over the air and the language pass runs when it is read, so this covers both ends
+    [Test]
+    public async Task PlantedStationLogRendersForWhoeverReadsIt()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+
+        var config = server.ResolveDependency<IConfigurationManager>();
+        var wasEnabled = config.GetCVar(AU14CCVars.NewCommsSystem);
+
+        await server.WaitPost(() => config.SetCVar(AU14CCVars.NewCommsSystem, true));
+
+        await server.WaitAssertion(() =>
+        {
+            var entities = server.EntMan;
+            var spawning = server.System<StationSpawningSystem>();
+            var radios = server.System<ANPRCRadioSystem>();
+            var languages = server.System<LanguageSystem>();
+
+            var reader = spawning.SpawnPlayerMob(
+                testMap.GridCoords,
+                Rifleman,
+                new HumanoidCharacterProfile(),
+                station: null);
+
+            var station = entities.SpawnEntity(Pack, testMap.GridCoords);
+
+            try
+            {
+                var radio = entities.GetComponent<ANPRCRadioComponent>(station);
+                radio.Planted = true;
+
+                // whatever the profile happened to grant, this one speaks the common
+                // tongue and nothing else, and is not part way through picking any up
+                languages.SetExclusiveLanguage(reader, Common);
+                entities.RemoveComponent<LanguageLearningComponent>(reader);
+
+                Assert.That(languages.CanUnderstand(reader, Foreign), Is.False);
+
+                const string spoken = "Убей его";
+
+                var traffic = new ANPRCDirectTrafficReceivedEvent(reader, "GIBBS", 1469, spoken, Foreign);
+                entities.EventBus.RaiseLocalEvent(station, ref traffic);
+
+                // the set keeps the sounds it caught, whoever ends up reading them
+                Assert.That(radio.NetLog, Has.Count.EqualTo(1));
+                Assert.That(radio.NetLog.Single().Message, Is.EqualTo(spoken));
+                Assert.That(radio.NetLog.Single().Language, Is.EqualTo(Foreign.Id));
+
+                // read by somebody without the language it comes out as syllables, the
+                // same way the chat line already did
+                var forReader = radios.BuildNetLog((station, radio), new[] { reader });
+                Assert.That(forReader.Single().Message, Is.Not.EqualTo(spoken));
+
+                // and with nobody identified at the panel it does not fall open
+                var forNobody = radios.BuildNetLog((station, radio), Array.Empty<EntityUid>());
+                Assert.That(forNobody.Single().Message, Is.Not.EqualTo(spoken));
+
+                // a language the reader does have still reads straight
+                var plain = new ANPRCDirectTrafficReceivedEvent(reader, "GIBBS", 1469, "kill him", Common);
+                entities.EventBus.RaiseLocalEvent(station, ref plain);
+
+                var rendered = radios.BuildNetLog((station, radio), new[] { reader });
+                Assert.That(rendered.Last().Message, Is.EqualTo("kill him"));
+            }
+            finally
+            {
+                entities.DeleteEntity(reader);
+                entities.DeleteEntity(station);
+            }
+        });
+
+        await server.WaitPost(() => config.SetCVar(AU14CCVars.NewCommsSystem, wasEnabled));
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Bui.cs
@@ -156,7 +156,13 @@ public sealed partial class ANPRCRadioSystem
         if (!ent.Comp.SlotLabels.ContainsKey(args.Slot))
             return;
 
-        if (!_prototype.HasIndex(args.Channel))
+        if (!_prototype.TryIndex(args.Channel, out var channelProto))
+            return;
+
+        // the picker only ever offers nets this set is entitled to, but the message is
+        // client-sent: without the same check here a hand-rolled one tunes the pack
+        // straight onto an enemy net nobody ever fixed
+        if (!KnowsFrequency(ent.Comp, channelProto))
             return;
 
         ent.Comp.FrequencyOverrides.Remove(args.Slot);
@@ -367,6 +373,50 @@ public sealed partial class ANPRCRadioSystem
 
     // the log lives in the set and rolls over at 50 entries. printing is how an
     // intercept becomes something the cell can act on after the operator moves on
+    // the log is a machine transcript, not a translation. who reads it is whoever has
+    // the panel open - the wearer, or anyone standing at a planted station - so the
+    // language pass belongs here, against the people actually looking. a line reads in
+    // clear only when every one of them speaks it, and with more than one reader it is
+    // rendered for nobody in particular so one reader's ear cannot lend another theirs
+    private List<ANPRCNetLogEntry> BuildNetLog(Entity<ANPRCRadioComponent> ent)
+    {
+        return BuildNetLog(ent, _ui.GetActors(ent.Owner, ANPRCRadioUI.Key));
+    }
+
+    public List<ANPRCNetLogEntry> BuildNetLog(Entity<ANPRCRadioComponent> ent, IEnumerable<EntityUid> readers)
+    {
+        var reading = readers.ToList();
+        var reader = reading.Count == 1 ? reading[0] : EntityUid.Invalid;
+        var entries = new List<ANPRCNetLogEntry>(ent.Comp.NetLog.Count);
+
+        foreach (var entry in ent.Comp.NetLog)
+        {
+            entries.Add(RenderLogEntry(entry, reading, reader));
+        }
+
+        return entries;
+    }
+
+    private ANPRCNetLogEntry RenderLogEntry(ANPRCNetLogEntry entry, List<EntityUid> readers, EntityUid reader)
+    {
+        // no reader on record falls back to Invalid, which understands the common
+        // tongue and nothing else - the safe way to be wrong
+        var clear = readers.Count > 0
+            ? readers.TrueForAll(r => _language.CanUnderstand(r, entry.Language))
+            : _language.CanUnderstand(EntityUid.Invalid, entry.Language);
+
+        if (clear)
+            return entry;
+
+        return new ANPRCNetLogEntry(
+            entry.Timestamp,
+            entry.SenderName,
+            entry.ChannelDisplay,
+            _language.ObfuscateMessageForListener(reader, entry.Message, entry.Language, EntityUid.Invalid),
+            entry.Intercepted,
+            entry.Language);
+    }
+
     private void OnPrintLog(Entity<ANPRCRadioComponent> ent, ref ANPRCPrintLogMsg args)
     {
         if (!ent.Comp.Enabled || (!ent.Comp.IsEquipped && !ent.Comp.Planted))
@@ -377,8 +427,15 @@ public sealed partial class ANPRCRadioSystem
 
         var interceptsOnly = args.InterceptsOnly;
 
+        var scribe = args.Actor;
+        var readers = new List<EntityUid> { scribe };
+
+        // you can only write down what you understood. a captured intercept copied off
+        // a set in a language the operator does not have goes onto the paper as the
+        // syllables they heard, for somebody who does speak it to read later
         var entries = ent.Comp.NetLog
             .Where(entry => !interceptsOnly || entry.Intercepted)
+            .Select(entry => RenderLogEntry(entry, readers, scribe))
             .ToList();
 
         if (entries.Count == 0)
@@ -506,7 +563,7 @@ public sealed partial class ANPRCRadioSystem
                 _crypto.GetFillFaction(ent.Owner),
                 _crypto.IsFillStale(ent.Owner),
                 ent.Comp.OperatorFaction,
-                new List<ANPRCNetLogEntry>(ent.Comp.NetLog),
+                BuildNetLog(ent),
                 batteryFraction,
                 hasBattery,
                 antennaLabel,

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.Transmit.cs
@@ -4,6 +4,7 @@ using Content.Server.Radio.Components;
 using Content.Shared._AU14.Callsigns;
 using Content.Shared._AU14.Radio;
 using Content.Shared._RMC14.Chat;
+using Content.Shared._RMC14.Language.Prototypes;
 using Content.Shared._RMC14.Marines;
 using Content.Shared.AU14.Radio;
 using Content.Shared.Chat;
@@ -162,29 +163,7 @@ public sealed partial class ANPRCRadioSystem
 
         if (!wearing.PendingANPRCTransmit)
         {
-            if (args.Channel != null &&
-                args.Channel.Frequency > 0 &&
-                TryComp(wearing.Radio, out ANPRCRadioComponent? logRadio) &&
-                logRadio.Enabled)
-            {
-                // log headset traffic under what actually went on air: the callsign
-                // on a callsign-faction net, the plain name on an open channel
-                var logName = AU14Callsigns.IsCallsignChannel(args.Channel) &&
-                              TryComp(ent.Owner, out AU14CallsignComponent? ownCallsign) &&
-                              !string.IsNullOrEmpty(ownCallsign.Callsign)
-                    ? ownCallsign.Callsign
-                    : Name(ent.Owner);
-
-                AppendNetLog(
-                    logRadio,
-                    _timing.CurTime.TotalSeconds,
-                    logName,
-                    $"{args.Channel.LocalizedName} ({TunableFrequencySystem.FormatFreq(_freqPlan.GetFrequency(args.Channel))} MHz)",
-                    args.Message);
-
-                UpdateBuiState(new Entity<ANPRCRadioComponent>(wearing.Radio, logRadio));
-            }
-
+            LogHeadsetTraffic(ent, ref args);
             return;
         }
 
@@ -204,6 +183,57 @@ public sealed partial class ANPRCRadioSystem
         TransmitThroughPack(ent.Owner, pack, GetOnAirName(pack), ref args);
     }
 
+    // the pack keeps a book on what its wearer put out over their own headset. this
+    // runs before HeadsetSystem has had its say, so args.Channel is still whatever
+    // prefix was typed - key or no key - and the log has to satisfy itself the message
+    // is really going on air before writing anything down. without that check, cycling
+    // every radio prefix in the game reads the whole frequency plan back off the panel
+    private void LogHeadsetTraffic(Entity<WearingANPRCComponent> ent, ref EntitySpokeEvent args)
+    {
+        if (args.Channel == null || args.Channel.Frequency <= 0)
+            return;
+
+        if (!TryComp(ent.Comp.Radio, out ANPRCRadioComponent? logRadio) || !logRadio.Enabled)
+            return;
+
+        if (!SpeakerTransmitsOn(ent.Owner, args.Channel))
+            return;
+
+        // log headset traffic under what actually went on air: the callsign
+        // on a callsign-faction net, the plain name on an open channel
+        var logName = AU14Callsigns.IsCallsignChannel(args.Channel) &&
+                      TryComp(ent.Owner, out AU14CallsignComponent? ownCallsign) &&
+                      !string.IsNullOrEmpty(ownCallsign.Callsign)
+            ? ownCallsign.Callsign
+            : Name(ent.Owner);
+
+        AppendNetLog(
+            logRadio,
+            _timing.CurTime.TotalSeconds,
+            logName,
+            FormatLogChannel(logRadio, args.Channel),
+            args.Message);
+
+        UpdateBuiState(new Entity<ANPRCRadioComponent>(ent.Comp.Radio, logRadio));
+    }
+
+    // whether this message is genuinely leaving the speaker on this net: a worn headset
+    // holding the key and not read-only on it, or an intrinsic transmitter that carries
+    // it. mirrors what HeadsetSystem and RadioSystem check a moment later
+    private bool SpeakerTransmitsOn(EntityUid speaker, RadioChannelPrototype channel)
+    {
+        if (TryComp(speaker, out WearingHeadsetComponent? wearingHeadset) &&
+            TryComp(wearingHeadset.Headset, out EncryptionKeyHolderComponent? keys) &&
+            keys.Channels.Contains(channel.ID) &&
+            !keys.ReadOnlyChannels.Contains(channel.ID))
+        {
+            return true;
+        }
+
+        return TryComp(speaker, out IntrinsicRadioTransmitterComponent? intrinsic) &&
+               intrinsic.Channels.Contains(channel.ID);
+    }
+
     // sends one spoken message out through the pack (raw frequency or the active preset
     // net), handles battery cost, COMSEC warning, name masking, DF exposure and logging.
     // speaker is the wearer or a handset user at the pack
@@ -214,6 +244,19 @@ public sealed partial class ANPRCRadioSystem
         ref EntitySpokeEvent args)
     {
         var radio = pack.Comp;
+
+        // sign language and the like never go over the air. the headsets already refuse
+        // to carry them; without the same check here the pack is the way around that
+        if (_prototype.TryIndex(args.Language, out LanguagePrototype? spokenLanguage) &&
+            !spokenLanguage.CanUseRadio)
+        {
+            args.Channel = null;
+            _cmChat.ChatMessageToOne(
+                Loc.GetString("anprc-language-no-radio", ("language", spokenLanguage.Name)),
+                speaker);
+
+            return;
+        }
 
         // the set cannot search and talk at once. stay silent or stop sweeping
         if (radio.SweepEnabled)
@@ -231,7 +274,7 @@ public sealed partial class ANPRCRadioSystem
             args.Channel = null;
 
             _powerCell.TryUseCharge(pack.Owner, GetTransmitCost(radio));
-            _tunable.BroadcastOnFrequency(speaker, frequency, outMessage, senderName);
+            _tunable.BroadcastOnFrequency(speaker, frequency, outMessage, senderName, args.Language);
 
             AppendNetLog(
                 radio,
@@ -299,7 +342,7 @@ public sealed partial class ANPRCRadioSystem
 
         try
         {
-            _radio.SendRadioMessage(speaker, outMessage, channel, pack.Owner);
+            _radio.SendRadioMessage(speaker, outMessage, channel, pack.Owner, args.Language);
         }
         finally
         {
@@ -326,7 +369,7 @@ public sealed partial class ANPRCRadioSystem
             radio,
             _timing.CurTime.TotalSeconds,
             senderName,
-            $"{channel.LocalizedName} ({TunableFrequencySystem.FormatFreq(_freqPlan.GetFrequency(channel))} MHz)",
+            FormatLogChannel(radio, channel),
             outMessage);
 
         UpdateBuiState(pack);

--- a/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
+++ b/Content.Server/_AU14/Radio/ANPRCRadioSystem.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Content.Server._RMC14.Language.Systems;
 using Content.Server._RMC14.Marines.Roles.Ranks;
 using Content.Server._RMC14.TacticalMap;
 using Content.Server.Chat.Managers;
@@ -12,6 +13,8 @@ using Content.Server.Radio.Components;
 using Content.Server.Radio.EntitySystems;
 using Content.Shared._AU14.Radio;
 using Content.Shared._RMC14.Chat;
+using Content.Shared._RMC14.Language.Prototypes;
+using Content.Shared._RMC14.Language.Systems;
 using Content.Shared._RMC14.PropCalling;
 using Content.Shared.Chat;
 using Content.Shared.Containers.ItemSlots;
@@ -54,6 +57,7 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
     [Dependency] private ANPRCCryptoSystem _crypto = default!;
     [Dependency] private ANPRCFrequencyPlanSystem _freqPlan = default!;
     [Dependency] private ANPRCGarbleSystem _garble = default!;
+    [Dependency] private LanguageSystem _language = default!;
     [Dependency] private ANPRCRangeSystem _range = default!;
     [Dependency] private ANPRCSweepSystem _sweep = default!;
     [Dependency] private AU14CommsToggleSystem _comms = default!;
@@ -205,6 +209,10 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         }
         else
         {
+            // the log stores what came over the air. the set is not a translator, but
+            // it is not one listener either - a planted station is read by whoever
+            // walks up to it - so the language pass runs when the log is read, not
+            // when it is written
             var heard = _garble.ApplyComsecGarble(args.MessageSource, ent.Owner, args.Channel, args.Message);
 
             // traffic on somebody else's faction net is an intercept: flagged in the
@@ -219,14 +227,23 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
                 radio,
                 _timing.CurTime.TotalSeconds,
                 GetSenderDisplayName(args.MessageSource),
-                $"{args.Channel.LocalizedName} ({TunableFrequencySystem.FormatFreq(_freqPlan.GetFrequency(args.Channel))} MHz)",
+                FormatLogChannel(radio, args.Channel),
                 heard,
-                intercepted);
+                intercepted,
+                args.Language);
 
             UpdateBuiState(ent);
 
             if (!covered && TryComp(wearer, out ActorComponent? actor))
             {
+                // out of the speaker it is one person's ear, so this one does get the
+                // language pass, against them
+                heard = _language.ObfuscateMessageForListener(
+                    wearer,
+                    heard,
+                    args.Language,
+                    args.MessageSource);
+
                 var senderName = FormattedMessage.EscapeText(GetSenderDisplayName(args.MessageSource));
                 var message = FormattedMessage.EscapeText(heard);
                 var wrapped = $"[color=#FF6B6B]{senderName}: {message}[/color]";
@@ -400,6 +417,11 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
 
     private void UpdateRelayAnchor(Entity<ANPRCRadioComponent> ent)
     {
+        // deleting a pack empties its containers, and the antenna coming out lands here
+        // on an entity that is already on its way out. re-adding the anchor to it throws
+        if (TerminatingOrDeleted(ent.Owner))
+            return;
+
         if ((!ent.Comp.IsEquipped && !ent.Comp.Planted) || !ent.Comp.Enabled)
         {
             RemComp<ANPRCRelayAnchorComponent>(ent.Owner);
@@ -680,7 +702,8 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
             args.SenderName,
             $"{TunableFrequencySystem.FormatFreq(args.Frequency)} MHz",
             args.Message,
-            intercepted);
+            intercepted,
+            args.Language);
 
         UpdateBuiState(ent);
     }
@@ -763,15 +786,51 @@ public sealed partial class ANPRCRadioSystem : EntitySystem
         return false;
     }
 
+    // one gate for every frequency that reaches the net log. the log is readable by
+    // anyone who opens the panel and printable to paper, so a number that lands in it
+    // has left COMSEC entirely. a set only writes down what it is entitled to know:
+    // unfactioned nets, its own faction's nets, and whatever the sweep has fixed
+    public bool KnowsFrequency(ANPRCRadioComponent radio, RadioChannelPrototype channel)
+    {
+        if (string.IsNullOrEmpty(channel.Faction) ||
+            string.IsNullOrEmpty(radio.OperatorFaction) ||
+            string.Equals(channel.Faction, radio.OperatorFaction, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // a number already dialled into a slot - off a captured card, off a contact the
+        // sweep fixed, or shipped with the set - is one the operator holds, whoever the
+        // net belongs to. slots cannot be filled with a net the set is not entitled to
+        return radio.DiscoveredFrequencies.Contains(_freqPlan.GetFrequency(channel)) ||
+               HasPreset(radio, channel.ID);
+    }
+
+    // the log line for a net. the name is always safe - it is what the set heard itself
+    // called - but the number only goes down when the operator is entitled to it
+    private string FormatLogChannel(ANPRCRadioComponent radio, RadioChannelPrototype channel)
+    {
+        return KnowsFrequency(radio, channel)
+            ? $"{channel.LocalizedName} ({TunableFrequencySystem.FormatFreq(_freqPlan.GetFrequency(channel))} MHz)"
+            : $"{channel.LocalizedName} ({Loc.GetString("anprc-log-frequency-unknown")})";
+    }
+
     private static void AppendNetLog(
         ANPRCRadioComponent radio,
         double timestamp,
         string sender,
         string channel,
         string message,
-        bool intercepted = false)
+        bool intercepted = false,
+        ProtoId<LanguagePrototype>? language = null)
     {
-        radio.NetLog.Enqueue(new ANPRCNetLogEntry((float) timestamp, sender, channel, message, intercepted));
+        radio.NetLog.Enqueue(new ANPRCNetLogEntry(
+            (float) timestamp,
+            sender,
+            channel,
+            message,
+            intercepted,
+            language?.Id ?? SharedLanguageSystem.CommonLanguage.Id));
 
         while (radio.NetLog.Count > ANPRCRadioComponent.MaxNetLogEntries)
         {

--- a/Content.Server/_AU14/Radio/TunableFrequencySystem.cs
+++ b/Content.Server/_AU14/Radio/TunableFrequencySystem.cs
@@ -1,11 +1,14 @@
 using System.Numerics;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Managers;
+using Content.Server._RMC14.Language.Systems;
 using Content.Server.Chat.Systems;
 using Content.Server.Radio.EntitySystems;
 using Content.Shared._AU14.CCVar;
 using Content.Shared._AU14.Radio;
 using Content.Shared._RMC14.Chat;
+using Content.Shared._RMC14.Language.Prototypes;
+using Content.Shared._RMC14.Language.Systems;
 using Content.Shared.Chat;
 using Content.Shared.Database;
 using Content.Shared.Ghost;
@@ -36,6 +39,8 @@ public sealed partial class TunableFrequencySystem : EntitySystem
     [Dependency] private IConfigurationManager _config = default!;
     [Dependency] private ANPRCRangeSystem _range = default!;
     [Dependency] private ANPRCSweepSystem _sweep = default!;
+    [Dependency] private IPrototypeManager _prototype = default!;
+    [Dependency] private LanguageSystem _language = default!;
 
     // direct frequencies reach one z-level up or down, same as a worn manpack
     private const int DirectFreqLevelReach = 1;
@@ -121,16 +126,33 @@ public sealed partial class TunableFrequencySystem : EntitySystem
             return;
         }
 
-        BroadcastOnFrequency(ent.Owner, ent.Comp.Frequency, args.Message);
+        // sign language and the like do not go over the air on a net either
+        if (_prototype.TryIndex(args.Language, out LanguagePrototype? spoken) && !spoken.CanUseRadio)
+        {
+            _cmChat.ChatMessageToOne(
+                Loc.GetString("tunable-radio-language-no-radio", ("language", spoken.Name)),
+                ent.Owner);
+
+            return;
+        }
+
+        BroadcastOnFrequency(ent.Owner, ent.Comp.Frequency, args.Message, language: args.Language);
     }
 
-    public void BroadcastOnFrequency(EntityUid sender, int frequency, string message, string? senderName = null)
+    public void BroadcastOnFrequency(
+        EntityUid sender,
+        int frequency,
+        string message,
+        string? senderName = null,
+        ProtoId<LanguagePrototype>? language = null)
     {
         if (!_commsEnabled)
             return;
 
         if (frequency <= 0 || string.IsNullOrWhiteSpace(message))
             return;
+
+        var spokenLanguage = language ?? SharedLanguageSystem.CommonLanguage;
 
         var senderPos = _transform.GetWorldPosition(sender);
         var senderMap = Transform(sender).MapID;
@@ -167,7 +189,7 @@ public sealed partial class TunableFrequencySystem : EntitySystem
                 continue;
             }
 
-            DeliverGarbled(sender, receiver, receiver, message, frequency, senderJam, intensity, senderName);
+            DeliverGarbled(sender, receiver, receiver, message, frequency, senderJam, intensity, senderName, spokenLanguage);
         }
 
         var anprcQuery = EntityQueryEnumerator<ANPRCRadioComponent, TransformComponent>();
@@ -242,6 +264,9 @@ public sealed partial class TunableFrequencySystem : EntitySystem
             var jam = MaxIntensity(senderJam, _garble.GetJamIntensity(anprc));
             var totalIntensity = MaxIntensity(intensity, jam);
 
+            // the log gets what came over the air, language and all - the set is read
+            // by whoever opens its panel, so that pass happens there. the wearer's own
+            // speaker line below is the one that has a listener to render for
             var heard = totalIntensity != RadioJamIntensity.None
                 ? _garble.GarbleMessage(message, totalIntensity)
                 : message;
@@ -250,7 +275,8 @@ public sealed partial class TunableFrequencySystem : EntitySystem
                 sender,
                 senderName ?? Name(sender),
                 frequency,
-                heard);
+                heard,
+                spokenLanguage);
 
             RaiseLocalEvent(anprc, ref logEv);
 
@@ -262,17 +288,17 @@ public sealed partial class TunableFrequencySystem : EntitySystem
                 continue;
             }
 
-            SendToEntity(sender, wearer, heard, frequency, senderName);
+            SendToEntity(sender, wearer, heard, frequency, senderName, spokenLanguage);
         }
 
-        SendToEntity(sender, sender, message, frequency, senderName);
+        SendToEntity(sender, sender, message, frequency, senderName, spokenLanguage, alreadyObfuscated: true);
 
         _adminLogger.Add(
             LogType.Chat,
             LogImpact.Low,
             $"Tunable frequency message from {ToPrettyString(sender):user} on {FormatFreq(frequency)} MHz: {message}");
 
-        var chat = BuildChatMessage(sender, message, frequency, senderName);
+        var chat = BuildChatMessage(sender, message, frequency, senderName, spokenLanguage);
         _replay.RecordServerMessage(chat);
 
         foreach (var session in Filter.Empty().AddWhereAttachedEntity(HasComp<GhostHearingComponent>).Recipients)
@@ -337,16 +363,24 @@ public sealed partial class TunableFrequencySystem : EntitySystem
         int frequency,
         RadioJamIntensity senderJam,
         RadioJamIntensity rangeIntensity,
-        string? senderName = null)
+        string? senderName = null,
+        ProtoId<LanguagePrototype>? language = null)
     {
         var jam = MaxIntensity(senderJam, _garble.GetJamIntensity(jamProbe));
         var intensity = MaxIntensity(rangeIntensity, jam);
 
-        var finalMessage = intensity != RadioJamIntensity.None
-            ? _garble.GarbleMessage(message, intensity)
-            : message;
+        var spokenLanguage = language ?? SharedLanguageSystem.CommonLanguage;
 
-        SendToEntity(sender, recipient, finalMessage, frequency, senderName);
+        // a net carries sound, not meaning: the language pass runs before the radio
+        // gets to chew on it, so a listener without the language hears mangled syllables
+        // mangled further rather than clean words behind a little static
+        var understood = _language.ObfuscateMessageForListener(recipient, message, spokenLanguage, sender);
+
+        var finalMessage = intensity != RadioJamIntensity.None
+            ? _garble.GarbleMessage(understood, intensity)
+            : understood;
+
+        SendToEntity(sender, recipient, finalMessage, frequency, senderName, spokenLanguage, alreadyObfuscated: true);
     }
 
     private EntityUid? FindANPRCRelay(
@@ -389,16 +423,33 @@ public sealed partial class TunableFrequencySystem : EntitySystem
         return null;
     }
 
-    private void SendToEntity(EntityUid sender, EntityUid receiver, string message, int frequency, string? senderName = null)
+    private void SendToEntity(
+        EntityUid sender,
+        EntityUid receiver,
+        string message,
+        int frequency,
+        string? senderName = null,
+        ProtoId<LanguagePrototype>? language = null,
+        bool alreadyObfuscated = false)
     {
         if (!TryComp(receiver, out ActorComponent? actor))
             return;
 
-        var chat = BuildChatMessage(sender, message, frequency, senderName);
+        var spokenLanguage = language ?? SharedLanguageSystem.CommonLanguage;
+
+        if (!alreadyObfuscated)
+            message = _language.ObfuscateMessageForListener(receiver, message, spokenLanguage, sender);
+
+        var chat = BuildChatMessage(sender, message, frequency, senderName, spokenLanguage);
         _netManager.ServerSendMessage(new MsgChatMessage { Message = chat }, actor.PlayerSession.Channel);
     }
 
-    private ChatMessage BuildChatMessage(EntityUid sender, string message, int frequency, string? senderNameOverride = null)
+    private ChatMessage BuildChatMessage(
+        EntityUid sender,
+        string message,
+        int frequency,
+        string? senderNameOverride = null,
+        ProtoId<LanguagePrototype>? language = null)
     {
         var frequencyText = FormatFreq(frequency);
         var senderName = FormattedMessage.EscapeText(senderNameOverride ?? Name(sender));
@@ -408,12 +459,19 @@ public sealed partial class TunableFrequencySystem : EntitySystem
                       $"[color=#C8D2E8]{senderName}[/color] " +
                       $"says, \"{messageText}\"";
 
+        // same marker the channel radio puts on a foreign-language line, so a direct
+        // frequency does not quietly read as plain speech
+        var languageIcon = language != null && _prototype.TryIndex(language.Value, out LanguagePrototype? proto)
+            ? proto.HideLanguageName ? null : proto.DisplayedLanguageIcon
+            : null;
+
         return new ChatMessage(
             ChatChannel.Radio,
             message,
             wrapped,
             GetNetEntity(sender),
             _chatManager.EnsurePlayer(CompOrNull<ActorComponent>(sender)?.PlayerSession.UserId)?.Key,
+            languageIcon: languageIcon,
             display: new ChatDisplayMetadata(
                 ChatDisplayKind.Radio,
                 senderName: senderName,
@@ -559,4 +617,5 @@ public readonly record struct ANPRCDirectTrafficReceivedEvent(
     EntityUid Sender,
     string SenderName,
     int Frequency,
-    string Message);
+    string Message,
+    ProtoId<LanguagePrototype> Language);

--- a/Content.Shared/_AU14/Radio/ANPRCRadioUI.cs
+++ b/Content.Shared/_AU14/Radio/ANPRCRadioUI.cs
@@ -76,7 +76,8 @@ public sealed class ANPRCNetLogEntry(
     string senderName,
     string channelDisplay,
     string message,
-    bool intercepted = false)
+    bool intercepted = false,
+    string language = "English")
 {
     public readonly float Timestamp = timestamp;
     public readonly string SenderName = senderName;
@@ -86,6 +87,11 @@ public sealed class ANPRCNetLogEntry(
     // traffic on a net belonging to somebody else's faction. worth writing down,
     // worth carrying to whoever can act on it
     public readonly bool Intercepted = intercepted;
+
+    // the set writes down sounds, not sense. the stored line is what came over the
+    // air and this is the language it came in, so the server can render it for
+    // whoever is actually reading the panel rather than for nobody in particular
+    public readonly string Language = language;
 }
 
 // a contact the search receiver has built up but not necessarily fixed. Resolved

--- a/Resources/Locale/en-US/_AU14/anprc-radio.ftl
+++ b/Resources/Locale/en-US/_AU14/anprc-radio.ftl
@@ -102,3 +102,8 @@ anprc-sweep-unknown-net = UNIDENTIFIED NET
 # net log to paper
 anprc-log-print-empty = Nothing in the log worth writing down.
 anprc-log-printed = You transcribe { $count } log entries onto paper.
+
+anprc-log-frequency-unknown = FREQ UNK
+
+# languages that do not carry over the air
+anprc-language-no-radio = { $language } does not carry over a radio net.

--- a/Resources/Locale/en-US/_AU14/tunable-radio.ftl
+++ b/Resources/Locale/en-US/_AU14/tunable-radio.ftl
@@ -24,3 +24,4 @@ tunable-radio-verb-clear = Clear Tuned Frequency
 
 tunable-radio-cleared = Headset frequency cleared.
 
+tunable-radio-language-no-radio = { $language } does not carry over a radio net.


### PR DESCRIPTION
## About the PR

Hotfix for two reported AN/PRC-117G issues, both of which effectively turned the pack's net log into a way around COMSEC

**Frequency leak.** Wearing a powered-on pack and typing any radio prefix `:b`, `:c`, `:i`, with or without the corresponding key caused the pack to write that net's name and frequency into its log. Cycling through prefixes was enough to recover the entire per-round frequency plan in a few seconds, including protected nets. This was reported on the Russian CMU server during Insurgency

**Language leak.** A planted station's net log displayed foreign-language traffic in clear text even though the same traffic was correctly obfuscated in chat. While tracing that issue, I found a few related language handling gaps in the same subsystem: the pack discarded the spoken language when retransmitting, never checked `canUseRadio`, and `:x` direct-frequency traffic bypassed language handling entirely for every listener

This also includes fixes for two smaller server-side issues found along the way, plus a crash when deleting a pack with an antenna fitted

## Why / Balance

The comms overhaul relies on frequencies being secret. The frequency plan is generated fresh each round, and the intended ways to learn a frequency are through an SOI card, a captured card, or by working it out through the band sweep

Both of these bugs bypassed that loop entirely: one exposed frequencies immediately to anyone carrying a pack, while the other exposed intercepted foreign-language traffic to anyone who walked up to a planted station. Fixing them puts the sweep and frequency cards back in their intended role as the ways to gain access to an enemy net

There should be no intended gameplay change beyond closing those leaks

## Technical details

**Frequency leak.** `ANPRCRadioSystem.Transmit.cs` subscribes to `EntitySpokeEvent` with `before: [typeof(HeadsetSystem)]`. That means the pack sees the event before the headset system has had a chance to reject an invalid transmission

`SharedChatSystem.TryProccessRadioMessage` resolves the typed prefix directly through `_channelLookup` without checking whether the speaker actually has the required key. That entitlement check only happens later in `HeadsetSystem.OnSpeak`, so by the time the pack handler ran, `args.Channel` was populated for any valid prefix the player typed

* `LogHeadsetTraffic` now verifies that the speaker can actually transmit on the channel before logging it: either through a worn, non-read-only key or an intrinsic transmitter
* All four `AppendNetLog` call sites now pass their channel label through the same `KnowsFrequency` / `FormatLogChannel` gate. If the operator is not entitled to know the frequency, the entry is logged as the net name with `FREQ UNK`
* `OnSetSlotChannel` is a client-sent BUI message that previously only checked `_prototype.HasIndex`. A hand-crafted message could therefore tune the pack directly onto an enemy net and start receiving it. It now goes through the same entitlement check

**Language leak.** The log now stores both the traffic received over the air and the language it was spoken in. Language rendering happens when the entry is read rather than when it is written, because a planted station does not have one fixed listener

* The BUI state is rendered against the actors who currently have the panel open. An entry is shown in clear only if every current reader understands the language. With multiple readers, it therefore does not allow one player's comprehension to effectively leak the message to another. `SetUiState` does not have a per-session variant in this Robust version, so this is per-viewer-set rather than truly per-viewer
* Printing to paper renders the entry against the player who pressed the print button
* The pack's own speaker output still renders against its wearer, since that case has exactly one listener
* COMSEC garbling and jamming remain write-time operations because they depend on crypto state and range at the moment the transmission is received
* `TransmitThroughPack` now forwards `args.Language` to `SendRadioMessage`, so the retransmission uses the language that was actually spoken instead of whatever `GetCurrentLanguage` happens to return. It also checks `canUseRadio`; both the pack and `:x` now reject languages that cannot be transmitted over radio
* `TunableFrequencySystem` now carries the language through `BroadcastOnFrequency` → `DeliverGarbled` → `SendToEntity` → `BuildChatMessage`, allowing the message to be obfuscated per listener and giving it the same language icon used by normal channel radio

**Also fixed.** Deleting a pack empties its containers. When the antenna was removed during that process, it could reach `UpdateRelayAnchor`, which then attempted to re-add `ANPRCRelayAnchorComponent` to an entity that was already terminating and hit a `DebugAssert`. This is now guarded with `TerminatingOrDeleted`

**Tests.** `ANPRCNetLogLeakTest` covers both reported issues end to end. Both test cases were also confirmed to fail with the fixes removed

* `PackOnlyLogsNetsTheWearerActuallyTransmitsOn` equips a GOVFOR pack and command headset, attempts to speak on `radioOpforCommand` without the required key and verifies that nothing is logged, then speaks on `radioGovforCommand` and verifies that the entry is logged with its frequency
* `PlantedStationLogRendersForWhoeverReadsIt` plants a station, feeds it Russian traffic, verifies that the stored entry retains the original text and language while the rendered entry is obfuscated for a non-speaker, and also covers the no-identified-reader case plus a control using a language the reader understands

## Media

N/A

## Requirements

* [x] I have read and am following the [[Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html)](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
* [x] I have added media to this PR or it does not require an ingame showcase.
* [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
* [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:

* fix: The AN/PRC-117G net log no longer records frequencies for nets you do not have access to. Typing a radio prefix you cannot actually transmit on will no longer create a log entry
* fix: AN/PRC-117G net logs now preserve the language traffic was received in and render it for whoever is reading. A planted station no longer exposes foreign-language traffic in clear, and printed intercepts reflect what the operator actually understood
* fix: AN/PRC-117G transmissions now use the language that was actually spoken. Languages that cannot be carried over radio, such as sign language, no longer work through a manpack or direct frequency
* fix: Direct-frequency (`:x`) traffic is now obfuscated for listeners who do not understand the spoken language, matching normal radio nets
* fix: Fixed an error when deleting an AN/PRC-117G with an antenna fitted