### PR TITLE
Another Bug Fixings

### DIFF
--- a/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
+++ b/Content.Client/Interactable/Components/InteractionOutlineComponent.cs
@@ -12,8 +12,10 @@ namespace Content.Client.Interactable.Components
 
         [Dependency] private IPrototypeManager _prototypeManager = default!;
         [Dependency] private IEntityManager _entMan = default!;
+        private SpriteSystem Sprite => _entMan.System<SpriteSystem>(); // CMU14: systems live in the ESM collection, not root IoC
 
         private const float DefaultWidth = 1;
+        private const string ShaderId = "InteractionOutline"; // CMU14: keyed id required by the v288 multi post-shader API
 
         private bool _inRange;
         private ShaderInstance? _inRangeShader;
@@ -24,9 +26,10 @@ namespace Content.Client.Interactable.Components
         {
             _lastRenderScale = renderScale;
             _inRange = inInteractionRange;
-            if (_entMan.TryGetComponent(uid, out SpriteComponent? sprite) && sprite.PostShader == null)
+            if (_entMan.TryGetComponent(uid, out SpriteComponent? sprite))
             {
-                sprite.PostShader = GetShader(inInteractionRange, renderScale);
+                // CMU14: keyed set coexists with other post-shaders; the PostShader == null guard only fed the single-slot API
+                Sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ShaderId, GetShader(inInteractionRange, renderScale)));
             }
         }
 
@@ -34,8 +37,10 @@ namespace Content.Client.Interactable.Components
         {
             if (_entMan.TryGetComponent(uid, out SpriteComponent? sprite))
             {
-                if (IsOutlineShader(sprite.PostShader))
-                    sprite.PostShader = null;
+                // CMU14: keyed removal only drops our own entry
+                // if (IsOutlineShader(sprite.PostShader))
+                //     sprite.PostShader = null;
+                Sprite.RemovePostShader(sprite, ShaderId);
                 sprite.RenderOrder = 0;
             }
         }
@@ -43,13 +48,13 @@ namespace Content.Client.Interactable.Components
         public void UpdateInRange(EntityUid uid, bool inInteractionRange, int renderScale)
         {
             if (_entMan.TryGetComponent(uid, out SpriteComponent? sprite)
-                && IsOutlineShader(sprite.PostShader)
+                && Sprite.HasPostShader(sprite, ShaderId) // CMU14: keyed lookup replaces IsOutlineShader
                 && (inInteractionRange != _inRange || _lastRenderScale != renderScale))
             {
                 _inRange = inInteractionRange;
                 _lastRenderScale = renderScale;
 
-                sprite.PostShader = GetShader(_inRange, _lastRenderScale);
+                Sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ShaderId, GetShader(_inRange, _lastRenderScale))); // CMU14
             }
         }
 
@@ -62,12 +67,13 @@ namespace Content.Client.Interactable.Components
             _outOfRangeShader = null;
         }
 
-        private bool IsOutlineShader(ShaderInstance? shader)
-        {
-            return shader != null &&
-                   (ReferenceEquals(shader, _inRangeShader) ||
-                    ReferenceEquals(shader, _outOfRangeShader));
-        }
+        // CMU14: obsolete with keyed post-shader ids
+        // private bool IsOutlineShader(ShaderInstance? shader)
+        // {
+        //     return shader != null &&
+        //            (ReferenceEquals(shader, _inRangeShader) ||
+        //             ReferenceEquals(shader, _outOfRangeShader));
+        // }
 
         private ShaderInstance GetShader(bool inRange, int renderScale)
         {

--- a/Content.Client/Interaction/DragDropSystem.cs
+++ b/Content.Client/Interaction/DragDropSystem.cs
@@ -33,6 +33,8 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
 
     private static readonly ProtoId<ShaderPrototype> ShaderDropTargetOutOfRange = "SelectionOutline";
 
+    private const string DropTargetShaderId = "DragDropOutline"; // CMU14: keyed id required by the v288 multi post-shader API
+
     [Dependency] private IStateManager _stateManager = default!;
     [Dependency] private IInputManager _inputManager = default!;
     [Dependency] private IEyeManager _eyeManager = default!;
@@ -98,8 +100,8 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
     /// </summary>
     private ScreenCoordinates? _mouseDownScreenPos;
 
-    private ShaderInstance? _dropTargetInRangeShader;
-    private ShaderInstance? _dropTargetOutOfRangeShader;
+    private ShaderInstance _dropTargetInRangeShader = default!; // CMU14: non-nullable, assigned in Initialize
+    private ShaderInstance _dropTargetOutOfRangeShader = default!; // CMU14
 
     private readonly List<SpriteComponent> _highlightedSprites = new();
     private readonly HashSet<EntityUid> _dropTargetCandidates = new();
@@ -462,15 +464,16 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
                         && _interactionSystem.InRangeUnobstructed(user.Value, entity);
             }
 
-            if (inRangeSprite.PostShader != null &&
-                inRangeSprite.PostShader != _dropTargetInRangeShader &&
-                inRangeSprite.PostShader != _dropTargetOutOfRangeShader)
-            {
-                continue;
-            }
+            // CMU14: obsolete PostShader property clears every keyed entry on the sprite, guard only fed the single-slot API
+            // if (inRangeSprite.PostShader != null &&
+            //     inRangeSprite.PostShader != _dropTargetInRangeShader &&
+            //     inRangeSprite.PostShader != _dropTargetOutOfRangeShader)
+            // {
+            //     continue;
+            // }
 
             // highlight depending on whether its in or out of range
-            inRangeSprite.PostShader = valid.Value ? _dropTargetInRangeShader : _dropTargetOutOfRangeShader;
+            _sprite.SetPostShader(inRangeSprite, new SpriteComponent.PostShaderArgs(DropTargetShaderId, valid.Value ? _dropTargetInRangeShader : _dropTargetOutOfRangeShader)); // CMU14
             inRangeSprite.RenderOrder = EntityManager.CurrentTick.Value;
             _highlightedSprites.Add(inRangeSprite);
         }
@@ -480,10 +483,11 @@ public sealed partial class DragDropSystem : SharedDragDropSystem
     {
         foreach (var highlightedSprite in _highlightedSprites)
         {
-            if (highlightedSprite.PostShader != _dropTargetInRangeShader && highlightedSprite.PostShader != _dropTargetOutOfRangeShader)
-                continue;
+            // CMU14: keyed removal, other entries (cloaks, holograms) are no longer clobbered
+            // if (highlightedSprite.PostShader != _dropTargetInRangeShader && highlightedSprite.PostShader != _dropTargetOutOfRangeShader)
+            //     continue;
 
-            highlightedSprite.PostShader = null;
+            _sprite.RemovePostShader(highlightedSprite, DropTargetShaderId); // CMU14
             highlightedSprite.RenderOrder = 0;
         }
 

--- a/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
+++ b/Content.Client/Movement/Systems/FloorOcclusionSystem.cs
@@ -9,8 +9,10 @@ namespace Content.Client.Movement.Systems;
 public sealed partial class FloorOcclusionSystem : SharedFloorOcclusionSystem
 {
     private static readonly ProtoId<ShaderPrototype> HorizontalCut = "HorizontalCut";
+    private const string ShaderId = "HorizontalCut"; // CMU14: keyed id required by the v288 multi post-shader API
 
     [Dependency] private IPrototypeManager _proto = default!;
+    [Dependency] private SpriteSystem _sprite = default!; // CMU14
 
     private EntityQuery<SpriteComponent> _spriteQuery;
 
@@ -50,18 +52,19 @@ public sealed partial class FloorOcclusionSystem : SharedFloorOcclusionSystem
         if (!_spriteQuery.Resolve(sprite.Owner, ref sprite.Comp, false))
             return;
 
-        var shader = _proto.Index(HorizontalCut).Instance();
-
-        if (sprite.Comp.PostShader is not null && sprite.Comp.PostShader != shader)
-            return;
+        // CMU14: obsolete PostShader property clears every keyed entry on the sprite (thermal cloaks, holograms);
+        // the guard below only made sense for the single-slot API it was protecting
+        // var shader = _proto.Index(HorizontalCut).Instance();
+        // if (sprite.Comp.PostShader is not null && sprite.Comp.PostShader != shader)
+        //     return;
 
         if (enabled)
         {
-            sprite.Comp.PostShader = shader;
+            _sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ShaderId, _proto.Index(HorizontalCut).InstanceUnique())); // CMU14
         }
         else
         {
-            sprite.Comp.PostShader = null;
+            _sprite.RemovePostShader(sprite, ShaderId); // CMU14
         }
     }
 }

--- a/Content.Client/Outline/TargetOutlineSystem.cs
+++ b/Content.Client/Outline/TargetOutlineSystem.cs
@@ -17,6 +17,7 @@ public sealed partial class TargetOutlineSystem : EntitySystem
 {
     private static readonly ProtoId<ShaderPrototype> ShaderTargetValid = "SelectionOutlineInrange";
     private static readonly ProtoId<ShaderPrototype> ShaderTargetInvalid = "SelectionOutline";
+    private const string ShaderId = "TargetOutline"; // CMU14: keyed id required by the v288 multi post-shader API
 
     [Dependency] private IEyeManager _eyeManager = default!;
     [Dependency] private IGameTiming _timing = default!;
@@ -27,6 +28,7 @@ public sealed partial class TargetOutlineSystem : EntitySystem
     [Dependency] private SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private SharedTransformSystem _transformSystem = default!;
+    [Dependency] private SpriteSystem _sprite = default!; // CMU14
 
     private bool _enabled = false;
 
@@ -73,8 +75,8 @@ public sealed partial class TargetOutlineSystem : EntitySystem
 
     private Vector2 LookupVector => new(LookupSize, LookupSize);
 
-    private ShaderInstance? _shaderTargetValid;
-    private ShaderInstance? _shaderTargetInvalid;
+    private ShaderInstance _shaderTargetValid = default!; // CMU14: non-nullable, assigned in Initialize
+    private ShaderInstance _shaderTargetInvalid = default!; // CMU14
 
     private readonly HashSet<SpriteComponent> _highlightedSprites = new();
     private readonly HashSet<EntityUid> _targetCandidates = new();
@@ -156,10 +158,11 @@ public sealed partial class TargetOutlineSystem : EntitySystem
 
             if (!valid)
             {
-                // was this previously valid?
-                if (_highlightedSprites.Remove(sprite) && (sprite.PostShader == _shaderTargetValid || sprite.PostShader == _shaderTargetInvalid))
+                // CMU14: keyed removal only drops our own entry
+                // if (_highlightedSprites.Remove(sprite) && (sprite.PostShader == _shaderTargetValid || sprite.PostShader == _shaderTargetInvalid))
+                if (_highlightedSprites.Remove(sprite))
                 {
-                    sprite.PostShader = null;
+                    _sprite.RemovePostShader(sprite, ShaderId); // CMU14
                     sprite.RenderOrder = 0;
                 }
 
@@ -176,13 +179,14 @@ public sealed partial class TargetOutlineSystem : EntitySystem
                 valid = (origin - target).LengthSquared() <= Range;
             }
 
-            if (sprite.PostShader != null &&
-                sprite.PostShader != _shaderTargetValid &&
-                sprite.PostShader != _shaderTargetInvalid)
-                return;
+            // CMU14: obsolete PostShader property clears every keyed entry on the sprite, guard only fed the single-slot API
+            // if (sprite.PostShader != null &&
+            //     sprite.PostShader != _shaderTargetValid &&
+            //     sprite.PostShader != _shaderTargetInvalid)
+            //     return;
 
             // highlight depending on whether its in or out of range
-            sprite.PostShader = valid ? _shaderTargetValid : _shaderTargetInvalid;
+            _sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ShaderId, valid ? _shaderTargetValid : _shaderTargetInvalid)); // CMU14
             sprite.RenderOrder = EntityManager.CurrentTick.Value;
             _highlightedSprites.Add(sprite);
         }
@@ -192,10 +196,11 @@ public sealed partial class TargetOutlineSystem : EntitySystem
     {
         foreach (var sprite in _highlightedSprites)
         {
-            if (sprite.PostShader != _shaderTargetValid && sprite.PostShader != _shaderTargetInvalid)
-                continue;
+            // CMU14: keyed removal, other entries (cloaks, holograms) are no longer clobbered
+            // if (sprite.PostShader != _shaderTargetValid && sprite.PostShader != _shaderTargetInvalid)
+            //     continue;
 
-            sprite.PostShader = null;
+            _sprite.RemovePostShader(sprite, ShaderId); // CMU14
             sprite.RenderOrder = 0;
         }
 

--- a/Content.Client/_CMU14/Chat/RunechatSpeechBubble.cs
+++ b/Content.Client/_CMU14/Chat/RunechatSpeechBubble.cs
@@ -3,17 +3,20 @@ using System.Numerics;
 using System.Text;
 using Content.Client.Resources;
 using Content.Shared._CMU14.Chat;
+using Content.Shared._RMC14.Language.Prototypes;
 using Content.Shared._RMC14.Marines.Squads;
 using Content.Shared._RMC14.Xenonids;
 using Content.Shared.CCVar;
 using Content.Shared.Chat;
 using Content.Shared.Ghost;
+using Robust.Client.GameObjects;
 using Robust.Client.Graphics;
 using Robust.Client.ResourceManagement;
 using Robust.Client.UserInterface;
 using Robust.Shared.Configuration;
 using Robust.Shared.IoC;
 using Robust.Shared.Maths;
+using Robust.Shared.Prototypes;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
 
@@ -82,14 +85,32 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
                 pages[i] = ForceBold(pages[i]);
         }
 
-        return new RunechatTextControl(pages, fontColor ?? DefaultColor, style);
+        var languageIcon = speechStyleClass is SayStyle or WhisperStyle
+            ? GetLanguageIconTexture(message)
+            : null;
+
+        return new RunechatTextControl(pages, fontColor ?? DefaultColor, style, languageIcon);
+    }
+
+    private static Texture? GetLanguageIconTexture(ChatMessage message)
+    {
+        if (string.IsNullOrEmpty(message.LanguageIcon))
+            return null;
+
+        var prototypes = IoCManager.Resolve<IPrototypeManager>();
+        if (!prototypes.TryIndex<LanguagePrototype>(message.LanguageIcon, out var prototype)
+            || prototype.LanguageIcon is not { } icon)
+            return null;
+
+        var sprites = IoCManager.Resolve<IEntitySystemManager>().GetEntitySystem<SpriteSystem>();
+        return sprites.Frame0(icon);
     }
 
     private static string GetStyleClass(SpeechType type, ChatMessage message)
     {
-        if (type == SpeechType.Emote &&
-            message.UseEmoteSpeechBubble &&
-            (message.Channel == ChatChannel.Local || message.Channel == ChatChannel.Whisper))
+        if (type == SpeechType.Emote
+            && message.UseEmoteSpeechBubble
+            && (message.Channel == ChatChannel.Local || message.Channel == ChatChannel.Whisper))
         {
             return message.Channel == ChatChannel.Whisper
                 ? WhisperStyle
@@ -183,10 +204,10 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
 
     private static bool IsYellEmote(string text)
     {
-        return text.Contains("scream", StringComparison.OrdinalIgnoreCase) ||
-               text.Contains("pain", StringComparison.OrdinalIgnoreCase) ||
-               text.Contains("medic", StringComparison.OrdinalIgnoreCase) ||
-               text.Contains("corpsman", StringComparison.OrdinalIgnoreCase);
+        return text.Contains("scream", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("pain", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("medic", StringComparison.OrdinalIgnoreCase)
+            || text.Contains("corpsman", StringComparison.OrdinalIgnoreCase);
     }
 
     private static TimeSpan GetLifetime(IReadOnlyList<List<TextRun>> pages)
@@ -380,18 +401,18 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
     }
 
     private static bool TryParseColor(string value, out Color color)
-{
-    value = value.Trim('"', '\'');
-
-    if (Color.TryFromHex(value, out var hexColor))
     {
-        color = hexColor;
-        return true;
-    }
+        value = value.Trim('"', '\'');
 
-    color = default;
-    return false;
-}
+        if (Color.TryFromHex(value, out var hexColor))
+        {
+            color = hexColor;
+            return true;
+        }
+
+        color = default;
+        return false;
+    }
 
     /// <summary>
     /// Collapses whitespace to single spaces and trims leading/trailing
@@ -696,6 +717,7 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
         private const float TextStrokeOffset = 1f;
         private const float TextHaloOffset = 2f;
         private const float EmoteIconBaseSize = 9f;
+        private const float LanguageIconUnits = 5f;
         private const float DefaultEmoteIconPixelSize = 1.4f;
         private const float PanicShakeDuration = 0.85f;
         private const float PanicShakeFrequency = 18f;
@@ -750,6 +772,7 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
         private readonly IReadOnlyList<List<TextRun>> _pages;
         private readonly Color _color;
         private readonly RunechatVisualStyle _style;
+        private readonly Texture? _languageIcon;
         private readonly float _scale;
         private readonly Font _regularFont;
         private readonly Font _italicFont;
@@ -761,7 +784,7 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
         private float _pageTime;
         private float _animationTime;
 
-        public RunechatTextControl(IReadOnlyList<List<TextRun>> pages, Color color, RunechatVisualStyle style)
+        public RunechatTextControl(IReadOnlyList<List<TextRun>> pages, Color color, RunechatVisualStyle style, Texture? languageIcon = null)
         {
             IoCManager.InjectDependencies(this);
 
@@ -769,6 +792,7 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
             _pages = pages;
             _color = color;
             _style = style;
+            _languageIcon = languageIcon;
             _scale = DefaultRunechatScale *
                      Math.Clamp(_configManager.GetCVar(CCVars.ChatRunechatBubbleScale), MinimumRunechatScale, MaximumRunechatScale);
 
@@ -820,11 +844,26 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
             {
                 var line = layout.Lines[i];
                 var visibleBounds = GetVisibleBounds(line);
+                Texture? languageIcon = i == 0 ? _languageIcon : null;
+                var languageIconWidth = languageIcon != null ? GetLanguageIconSize() : 0f;
                 var iconWidth = _style.PrefixEmoteIcon && i == 0 ? GetVisibleIconWidth() : 0f;
-                var iconGap = iconWidth > 0f ? GetIconGap() : 0f;
-                var contentWidth = iconWidth + iconGap + visibleBounds.Width;
-                var x = (PixelSize.X - contentWidth) / 2f + iconWidth + iconGap - visibleBounds.Left + shakeOffset;
+                var iconGap = iconWidth + languageIconWidth > 0f ? GetIconGap() : 0f;
+                var contentWidth = iconWidth + languageIconWidth + iconGap + visibleBounds.Width;
+                var x = (PixelSize.X - contentWidth) / 2f + iconWidth + languageIconWidth + iconGap - visibleBounds.Left + shakeOffset;
                 var position = new Vector2(x, y);
+
+                if (languageIcon != null)
+                {
+                    var iconY = position.Y +
+                                visibleBounds.Top +
+                                visibleBounds.Height / 2f -
+                                languageIconWidth / 2f;
+
+                    handle.DrawTextureRect(
+                        languageIcon,
+                        UIBox2.FromDimensions(position.X - iconGap - languageIconWidth, iconY, languageIconWidth, languageIconWidth),
+                        Color.White.WithAlpha(textOpacity));
+                }
 
                 if (_style.PrefixEmoteIcon && i == 0)
                 {
@@ -1171,6 +1210,9 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
             return _scale * 2f * UIScale;
         }
 
+        private float GetLanguageIconSize()
+            => LanguageIconUnits * GetIconPixelSize() * UIScale;
+
         private float GetSyntheticBoldOffset()
         {
             return SyntheticBoldOffset * UIScale;
@@ -1351,18 +1393,18 @@ public sealed partial class RunechatSpeechBubble : SpeechBubble
 
         private static bool IsSmallFontsFace(ISystemFontFace face)
         {
-            return IsSmallFontsName(face.FamilyName) ||
-                   IsSmallFontsName(face.FullName) ||
-                   IsSmallFontsName(face.GetLocalizedFamilyName(CultureInfo.InvariantCulture)) ||
-                   IsSmallFontsName(face.GetLocalizedFullName(CultureInfo.InvariantCulture)) ||
-                   IsSmallFontsName(face.GetLocalizedFamilyName(EnUsCulture)) ||
-                   IsSmallFontsName(face.GetLocalizedFullName(EnUsCulture));
+            return IsSmallFontsName(face.FamilyName)
+                || IsSmallFontsName(face.FullName)
+                || IsSmallFontsName(face.GetLocalizedFamilyName(CultureInfo.InvariantCulture))
+                || IsSmallFontsName(face.GetLocalizedFullName(CultureInfo.InvariantCulture))
+                || IsSmallFontsName(face.GetLocalizedFamilyName(EnUsCulture))
+                || IsSmallFontsName(face.GetLocalizedFullName(EnUsCulture));
         }
 
         private static bool IsSmallFontsName(string name)
         {
-            return name.Equals(SmallFontsFamily, StringComparison.OrdinalIgnoreCase) ||
-                   name.Equals(SmallFonts120Family, StringComparison.OrdinalIgnoreCase);
+            return name.Equals(SmallFontsFamily, StringComparison.OrdinalIgnoreCase)
+                || name.Equals(SmallFonts120Family, StringComparison.OrdinalIgnoreCase);
         }
 
         private sealed record RunechatPageLayout(

--- a/Content.Client/_RMC14/Stealth/EntityInvisibilityVisualsSystem.cs
+++ b/Content.Client/_RMC14/Stealth/EntityInvisibilityVisualsSystem.cs
@@ -21,13 +21,15 @@ public sealed partial class EntityInvisibilityVisualsSystem : EntitySystem
         SubscribeLocalEvent<EntityTurnInvisibleComponent, ComponentShutdown>(OnShutdown);
     }
 
+    private void EnsureShader(SpriteComponent sprite) // CMU14 Method
+        => _sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ShaderId, _prototypes.Index(InvisibilityShader).InstanceUnique()));
+
     private void OnStartup(Entity<EntityTurnInvisibleComponent> ent, ref ComponentStartup args)
     {
         if (!TryComp(ent, out SpriteComponent? sprite))
             return;
 
-        // CMU14: legacy PostShader setter would clear every other post-shader on the sprite
-        _sprite.SetPostShader(sprite, new SpriteComponent.PostShaderArgs(ShaderId, _prototypes.Index(InvisibilityShader).InstanceUnique()));
+        EnsureShader(sprite);
     }
 
     private void OnShutdown(Entity<EntityTurnInvisibleComponent> ent, ref ComponentShutdown args)
@@ -47,9 +49,13 @@ public sealed partial class EntityInvisibilityVisualsSystem : EntitySystem
         while (invisible.MoveNext(out var uid, out var comp, out var sprite))
         {
             var opacity =  TryComp<EntityActiveInvisibleComponent>(uid, out var activeInvisible) ? activeInvisible.Opacity : 1;
-            // CMU14: keyed lookup so we only touch our own shader instance
-            if (_sprite.TryGetPostShader(sprite, ShaderId, out var entry))
-                entry.Shader.SetParameter("visibility", opacity);
+            if (!_sprite.TryGetPostShader(sprite, ShaderId, out var entry)) // CMU14
+            {
+                EnsureShader(sprite);
+                continue;
+            }
+
+            entry.Shader.SetParameter("visibility", opacity);
         }
     }
 }

--- a/Content.Client/_RMC14/Vehicle/Ui/VehicleAmmoLoaderMenu.cs
+++ b/Content.Client/_RMC14/Vehicle/Ui/VehicleAmmoLoaderMenu.cs
@@ -242,7 +242,7 @@ public sealed partial class VehicleAmmoLoaderMenu : FancyWindow
                 MouseFilter = Control.MouseFilterMode.Ignore
             };
 
-            var slotAmmoPrototype = hardpoint.AmmoPrototype ?? ammoPrototype;
+            var slotAmmoPrototype = ammoSlot.DisplayPrototype ?? hardpoint.AmmoPrototype ?? ammoPrototype; // CMU14
             if (slotAmmoPrototype is { } prototype)
             {
                 icon.SetPrototype(prototype);

--- a/Content.IntegrationTests/_RMC14/XenoGhostRoleAvailabilityTest.cs
+++ b/Content.IntegrationTests/_RMC14/XenoGhostRoleAvailabilityTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server.Ghost; // CMU14
 using Content.Server.Ghost.Roles;
 using Content.Server.Ghost.Roles.Components;
 using Content.Server.Mind;
@@ -11,6 +12,18 @@ namespace Content.IntegrationTests._RMC14;
 [TestFixture]
 public sealed class XenoGhostRoleAvailabilityTest
 {
+    [TestPrototypes] // CMU14
+    private const string Prototypes = @"
+- type: entity
+  id: CMUGhostRoleTestEntity
+  components:
+  - type: MindContainer
+  - type: MobState
+  - type: MobThresholds
+    thresholds:
+      0: Alive
+      200: Dead
+";
     [Test]
     public async Task LarvaDoesNotRegisterAsGhostRole()
     {
@@ -34,6 +47,50 @@ public sealed class XenoGhostRoleAvailabilityTest
             var larvaNet = entMan.GetNetEntity(larva);
             Assert.That(ghostRole.GetGhostRoleCount(), Is.EqualTo(0));
             Assert.That(ghostRole.GetGhostRolesInfo(null).Any(info => info.Entity == larvaNet), Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    // CMU14 method
+    [Test]
+    public async Task GhostedBodyRegistersAsGhostRole()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            Dirty = true,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var entMan = server.EntMan;
+        var ghostRole = entMan.System<GhostRoleSystem>();
+        var mind = entMan.System<MindSystem>();
+        var ghosts = entMan.System<GhostSystem>();
+        var player = server.PlayerMan.Sessions.Single();
+
+        EntityUid mob = default;
+
+        await server.WaitAssertion(() =>
+        {
+            mob = entMan.SpawnEntity("CMUGhostRoleTestEntity", MapCoordinates.Nullspace);
+            entMan.EnsureComponent<MindContainerComponent>(mob);
+
+            var mindId = mind.CreateMind(player.UserId, "Ghosted Mob");
+            mind.TransferTo(mindId, mob);
+            mind.SetUserId(mindId, player.UserId);
+
+            entMan.EnsureComponent<GhostTakeoverAvailableComponent>(mob);
+            entMan.EnsureComponent<GhostRoleComponent>(mob);
+
+            // alive player runs the ghost command: non-returnable, so the mind leaves the body
+            // and the role must re-register even though the session detaches one event later
+            Assert.That(ghosts.OnGhostAttempt(mindId, true, viaCommand: true), Is.True);
+
+            var mobNet = entMan.GetNetEntity(mob);
+            Assert.That(ghostRole.GetGhostRoleCount(), Is.EqualTo(1));
+            Assert.That(ghostRole.GetGhostRolesInfo(null).Any(info => info.Entity == mobNet), Is.True);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Server/GameTicking/GameTicker.Spawning.cs
+++ b/Content.Server/GameTicking/GameTicker.Spawning.cs
@@ -243,7 +243,7 @@ namespace Content.Server.GameTicking
             Dictionary<NetUserId, HumanoidCharacterProfile> profiles,
             bool force)
         {
-            _distressSignal.TheHive = _hive.CreateHive("xenonid hive", "CMXenoHive");
+            _distressSignal.TheHive = _hive.CreateHive("Xenomorph Prime", "CMXenoHive");
             _hive.CreateHive("Mycelial Confluence", "CMUPathogenHive");
 
             // For presets without CMDistressSignalRule (e.g. AU14 DistressSignal), the planet map

--- a/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
+++ b/Content.Server/GameTicking/Presets/GamePresetPrototype.cs
@@ -42,6 +42,10 @@ namespace Content.Server.GameTicking.Presets
         [DataField("maxPlayers")]
         public int? MaxPlayers;
 
+        /// <summary>Whether hives can gain or spawn burrowed larva during this preset.</summary>
+        [DataField("burrowedLarvaEnabled")]
+        public bool BurrowedLarvaEnabled = true; // CMU14
+
         /// <summary>
         /// Whether this preset starts the automatic third-party queue without requiring a selected threat.
         /// </summary>

--- a/Content.Server/Ghost/Roles/GhostRoleSystem.cs
+++ b/Content.Server/Ghost/Roles/GhostRoleSystem.cs
@@ -368,7 +368,16 @@ public sealed partial class GhostRoleSystem : EntitySystem
 
     public void RegisterGhostRole(Entity<GhostRoleComponent> role)
     {
-        if (!CanTakeGhost(role.Owner, role.Comp))
+        // CMU14: registration must not check actor/mind - MindRemovedMessage fires before the
+        // session detaches, so CanTakeGhost here unregistered every ghosted body's role.
+        // if (!CanTakeGhost(role.Owner, role.Comp))
+        // {
+        //     UnregisterGhostRole(role);
+        //     return;
+        // }
+        if (role.Comp.Taken
+            || MetaData(role.Owner).EntityPaused
+            || IsBlockedXenoGhostRole(role.Owner))
         {
             UnregisterGhostRole(role);
             return;

--- a/Content.Server/_CMU14/Medical/Diagnostics/Telemetry/CMUMedicalTelemetrySystem.cs
+++ b/Content.Server/_CMU14/Medical/Diagnostics/Telemetry/CMUMedicalTelemetrySystem.cs
@@ -47,7 +47,7 @@ public sealed partial class CMUMedicalTelemetrySystem : EntitySystem
         SubscribeLocalEvent<CMSurgeryTargetComponent, CMSurgeryCompleteEvent>(OnSurgeryDone);
         SubscribeLocalEvent<DamageableComponent, RMCDefibrillatorAttemptEvent>(OnDefibAttempt);
         SubscribeLocalEvent<CMUPainShockStatusComponent, ComponentStartup>(OnPainShockEntered);
-        SubscribeLocalEvent<BodyPartComponent, BodyPartSeveredEvent>(OnBodyPartSevered);
+        SubscribeLocalEvent<BodyPartSeveredEvent>(OnBodyPartSevered);
         SubscribeLocalEvent<InternalBleedingChangedEvent>(OnInternalBleedingChanged);
         SubscribeLocalEvent<Content.Shared._CMU14.Medical.Anatomy.BodyParts.BodyPartHealthComponent, CMUShrapnelChangedEvent>(OnShrapnelChanged);
         SubscribeLocalEvent<RoundEndSummaryStatsEvent>(OnRoundEndStats);
@@ -95,7 +95,7 @@ public sealed partial class CMUMedicalTelemetrySystem : EntitySystem
         _painShockEntries[ent.Owner] = prior + 1;
     }
 
-    private void OnBodyPartSevered(Entity<BodyPartComponent> ent, ref BodyPartSeveredEvent args)
+    private void OnBodyPartSevered(ref BodyPartSeveredEvent args)
     {
         if (args.Type is BodyPartType.Arm or BodyPartType.Leg)
             _severedLimbs++;

--- a/Content.Server/_CMU14/Medical/Injuries/Wounds/CMUBandageInterceptionSystem.cs
+++ b/Content.Server/_CMU14/Medical/Injuries/Wounds/CMUBandageInterceptionSystem.cs
@@ -152,13 +152,13 @@ public sealed partial class CMUBandageInterceptionSystem : EntitySystem
         var doAfter = new DoAfterArgs(EntityManager, args.User, delay, doAfterEv,
             args.User, target: patient, used: used)
         {
-            BreakOnMove = true,
+            // BreakOnMove = true, // CMU14: bandage keeps applying while moving
             BreakOnHandChange = true,
             NeedHand = true,
             BlockDuplicate = true,
             CancelDuplicate = false,
             DuplicateCondition = DuplicateConditions.SameTool | DuplicateConditions.SameTarget,
-            MovementThreshold = 0.5f,
+            // MovementThreshold = 0.5f, // CMU14: only read with BreakOnMove
             TargetEffect = "RMCEffectHealBusy",
         };
         args.Handled = true;

--- a/Content.Server/_CMU14/Threats/Mobs/ZombieSummoner/ZombieSummonerSystem.cs
+++ b/Content.Server/_CMU14/Threats/Mobs/ZombieSummoner/ZombieSummonerSystem.cs
@@ -382,7 +382,7 @@ public sealed partial class ZombieSummonerSystem : EntitySystem
 
         var (severedPartUid, severedPart) = _random.Pick(chosen);
         var ev = new BodyPartSeveredEvent(body, severedPartUid, severedPart.PartType);
-        RaiseLocalEvent(severedPartUid, ref ev);
+        RaiseLocalEvent(severedPartUid, ref ev, broadcast: true);
     }
 
     private void OnMinionShutdown(Entity<ZombieSummonerMinionComponent> ent, ref ComponentShutdown args)

--- a/Content.Server/_CMU14/Util/Admin/Console/NukeDecalCommand.cs
+++ b/Content.Server/_CMU14/Util/Admin/Console/NukeDecalCommand.cs
@@ -16,6 +16,7 @@ public sealed partial class NukeDecalsCommand : LocalizedEntityCommands
     [Dependency] private IPrototypeManager _protoMan = default!;
 
     public override string Command => "nuke:decals";
+    public override string Description => "Deletes decals from every loaded grid.";
     public override string Help =>
         "nuke:decals [all (true/false, default: false)] [decalId...] - Deletes decals from every loaded grid.\n" +
         " By default this will only delete cleanable decals (like blood/dirt etc.) to spare map details.\n" +

--- a/Content.Server/_CMU14/Util/Admin/Console/NukeEntitiesCommand.cs
+++ b/Content.Server/_CMU14/Util/Admin/Console/NukeEntitiesCommand.cs
@@ -22,6 +22,8 @@ public abstract class NukeEntitiesCommand : LocalizedEntityCommands
     [Dependency] protected SharedContainerSystem _container = default!;
     [Dependency] protected IPrototypeManager _protoMan = default!;
 
+    public override string Description => "Nuke/delete from every loaded grid.";
+
     protected static (bool All, HashSet<string>? Ids) ParseBoolAndIds(string[] args)
     {
         var all = false;
@@ -215,14 +217,16 @@ public sealed partial class NukeTrashCommand : NukeEntitiesCommand
 {
     [Dependency] private TagSystem _tag = default!;
 
-    // Curated extras on top of the "Trash" tag
     private static readonly string[] AdditionalTrashTags = { };
     private static readonly string[] AdditionalTrashPrototypes = { };
+
+    private static readonly string[] ExcludedTrashComponents = { "Paper" };
 
     public override string Command => "nuke:trash";
     public override string Help =>
         "nuke:trash [trashId...] - Deletes loose trash entities from the world.\n" +
         " Trash is anything tagged 'Trash', plus the curated AdditionalTrashTags and AdditionalTrashPrototypes lists in this command's source.\n" +
+        " Prototypes carrying a component from ExcludedTrashComponents (papers and friends) are always spared.\n" +
         " Trash that is held, worn, or otherwise inside a container is left alone.\n" +
         " Optionally list prototype ids to restrict the nuke to those types.";
 
@@ -253,8 +257,14 @@ public sealed partial class NukeTrashCommand : NukeEntitiesCommand
 
     private bool IsTrash(EntityUid uid, MetaDataComponent meta)
     {
-        if (meta.EntityPrototype is { } proto && AdditionalTrashPrototypes.Contains(proto.ID))
-            return true;
+        if (meta.EntityPrototype is { } proto)
+        {
+            if (ExcludedTrashComponents.Any(c => proto.Components.ContainsKey(c)))
+                return false;
+
+            if (AdditionalTrashPrototypes.Contains(proto.ID))
+                return true;
+        }
 
         if (!EntityManager.TryGetComponent<TagComponent>(uid, out var tags))
             return false;
@@ -272,8 +282,9 @@ public sealed partial class NukeTrashCommand : NukeEntitiesCommand
     }
 
     protected override bool IncludeProto(EntityPrototype proto) =>
-        AdditionalTrashPrototypes.Contains(proto.ID)
-        || (proto.Components.TryGetValue("Tag", out var reg)
-            && reg.Component is TagComponent tag
-            && (_tag.HasTag(tag, "Trash") || AdditionalTrashTags.Any(t => _tag.HasTag(tag, t)))); // CMU14: analyzer-safe tag access
+        !ExcludedTrashComponents.Any(c => proto.Components.ContainsKey(c))
+        && (AdditionalTrashPrototypes.Contains(proto.ID)
+            || (proto.Components.TryGetValue("Tag", out var reg)
+                && reg.Component is TagComponent tag
+                && (_tag.HasTag(tag, "Trash") || AdditionalTrashTags.Any(t => _tag.HasTag(tag, t))))); // CMU14: analyzer-safe tag access
 }

--- a/Content.Server/_CMU14/Util/Admin/Console/NukeLightCommand.cs
+++ b/Content.Server/_CMU14/Util/Admin/Console/NukeLightCommand.cs
@@ -25,6 +25,7 @@ public sealed partial class NukeLightCommand : LocalizedEntityCommands
     private static readonly Color DefaultColor = Color.Orange;
 
     public override string Command => "nuke:lights";
+    public override string Description => "Deletes lights in a radius around you, use 'help nuke:lights' for more info.";
     public override string Help =>
         "Usage: nuke:lights [radius=80] [energy=80] [duration=4] [x y mapId] [color=Orange]";
 

--- a/Content.Server/_CMU14/Weapons/Ranged/CMUSpentCasingSystem.cs
+++ b/Content.Server/_CMU14/Weapons/Ranged/CMUSpentCasingSystem.cs
@@ -1,0 +1,57 @@
+using Content.Shared._CMU14.Weapons.Ranged;
+using Content.Shared._CMU14.ZLevels.Core.Components;
+using Content.Shared.CCVar;
+using Robust.Shared.Configuration;
+using Robust.Shared.Containers;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Timing;
+
+namespace Content.Server._CMU14.Weapons.Ranged;
+
+/// <summary>
+/// Periodic sweeper for ejected spent casings: strips their physics a few seconds
+/// after landing (they become free-floating decals) and despawns them after
+/// <see cref="CCVars.SpentCasingDespawnTime"/>. One shared sweep instead of
+/// per-entity timers; contained casings (held, stored) are left alone.
+/// </summary>
+public sealed class CMUSpentCasingSystem : EntitySystem
+{
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private static readonly TimeSpan SweepInterval = TimeSpan.FromSeconds(5);
+
+    /// <summary>Delay before the physics strip, so the ejection throw always finishes first.</summary>
+    private static readonly TimeSpan StripDelay = TimeSpan.FromSeconds(3);
+
+    private TimeSpan _nextSweep;
+
+    public override void Initialize() => _nextSweep = _timing.CurTime + SweepInterval;
+
+    public override void Update(float frameTime)
+    {
+        if (_timing.CurTime < _nextSweep)
+            return;
+
+        _nextSweep += SweepInterval;
+
+        var despawn = TimeSpan.FromSeconds(_cfg.GetCVar(CCVars.SpentCasingDespawnTime));
+        if (despawn <= TimeSpan.Zero)
+            return;
+
+        var now = _timing.CurTime;
+        var query = EntityQueryEnumerator<CMUSpentCasingComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (_containers.IsEntityInContainer(uid))
+                continue;
+
+            var age = now - comp.EjectedAt;
+            if (age >= despawn)
+                QueueDel(uid);
+            else if (age >= StripDelay && !HasComp<CMUZFallingComponent>(uid))
+                RemComp<PhysicsComponent>(uid);
+        }
+    }
+}

--- a/Content.Server/_CMU14/Xenomorphs/Pathogen/Walker/PathogenWalkerSystem.cs
+++ b/Content.Server/_CMU14/Xenomorphs/Pathogen/Walker/PathogenWalkerSystem.cs
@@ -78,7 +78,7 @@ public sealed partial class CMUPathogenWalkerSystem : EntitySystem
         SubscribeLocalEvent<CMUPathogenWalkerComponent, ExaminedEvent>(OnWalkerExamined);
         SubscribeNetworkEvent<CMUPathogenWalkerAcceptNetEvent>(OnAcceptNet);
         SubscribeNetworkEvent<CMUPathogenWalkerDeclineNetEvent>(OnDeclineNet);
-        SubscribeLocalEvent<CMUPathogenWalkerComponent, BodyPartSeveredEvent>(OnWalkerSevered);
+        SubscribeLocalEvent<BodyPartComponent, BodyPartSeveredEvent>(OnWalkerSevered);
     }
 
     private void OnReanimate(CMUMycotoxinInjectDoReanimateEvent ev)
@@ -152,17 +152,25 @@ public sealed partial class CMUPathogenWalkerSystem : EntitySystem
         Dirty(target, walker);
     }
 
-    private void OnWalkerSevered(Entity<CMUPathogenWalkerComponent> walker, ref BodyPartSeveredEvent args)
+    private void OnWalkerSevered(Entity<BodyPartComponent> part, ref BodyPartSeveredEvent args)
     {
         if (args.Type != BodyPartType.Head)
             return;
 
-        // Cancel any pending revive and mark as exhausted
-        walker.Comp.ReviveAt = null;
-        walker.Comp.RevivesUsed = walker.Comp.MaxRevives;
-        Dirty(walker);
+        if (!TryComp<CMUPathogenWalkerComponent>(args.Body, out var walker))
+            return;
 
-        _popup.PopupEntity(Loc.GetString("cmu14-walker-permanent-death"), walker, PopupType.Medium);
+        // Decap is permanent death
+        walker.ReviveAt = null;
+        walker.RevivesUsed = walker.MaxRevives;
+        walker.OfferResolved = true;
+        walker.OfferExpiresAt = null;
+        Dirty(args.Body, walker);
+
+        RemComp<GhostTakeoverAvailableComponent>(args.Body);
+        RemComp<GhostRoleComponent>(args.Body);
+
+        _popup.PopupEntity(Loc.GetString("cmu14-walker-permanent-death"), args.Body, PopupType.Medium);
     }
 
     private void OnAcceptNet(CMUPathogenWalkerAcceptNetEvent ev, EntitySessionEventArgs args)

--- a/Content.Server/_CMU14/Xenonids/Hive/CMUBurrowedLarvaSystem.cs
+++ b/Content.Server/_CMU14/Xenonids/Hive/CMUBurrowedLarvaSystem.cs
@@ -1,0 +1,21 @@
+using Content.Server.GameTicking;
+using Content.Shared._RMC14.Xenonids.Hive;
+
+namespace Content.Server._CMU14.Xenonids.Hive;
+
+public sealed class CMUBurrowedLarvaSystem : EntitySystem
+{
+    [Dependency] private GameTicker _gameTicker = default!;
+    [Dependency] private SharedXenoHiveSystem _hive = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<HiveComponent, ComponentStartup>(OnHiveStartup);
+    }
+
+    private void OnHiveStartup(Entity<HiveComponent> ent, ref ComponentStartup args)
+    {
+        var preset = _gameTicker.CurrentPreset ?? _gameTicker.Preset;
+        _hive.SetBurrowedLarvaEnabled(ent, preset?.BurrowedLarvaEnabled ?? true);
+    }
+}

--- a/Content.Server/_CMU14/Yautja/YautjaBracerUtilitySystem.cs
+++ b/Content.Server/_CMU14/Yautja/YautjaBracerUtilitySystem.cs
@@ -435,7 +435,7 @@ public sealed partial class YautjaBracerUtilitySystem : EntitySystem
             return false;
 
         var ev = new BodyPartSeveredEvent(body, part, type);
-        RaiseLocalEvent(part, ref ev);
+        RaiseLocalEvent(part, ref ev, broadcast: true);
         return true;
     }
 

--- a/Content.Server/_CMU14/Yautja/YautjaTrophySystem.cs
+++ b/Content.Server/_CMU14/Yautja/YautjaTrophySystem.cs
@@ -653,7 +653,7 @@ public sealed partial class YautjaTrophySystem : EntitySystem
             return;
 
         var ev = new BodyPartSeveredEvent(target, part, type);
-        RaiseLocalEvent(part, ref ev);
+        RaiseLocalEvent(part, ref ev, broadcast: true);
     }
 
     private static bool TryGetPartForTrophy(YautjaTrophyKind kind, out BodyPartType type, out BodyPartSymmetry symmetry)

--- a/Content.Server/_RMC14/Weapons/Ranged/Sharp/SharpSystem.cs
+++ b/Content.Server/_RMC14/Weapons/Ranged/Sharp/SharpSystem.cs
@@ -185,6 +185,15 @@ public sealed partial class SharpSystem : EntitySystem
         if (args.Handled || ent.Comp.Disarmed)
             return;
 
+        // CMU14: every shrapnel hit would previously triggers a fresh detonation
+        ent.Comp.Disarmed = true;
+        ent.Comp.Armed = false;
+        if (_landmineQuery.TryComp(ent, out var landmine))
+        {
+            landmine.Armed = false;
+            Dirty(ent, landmine);
+        }
+
         var effect = GetMineEffect(ent.Comp);
         if (effect != null)
             SpawnAndTrigger(effect.Value, Transform(ent).Coordinates, args.User);

--- a/Content.Server/_RMC14/Xenonids/Melee/XenoMeleeSeverSystem.cs
+++ b/Content.Server/_RMC14/Xenonids/Melee/XenoMeleeSeverSystem.cs
@@ -74,6 +74,6 @@ public sealed partial class XenoMeleeSeverSystem : EntitySystem
 
         var (severedPartUid, severedPart) = _random.Pick(chosen);
         var ev = new BodyPartSeveredEvent(body, severedPartUid, severedPart.PartType);
-        RaiseLocalEvent(severedPartUid, ref ev);
+        RaiseLocalEvent(severedPartUid, ref ev, broadcast: true); // CMU14: broadcast so non-directed observers see it
     }
 }

--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared._RMC14.Weapons.Ranged;
 using Content.Shared._RMC14.Weapons.Ranged.Flamer;
 using Content.Shared._RMC14.Weapons.Ranged.Prediction;
 using Content.Shared._RMC14.Vehicle;
+using Content.Shared._CMU14.Weapons.Ranged; // CMU14
 using Content.Shared._CMU14.ZLevels.Core.EntitySystems;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
@@ -1096,6 +1097,9 @@ public abstract partial class SharedGunSystem : EntitySystem
         {
             Audio.PlayPvs(cartridge.EjectSound, entity, AudioParams.Default.WithVariation(SharedContentAudioSystem.DefaultVariation).WithVolume(-1f));
         }
+
+        if (TryComp<CartridgeAmmoComponent>(entity, out var spent) && spent.Spent) // CMU14
+            EnsureComp<CMUSpentCasingComponent>(entity).EjectedAt = Timing.CurTime;
     }
 
     public IShootable EnsureShootable(EntityUid uid) // RMC14

--- a/Content.Shared/_CMU14/CCVar/CMUCCVars.Game.cs
+++ b/Content.Shared/_CMU14/CCVar/CMUCCVars.Game.cs
@@ -9,4 +9,7 @@ public sealed partial class CCVars
 
     public static readonly CVarDef<bool> MuteScriptedSounds =
         CVarDef.Create("cmu.game.mute_scripted_sfx", false, CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    public static readonly CVarDef<float> SpentCasingDespawnTime =
+        CVarDef.Create("cmu.game.spent_casing_despawn_time", 300f, CVar.SERVERONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/_CMU14/Medical/Anatomy/BodyParts/SharedBodyPartHealthSystem.cs
+++ b/Content.Shared/_CMU14/Medical/Anatomy/BodyParts/SharedBodyPartHealthSystem.cs
@@ -161,7 +161,7 @@ public abstract partial class SharedBodyPartHealthSystem : EntitySystem
         if (health.SeveranceDamage >= health.Max + health.SeveranceThreshold && !IsSeveranceLocked(partType))
         {
             var severed = new BodyPartSeveredEvent(body, partUid, partType);
-            RaiseLocalEvent(partUid, ref severed);
+            RaiseLocalEvent(partUid, ref severed, broadcast: true);
         }
 
         return true;

--- a/Content.Shared/_CMU14/Weapons/Ranged/CMUSpentCasingComponent.cs
+++ b/Content.Shared/_CMU14/Weapons/Ranged/CMUSpentCasingComponent.cs
@@ -1,0 +1,12 @@
+namespace Content.Shared._CMU14.Weapons.Ranged;
+
+/// <summary>
+/// Marks a spent casing ejected from a gun, so the server can strip its physics
+/// and despawn it later without a per-entity timer.
+/// </summary>
+[RegisterComponent]
+public sealed partial class CMUSpentCasingComponent : Component
+{
+    /// <summary>When the casing was ejected; drives both the physics strip and the despawn.</summary>
+    public TimeSpan EjectedAt;
+}

--- a/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
+++ b/Content.Shared/_RMC14/Repairable/RMCRepairableSystem.cs
@@ -304,6 +304,9 @@ public sealed partial class RMCRepairableSystem : EntitySystem
             return false;
         }
 
+        if (attempt) // CMU14: flows bypass SharedToolSystem.UseTool, raise its attempt event so unprotected welding damages eyes
+            RaiseLocalEvent(tool, new ToolUseAttemptEvent(user, fuelUsed.Float()));
+
         if (!attempt && _net.IsServer)
         {
             _solution.RemoveReagent(solutionComp.Value, ReagentWelder, fuelUsed);

--- a/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
+++ b/Content.Shared/_RMC14/Synth/SharedSynthSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared._RMC14.Damage; // CMU14
 using Content.Shared._RMC14.IdentityManagement;
 using Content.Shared._RMC14.Medical.HUD.Components;
 using Content.Shared._RMC14.Medical.Stasis;
@@ -34,6 +35,8 @@ namespace Content.Shared._RMC14.Synth;
 public abstract partial class SharedSynthSystem : EntitySystem
 {
     private static readonly TimeSpan UnableUsePopupCooldown = TimeSpan.FromSeconds(1);
+    private static readonly ProtoId<DamageGroupPrototype>[] SynthImmuneGroups = ["Toxin", "Airloss"]; // CMU14
+    private readonly HashSet<ProtoId<DamageTypePrototype>> _synthImmuneTypes = new(); // CMU14
 
     [Dependency] private RMCRepairableSystem _repairable = default!;
     [Dependency] private SharedActionsSystem _actions = default!;
@@ -63,8 +66,20 @@ public abstract partial class SharedSynthSystem : EntitySystem
         SubscribeLocalEvent<SynthComponent, CMBleedEvent>(OnBleed);
         SubscribeLocalEvent<SynthComponent, InteractUsingEvent>(OnSynthInteractUsing);
         SubscribeLocalEvent<SynthComponent, RMCSynthRepairEvent>(OnSynthRepairDoAfter);
+        SubscribeLocalEvent<SynthComponent, DamageModifyAfterResistEvent>(OnSynthDamageAfterResist); // CMU14
 
         SubscribeLocalEvent<UseOnSynthBlockedComponent, BeforeRangedInteractEvent>(OnSynthBlockedBeforeRangedInteract);
+
+        // CMU14: cache the immune groups' damage types once
+        _synthImmuneTypes.Clear();
+        foreach (var groupId in SynthImmuneGroups)
+        {
+            if (!_prototypes.TryIndex(groupId, out var group))
+                continue;
+
+            foreach (var type in group.DamageTypes)
+                _synthImmuneTypes.Add(type);
+        }
     }
 
     // Change any mob to a synth, even after it has already been map-initialized
@@ -229,6 +244,15 @@ public abstract partial class SharedSynthSystem : EntitySystem
     private void OnBleed(Entity<SynthComponent> ent, ref CMBleedEvent args)
     {
         args.Handled = true;
+    }
+
+    private void OnSynthDamageAfterResist(Entity<SynthComponent> ent, ref DamageModifyAfterResistEvent args) // CMU14 Method
+    {
+        foreach (var (type, amount) in args.Damage.DamageDict)
+        {
+            if (amount > FixedPoint2.Zero && _synthImmuneTypes.Contains(type))
+                args.Damage.DamageDict[type] = FixedPoint2.Zero;
+        }
     }
 
     private void OnSynthInteractUsing(Entity<SynthComponent> synth, ref InteractUsingEvent args)

--- a/Content.Shared/_RMC14/Vehicle/Weapons/VehicleAmmoLoaderSystem.cs
+++ b/Content.Shared/_RMC14/Vehicle/Weapons/VehicleAmmoLoaderSystem.cs
@@ -675,7 +675,8 @@ public sealed partial class VehicleAmmoLoaderSystem : EntitySystem
                 slot.Capacity,
                 CanLoadSlot(heldBox, ammoPrototype, ammo, hardpointAmmo, slot.SlotIndex),
                 _hardpointAmmo.HasUnloadRounds(hardpointAmmo, ammo, slot.SlotIndex),
-                slot.IsReadySlot));
+                slot.IsReadySlot,
+                slot.IsReadySlot ? _bulletBox.GetBoxForAmmo(ammo.Proto) : null)); // CMU14
         }
 
         return entries;
@@ -754,7 +755,7 @@ public sealed partial class VehicleAmmoLoaderSystem : EntitySystem
         if (transferAmount <= 0)
             return;
 
-        var unloadedAmount = SpawnUnloadedAmmo(user, refill, transferAmount);
+        var unloadedAmount = SpawnUnloadedAmmo(user, refill, transferAmount, ammoSlot == 0 ? ammo.Proto : null); // CMU14
         if (unloadedAmount <= 0)
             return;
 
@@ -763,9 +764,10 @@ public sealed partial class VehicleAmmoLoaderSystem : EntitySystem
         _popup.PopupClient(Loc.GetString("rmc-vehicle-ammo-loader-unloaded", ("amount", unloadedAmount), ("target", ammoUid)), loader, user);
     }
 
-    private int SpawnUnloadedAmmo(EntityUid user, RefillableByBulletBoxComponent refill, int amount)
+    private int SpawnUnloadedAmmo(EntityUid user, RefillableByBulletBoxComponent refill, int amount, EntProtoId? chamberedProto) // CMU14 Method
     {
-        if (amount <= 0 || refill.BulletType is not { } prototype)
+        // CMU14: chambered variant rounds unload as the shell box that loaded them, not the generic bullet type box
+        if (amount <= 0 || (_bulletBox.GetBoxForAmmo(chamberedProto) ?? refill.BulletType) is not { } prototype)
             return 0;
 
         var remaining = amount;

--- a/Content.Shared/_RMC14/Vehicle/Weapons/VehicleAmmoLoaderUi.cs
+++ b/Content.Shared/_RMC14/Vehicle/Weapons/VehicleAmmoLoaderUi.cs
@@ -58,6 +58,7 @@ public sealed class VehicleAmmoLoaderUiAmmoSlot
     public readonly bool CanLoad;
     public readonly bool CanUnload;
     public readonly bool IsReadySlot;
+    public readonly EntProtoId? DisplayPrototype; // CMU14
 
     public VehicleAmmoLoaderUiAmmoSlot(
         int slotIndex,
@@ -66,7 +67,8 @@ public sealed class VehicleAmmoLoaderUiAmmoSlot
         int capacity,
         bool canLoad,
         bool canUnload,
-        bool isReadySlot)
+        bool isReadySlot,
+        EntProtoId? displayPrototype) // CMU14
     {
         SlotIndex = slotIndex;
         Label = label;
@@ -75,6 +77,7 @@ public sealed class VehicleAmmoLoaderUiAmmoSlot
         CanLoad = canLoad;
         CanUnload = canUnload;
         IsReadySlot = isReadySlot;
+        DisplayPrototype = displayPrototype; // CMU14
     }
 }
 

--- a/Content.Shared/_RMC14/Weapons/Ranged/Ammo/BulletBox/BulletBoxSystem.cs
+++ b/Content.Shared/_RMC14/Weapons/Ranged/Ammo/BulletBox/BulletBoxSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared.Popups;
 using Content.Shared.Verbs;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Systems;
+using Robust.Shared.Prototypes; // CMU14
 
 namespace Content.Shared._RMC14.Weapons.Ranged.Ammo.BulletBox;
 
@@ -14,6 +15,8 @@ public sealed partial class BulletBoxSystem : EntitySystem
 {
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedDoAfterSystem _doAfter = default!;
+    [Dependency] private IComponentFactory _compFactory = default!; // CMU14
+    [Dependency] private IPrototypeManager _prototypes = default!; // CMU14
     [Dependency] private SharedGunSystem _gun = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private SharedHandsSystem _hands = default!;
@@ -123,6 +126,9 @@ public sealed partial class BulletBoxSystem : EntitySystem
                 return;
 
             transfer = Math.Min(transfer, ent.Comp.Amount);
+            // CMU14: chamber the box's shell variant when filling an empty gun, so LTB AP/HE/etc shells fire as loaded
+            if (used.Comp2.Count == 0 && ent.Comp.AmmoProto is { } ammoProto)
+                _gun.SetBallisticProto((used, used.Comp2), ammoProto);
             _gun.SetBallisticUnspawned((used, used.Comp2), used.Comp2.UnspawnedCount + transfer);
             ent.Comp.Amount -= transfer;
         }
@@ -227,5 +233,30 @@ public sealed partial class BulletBoxSystem : EntitySystem
         Dirty(ent);
         UpdateAppearance(ent);
         return true;
+    }
+
+    // CMU14 Method
+    /// <summary>
+    ///     Finds the ammo box prototype that chambers <paramref name="ammoProto"/>, so unloading a
+    ///     vehicle chamber hands back the same shell variant that was loaded.
+    /// </summary>
+    public EntProtoId? GetBoxForAmmo(EntProtoId? ammoProto)
+    {
+        if (ammoProto is not { } proto)
+            return null;
+
+        foreach (var prototype in _prototypes.EnumeratePrototypes<EntityPrototype>())
+        {
+            if (prototype.Abstract)
+                continue;
+
+            if (!prototype.TryComp(out BulletBoxComponent? box, _compFactory))
+                continue;
+
+            if (box.AmmoProto == proto)
+                return prototype.ID;
+        }
+
+        return null;
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/HiveComponent.cs
@@ -114,6 +114,9 @@ public sealed partial class HiveComponent : Component
     public int BurrowedLarva;
 
     [DataField, AutoNetworkedField]
+    public bool BurrowedLarvaEnabled = true; // CMU14
+
+    [DataField, AutoNetworkedField]
     public int BurrowedLarvaSlotFactor = 4;
 
     [DataField, AutoNetworkedField]

--- a/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Hive/SharedXenoHiveSystem.cs
@@ -527,11 +527,30 @@ public abstract partial class SharedXenoHiveSystem : EntitySystem
 
     public void ChangeBurrowedLarva(Entity<HiveComponent> hive, int amount)
     {
+        if (!hive.Comp.BurrowedLarvaEnabled) // CMU14
+            return;
+
         SetHiveBurrowedLarva(hive, hive.Comp.BurrowedLarva + amount);
+    }
+
+    // CMU14 method
+    public void SetBurrowedLarvaEnabled(Entity<HiveComponent> hive, bool enabled)
+    {
+        if (hive.Comp.BurrowedLarvaEnabled == enabled)
+            return;
+
+        hive.Comp.BurrowedLarvaEnabled = enabled;
+        if (!enabled && hive.Comp.BurrowedLarva != 0)
+            SetHiveBurrowedLarva(hive, 0);
+        else
+            Dirty(hive);
     }
 
     public bool HasBurrowedLarvaSpawnPoint(Entity<HiveComponent> hive)
     {
+        if (!hive.Comp.BurrowedLarvaEnabled) // CMU14
+            return false;
+
         return TryGetBurrowedLarvaSpawnPosition(hive, out _);
     }
 
@@ -557,7 +576,8 @@ public abstract partial class SharedXenoHiveSystem : EntitySystem
         if (_net.IsClient)
             return false;
 
-        if (hive.Comp.BurrowedLarva <= 0)
+        if (!hive.Comp.BurrowedLarvaEnabled // CMU14
+            || hive.Comp.BurrowedLarva <= 0)
             return false;
 
         if (!TryGetBurrowedLarvaSpawnPosition(hive, out var position))

--- a/Resources/Maps/_CMU14/HopesRetreatMultiZ/HopesRetreatMultiZ0.yml
+++ b/Resources/Maps/_CMU14/HopesRetreatMultiZ/HopesRetreatMultiZ0.yml
@@ -127974,8 +127974,8 @@ entities:
   - uid: 9734
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 66.5,-12.5
+      rot: 4.71238898038469 rad
+      pos: 123.5,-17.5
       parent: 1
 - proto: AUDepartmentConsoleServices
   entities:
@@ -159590,9 +159590,6 @@ entities:
     - type: Transform
       pos: 122.5,-16.5
       parent: 1
-    - type: AccessReader
-      access:
-      - - CMAccessColonyBrig
 - proto: CMVendorSeeds
   entities:
   - uid: 72077

--- a/Resources/Prototypes/_CMU14/Entities/Structures/Machines/cash_vendors.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Structures/Machines/cash_vendors.yml
@@ -133,47 +133,54 @@
   - type: AU14CashVendor
     allowDepartmentBudget: true
     items:
+    # BASIC
     - id: CMDrinkCanBobdaClassic
-      name: Bobda Classic
       price: 2
     - id: CMDrinkCanBobdaCherry
-      name: Bobda Cherry
       price: 2
     - id: CMDrinkCanBobdaLime
-      name: Bobda Lime
       price: 2
     - id: CMDrinkCanBobdaGrape
-      name: Bobda Grape
       price: 2
     - id: CMDrinkCanBobdaBlue
-      name: Bobda Blue
       price: 2
     - id: CMDrinkCanBobdaPeach
-      name: Bobda Peach
       price: 2
     - id: CMDrinkCanBobdaCranberry
-      name: Bobda Cranberry
       price: 2
     - id: CMDrinkCanBobdaVanilla
-      name: Bobda Vanilla
       price: 2
     - id: CMDrinkCanBobdaPineapple
-      name: Bobda Pineapple
+      price: 2
+    # DIET
+    - id: CMDrinkCanBobdaDiet
       price: 2
     - id: CMDrinkCanBobdaClassicDiet
-      name: Diet Bobda Classic
       price: 2
+    - id: CMDrinkCanBobdaCherryDiet
+      price: 2
+    - id: CMDrinkCanBobdaLimeDiet
+      price: 2
+    - id: CMDrinkCanBobdaGrapeDiet
+      price: 2
+    - id: CMDrinkCanBobdaBlueDiet
+      price: 2
+    - id: CMDrinkCanBobdaPeachDiet
+      price: 2
+    - id: CMDrinkCanBobdaCranberryDiet
+      price: 2
+    - id: CMDrinkCanBobdaVanillaDiet
+      price: 2
+    - id: CMDrinkCanBobdaPineappleDiet
+      price: 2
+    # NON BOBDA
     - id: CMDrinkCanCola
-      name: Space Cola
       price: 2
     - id: CMDrinkCanSoda
-      name: Soda
       price: 2
     - id: CMDrinkCanTonic
-      name: Tonic Water
       price: 2
     - id: CMDrinkCanFruitBeer
-      name: Fruit Beer (NA)
       price: 2
 
 # Snack machine — mirrors CMVendorSnack
@@ -586,7 +593,7 @@
 #     - id: RMCArcadeCircuitboard
 #       amount: 2
 #     - id: RMCAtmosphericConsoleCircuitboard
-#       amount: 2    
+#       amount: 2
 
 # General medical supplies — mirrors AU14GeneralMedicalVendor field supplies + autoinjectors
 - type: entity

--- a/Resources/Prototypes/_CMU14/Entities/Structures/Xeno/Pathogen/sporecaster.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Structures/Xeno/Pathogen/sporecaster.yml
@@ -55,7 +55,7 @@
     raffle:
       settings: short
   - type: GhostRoleMobSpawner
-    availableTakeovers: 2
+    availableTakeovers: 3
     deleteOnSpawn: false
     prototype: CMU14XenoPopper
 

--- a/Resources/Prototypes/_CMU14/RoundSetup/GameModes/game_presets.yml
+++ b/Resources/Prototypes/_CMU14/RoundSetup/GameModes/game_presets.yml
@@ -36,6 +36,7 @@
   showInVote: true
   description: Insurgency mode
   minPlayers: 35
+  burrowedLarvaEnabled: false
   requiresGovforVote: true
   thirdPartyAutoSpawn: true
   thirdPartyInterval: 3600
@@ -95,6 +96,7 @@
   showInVote: true
   maxPlayers: 60
   description: Live in an offworld colony as it falls into chaos.
+  burrowedLarvaEnabled: false
   supportedPlanets:
     - AUPlanetShepherdsPride
 #    - AUPlanetLV327

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Tools/welders.yml
@@ -180,6 +180,7 @@
   name: ME3 hand welder
   description: A compact, handheld welding torch used by the Marines for cutting and welding jobs on the field. Due to the small size and slow strength, its function is limited compared to a full-sized technician's blowtorch.
   components:
+  - type: RequiresEyeProtection # CMU14
   - type: Sprite
     sprite: _RMC14/Objects/Tools/welder_hand.rsi
   - type: Item

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Guns/Rifles/m4spr_rifle.yml
@@ -1,4 +1,4 @@
-﻿- type: entity
+- type: entity
   parent: [ CMBaseWeaponRifle, RMCBaseWeaponMagazineVisuals ]
   name: M4RA battle rifle
   id: WeaponRifleM4SPR
@@ -106,6 +106,8 @@
   - type: Tag
     tags:
     - RMCWeaponRifleM4SPR
+  - type: Corrodible
+    isCorrodible: false
 
 - type: entity
   parent: WeaponRifleM4SPR

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/Vending/vending_machines.yml
@@ -495,7 +495,7 @@
     denyState: deny-unshaded
     ejectState: eject-unshaded
   - type: AccessReader
-    access: [["AU14AccessGovforSecurity"], ["AU14AccessOpforSecurity"], ["CMAccessArmory"]]
+    access: [["AU14AccessGovforSecurity"], ["AU14AccessOpforSecurity"], ["CMAccessArmory"], ["CMAccessBrig"], ["CMAccessColonyBrig"]] # CMU14
 
 - type: vendingMachineInventory
   id: CMVendorSec

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console_special.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console_special.yml
@@ -2,7 +2,7 @@
 - type: entity
   parent: RMCOverwatchConsole
   id: RMCOverwatchConsoleSPP
-  suffix: SPP
+  suffix: UPP
   components:
   - type: OverwatchConsole
     canOrbitalBombardment: false
@@ -11,7 +11,7 @@
 - type: entity
   parent: RMCOverwatchConsoleSPP
   id: RMCOverwatchConsoleSPPRotating
-  suffix: SPP, Rotating
+  suffix: UPP, Rotating
   components:
   - type: Sprite
     overrideDir: South

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console_spp_toc.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Machines/rmc_communications_console_spp_toc.yml
@@ -1,8 +1,8 @@
 - type: entity
   parent: RMCOverwatchConsoleGovfor
   id: RMCOverwatchConsoleSPPTOC
-  name: SPP tactical operations console
-  description: A tactical operations console configured for SPP overwatch duties.
+  name: UPP tactical operations console
+  description: A tactical operations console configured for UPP overwatch duties.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Machines/toc_spp.rsi

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Xeno/Hive/xeno_hive_core.yml
@@ -64,7 +64,7 @@
     raffle:
       settings: short
   - type: GhostRoleMobSpawner
-    availableTakeovers: 2
+    availableTakeovers: 4
     deleteOnSpawn: false
     prototype: CMXenoLesserDrone
   - type: HiveConstructionLimited
@@ -168,7 +168,7 @@
     raffle:
       settings: short
   - type: GhostRoleMobSpawner
-    availableTakeovers: 2
+    availableTakeovers: 3
     deleteOnSpawn: false
     prototype: CMXenoLesserDrone
   - type: HiveConstructionLimited

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/synth.yml
@@ -148,3 +148,6 @@
   - type: Wounded
   - type: RMCSuicide
     damage: { }
+  - type: Respirator # CMU14: stops crit/underwater gasp loop (synths don't breathe)
+    damage: { }
+    damageRecovery: { }

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/spp_hardpoints.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/spp_hardpoints.yml
@@ -12,8 +12,8 @@
 - type: entity
   parent: VehicleSPPAPCHardpointBase
   id: VehicleSPPAPCWheel
-  name: SPP APC wheel
-  description: A reinforced APC wheel produced for SPP vehicles.
+  name: UPP APC wheel
+  description: A reinforced APC wheel produced for UPP vehicles.
   components:
   - type: Sprite
     state: spp_tires
@@ -34,8 +34,8 @@
 - type: entity
   parent: VehicleSPPAPCHardpointBase
   id: VehicleSPPAPCTurret
-  name: SPP APC turret
-  description: A rotating turret mount for an SPP APC.
+  name: UPP APC turret
+  description: A rotating turret mount for an UPP APC.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/sppapc.rsi
@@ -84,8 +84,8 @@
 - type: entity
   parent: RMCAPCDualCannon
   id: VehicleSPPAPCMinigun
-  name: SPP APC minigun
-  description: A minigun fitted to an SPP APC turret.
+  name: UPP APC minigun
+  description: A minigun fitted to an UPP APC turret.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/hardpoints/sppapc.rsi
@@ -122,8 +122,8 @@
 - type: entity
   parent: RMCAPCFrontCannon
   id: VehicleSPPAPCAutocannon
-  name: SPP APC autocannon
-  description: A frontal autocannon hardpoint for an SPP APC.
+  name: UPP APC autocannon
+  description: A frontal autocannon hardpoint for an UPP APC.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/hardpoints/sppapc.rsi
@@ -146,7 +146,7 @@
   parent: VehicleTankTowLauncher
   id: VehicleSPPAPCHJ35Launcher
   name: HJ35 APC launcher
-  description: A missile launcher fitted to the secondary mount of an SPP APC.
+  description: A missile launcher fitted to the secondary mount of an UPP APC.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/hardpoints/sppapc.rsi
@@ -165,8 +165,8 @@
 - type: entity
   parent: RMCAPCFlareLauncher
   id: VehicleSPPAPCFlareLauncher
-  name: SPP APC flare launcher
-  description: A flare launcher hardpoint for SPP APC support slots.
+  name: UPP APC flare launcher
+  description: A flare launcher hardpoint for UPP APC support slots.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/hardpoints/sppapc.rsi

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/spp_interiors.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/spp_interiors.yml
@@ -1,8 +1,8 @@
 - type: entity
   abstract: true
   id: VehicleSPPAPCInteriorBase
-  name: SPP APC interior piece
-  description: A decorative interior piece for an SPP APC.
+  name: UPP APC interior piece
+  description: A decorative interior piece for an UPP APC.
   placement:
     mode: PlaceFree
   components:
@@ -14,7 +14,7 @@
 - type: entity
   abstract: true
   id: VehicleSPPAPCRoofBase
-  name: SPP APC Side Door
+  name: UPP APC Side Door
   placement:
     mode: PlaceFree
   components:
@@ -38,8 +38,8 @@
 - type: entity
   abstract: true
   id: VehicleSPPAPCChassisBase
-  name: SPP APC interior chassis
-  description: A chassis segment for an SPP APC interior.
+  name: UPP APC interior chassis
+  description: A chassis segment for an UPP APC interior.
   placement:
     mode: PlaceFree
   components:
@@ -162,7 +162,7 @@
 - type: entity
   parent: VehicleSPPAPCConsoleBase
   id: VehicleSPPAPCDriverConsole
-  name: SPP APC driver console
+  name: UPP APC driver console
   components:
   - type: Sprite
     state: Driveconsole
@@ -170,7 +170,7 @@
 - type: entity
   parent: VehicleSPPAPCConsoleBase
   id: VehicleSPPAPCDriverConsoleOff
-  name: SPP APC driver console (off)
+  name: UPP APC driver console (off)
   components:
   - type: Sprite
     state: Driveconsole0
@@ -178,7 +178,7 @@
 - type: entity
   parent: VehicleSPPAPCConsoleBase
   id: VehicleSPPAPCDriverConsoleBroken
-  name: SPP APC driver console (broken)
+  name: UPP APC driver console (broken)
   components:
   - type: Sprite
     state: Driveconsoleb
@@ -186,7 +186,7 @@
 - type: entity
   parent: VehicleSPPAPCConsoleBase
   id: VehicleSPPAPCWeaponConsole
-  name: SPP APC weapon console
+  name: UPP APC weapon console
   components:
   - type: Sprite
     state: Weaponconsole
@@ -194,7 +194,7 @@
 - type: entity
   parent: VehicleSPPAPCConsoleBase
   id: VehicleSPPAPCWeaponConsoleOff
-  name: SPP APC weapon console (off)
+  name: UPP APC weapon console (off)
   components:
   - type: Sprite
     state: Weaponconsole0
@@ -202,7 +202,7 @@
 - type: entity
   parent: VehicleSPPAPCConsoleBase
   id: VehicleSPPAPCWeaponConsoleBroken
-  name: SPP APC weapon console (broken)
+  name: UPP APC weapon console (broken)
   components:
   - type: Sprite
     state: Weaponconsoleb
@@ -211,8 +211,8 @@
   abstract: true
   parent: CMClosetBase
   id: VehicleSPPAPCLockerBase
-  name: SPP APC locker
-  description: A storage locker for SPP APC interiors.
+  name: UPP APC locker
+  description: A storage locker for UPP APC interiors.
   placement:
     mode: PlaceFree
   components:
@@ -239,13 +239,13 @@
 - type: entity
   parent: VehicleSPPAPCLockerBase
   id: VehicleSPPAPCLocker
-  name: SPP APC locker
+  name: UPP APC locker
 
 - type: entity
   parent: VehicleInteriorWallMountedBase
   id: VehicleSPPAPCAmmoLoader
-  name: SPP APC ammo loader
-  description: A loader for SPP APC hardpoint ammunition.
+  name: UPP APC ammo loader
+  description: A loader for UPP APC hardpoint ammunition.
   components:
   - type: Sprite
     sprite: _RMC14/Structures/Vehicles/Interiors/sppapc.rsi

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/spp_interiors.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/spp_interiors.yml
@@ -1,8 +1,8 @@
 - type: entity
   abstract: true
   id: VehicleSPPTankInteriorBase
-  name: SPP tank interior piece
-  description: A decorative interior piece for an SPP tank.
+  name: UPP tank interior piece
+  description: A decorative interior piece for an UPP tank.
   placement:
     mode: PlaceFree
   components:
@@ -14,8 +14,8 @@
 - type: entity
   abstract: true
   id: VehicleSPPTankChassisBase
-  name: SPP tank interior chassis
-  description: A chassis segment for an SPP tank interior.
+  name: UPP tank interior chassis
+  description: A chassis segment for an UPP tank interior.
   placement:
     mode: PlaceFree
   components:
@@ -109,8 +109,8 @@
   abstract: true
   parent: CMClosetBase
   id: VehicleSPPTankLockerBase
-  name: SPP tank locker
-  description: A storage locker for SPP tank interiors.
+  name: UPP tank locker
+  description: A storage locker for UPP tank interiors.
   placement:
     mode: PlaceFree
   components:
@@ -137,14 +137,14 @@
 - type: entity
   parent: VehicleSPPTankLockerBase
   id: VehicleSPPTankLocker
-  name: SPP tank locker
+  name: UPP tank locker
 
 - type: entity
   abstract: true
   parent: CMClosetBase
   id: VehicleSPPTankSmallLockerBase
-  name: SPP tank small locker
-  description: A small storage locker for SPP tank interiors.
+  name: UPP tank small locker
+  description: A small storage locker for UPP tank interiors.
   placement:
     mode: PlaceFree
   components:
@@ -171,14 +171,14 @@
 - type: entity
   parent: VehicleSPPTankSmallLockerBase
   id: VehicleSPPTankSmallLocker
-  name: SPP tank small locker
+  name: UPP tank small locker
 
 - type: entity
   abstract: true
   parent: CMClosetBase
   id: VehicleSPPTankSmallLockerAltBase
-  name: SPP tank small locker (alt)
-  description: An alternate small storage locker for SPP tank interiors.
+  name: UPP tank small locker (alt)
+  description: An alternate small storage locker for UPP tank interiors.
   placement:
     mode: PlaceFree
   components:
@@ -205,14 +205,14 @@
 - type: entity
   parent: VehicleSPPTankSmallLockerAltBase
   id: VehicleSPPTankSmallLockerAlt
-  name: SPP tank small locker (alt)
+  name: UPP tank small locker (alt)
 
 - type: entity
   abstract: true
   parent: CMClosetBase
   id: VehicleSPPTankAmmoStorageBase
-  name: SPP tank ammunition storage
-  description: Ammunition storage for SPP tank interiors.
+  name: UPP tank ammunition storage
+  description: Ammunition storage for UPP tank interiors.
   placement:
     mode: PlaceFree
   components:
@@ -239,13 +239,13 @@
 - type: entity
   parent: VehicleSPPTankAmmoStorageBase
   id: VehicleSPPTankAmmoStorage
-  name: SPP tank ammunition storage
+  name: UPP tank ammunition storage
 
 - type: entity
   parent: VehicleInteriorWallMountedBase
   id: VehicleSPPTankAmmoLoader
-  name: SPP tank ammo loader
-  description: A loader for SPP tank hardpoint ammunition.
+  name: UPP tank ammo loader
+  description: A loader for UPP tank hardpoint ammunition.
   components:
   - type: Sprite
     drawdepth: BelowMobs


### PR DESCRIPTION
- **📋 M4SPR/M5RA are no longer meltable**
- **🩹 remove doAfter from basic medical gauze**
- **🩹 exclude paper marked with Trash tag from the nuke:trash cmd**
- **🔧 despawn spent cartridges after cmu.game.spent_casing_despawn_time**
- **🩹 scout cloak wiped by legacy PostShader users; migrate outlines/occlusion to keyed API**
- **📋 more lesser drone spawns**
- **🩹 synths take no toxin/airloss damage and no longer gasp**
- **🩹 ghosted bodies become ghost roles again**
- **🩹 decapped pathogen walkers no longer revive**
- **🩹 fix Suoto/Bobda cans names on the cash vendor**
- **📋 Rename Xenonid -> Xenomorph Hive**
- **🩹 fix welder eye damage never applying on RMC repair flows**
- **🩹 LTB cannon rounds no longer become HESH**
- **📋 rename SPP interiors to UPP interiors BUG-352**
- **🩹 Neutralize SHARP mine before detonation effect**
- **🩹 port burrowed larva preset gate from Rebase, disables it on Insurgency and Colony Fall (BUG-470)**
- **🩹 runechat bubbles now show the language flag (BUG-192)**

**Changelog**
:cl:
- fix: Runechat speech bubbles now also show the language flag
- fix: Synths no longer take toxin/airloss damage and no longer gasp
- fix: Ghosted bodies become ghost roles again!!
- fix: Decapitated pathogen walkers no longer resurrect the head back to life
- fix: Scout cloak is no longer undone by outlines and other FX
- fix: Welder eye damage now applies correctly if you're not wearing protection
- fix: LTB cannon rounds no longer turn into always HESH
- fix: SHARP mines are no longer nuclear explosives
- fix: Fixed Suoto/Bobda can names on the cash vendor
- tweak: M4SPR and M5RA (/2) are no longer meltable
- tweak: Basic medical gauze no longer stops when moving
- tweak: Spent cartridges now despawn after a set time (5 minutes) and removes physics after seconds
- tweak: More lesser drone spawns (and 1 extra popper spawn)
- tweak: Renamed Xenonid to Xenomorph Hive
- tweak: Renamed SPP interiors to UPP interiors
- tweak: Burrowed larva preset no longer appears on Insurgency and Colony Fall
- admin: nuke:trash no longer deletes paper marked with the Trash tag
- fix: Hope's Retreat SecTech vendor access + deputized Security (recruited constables) get the new access also