### PR TITLE
Ports missing hive boons

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Evolution/EvolutionIgnoreGranterComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/EvolutionIgnoreGranterComponent.cs
@@ -1,0 +1,7 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Xenonids.Evolution;
+
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(XenoEvolutionSystem))]
+public sealed partial class EvolutionIgnoreGranterComponent : Component;

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -964,10 +964,6 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
             }
         }
 
-        var ignoreGranter = EntityQueryEnumerator<EvolutionIgnoreGranterComponent>();
-        if (ignoreGranter.MoveNext(out _))
-            hasGranter = true;
-
         var evoBonus = FixedPoint2.Zero;
         var bonuses = EntityQueryEnumerator<EvolutionBonusComponent>();
         while (bonuses.MoveNext(out var comp))

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -7,6 +7,7 @@ using Content.Shared._RMC14.Xenonids.Announce;
 using Content.Shared._RMC14.Xenonids.Egg;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.JoinXeno;
+using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Actions;
 using Content.Shared.Administration.Logs;
@@ -100,6 +101,8 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
         SubscribeLocalEvent<XenoEvolutionGranterComponent, NewXenoEvolvedEvent>(OnGranterEvolved);
 
         SubscribeLocalEvent<XenoOvipositorChangedEvent>(OnOvipositorChanged);
+
+        SubscribeLocalEvent<HiveBoonActivateAdaptabilityEvent>(OnBoonAdaptability);
 
         Subs.BuiEvents<XenoEvolutionComponent>(XenoEvolutionUIKey.Key,
             subs =>
@@ -355,6 +358,49 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
     private void OnGranterEvolved(Entity<XenoEvolutionGranterComponent> ent, ref NewXenoEvolvedEvent args)
     {
         _xenoAnnounce.AnnounceSameHive(ent.Owner, Loc.GetString(ent.Comp.AnnounceMessage));
+    }
+
+    private void OnBoonAdaptability(HiveBoonActivateAdaptabilityEvent ev)
+    {
+        var castes = new List<(EntProtoId Id, int Tier)>();
+        foreach (var prototype in _prototypes.EnumeratePrototypes<EntityPrototype>())
+        {
+            if (!prototype.TryGetComponent(out XenoEvolutionComponent? evolution, _compFactory))
+                continue;
+
+            foreach (var id in evolution.EvolvesTo)
+            {
+                if (_prototypes.TryIndex(id, out var caste) &&
+                    caste.TryGetComponent(out XenoComponent? xeno, _compFactory))
+                {
+                    castes.Add((id, xeno.Tier));
+                }
+            }
+        }
+
+        var xenos = EntityQueryEnumerator<XenoComponent, XenoEvolutionComponent>();
+        while (xenos.MoveNext(out var uid, out var xenoComp, out var comp))
+        {
+            if (_mobState.IsDead(uid) || !_xenoHive.FromSameHive(uid, ev.Boon))
+                continue;
+
+            var self = Prototype(uid)?.ID;
+            foreach (var (id, tier) in castes)
+            {
+                if (tier != xenoComp.Tier ||
+                    id.Id == self ||
+                    comp.EvolvesToWithoutPoints.Contains(id))
+                {
+                    continue;
+                }
+
+                comp.EvolvesToWithoutPoints.Add(id);
+            }
+
+            Dirty(uid, comp);
+        }
+
+        _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has loosened our forms. We may take the shape of another of our rank!");
     }
 
     private void OnOvipositorChanged(ref XenoOvipositorChangedEvent ev)
@@ -917,6 +963,10 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
                 _xenoHive.AnnounceNeedsOvipositorToSameHive(uid);
             }
         }
+
+        var ignoreGranter = EntityQueryEnumerator<EvolutionIgnoreGranterComponent>();
+        if (ignoreGranter.MoveNext(out _))
+            hasGranter = true;
 
         var evoBonus = FixedPoint2.Zero;
         var bonuses = EntityQueryEnumerator<EvolutionBonusComponent>();

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAdaptabilityEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAdaptabilityEvent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[Serializable, NetSerializable]
+public sealed partial class HiveBoonActivateAdaptabilityEvent : HiveBoonEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAggressionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateAggressionEvent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[Serializable, NetSerializable]
+public sealed partial class HiveBoonActivateAggressionEvent : HiveBoonEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateEvolutionEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonActivateEvolutionEvent.cs
@@ -1,0 +1,6 @@
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[Serializable, NetSerializable]
+public sealed partial class HiveBoonActivateEvolutionEvent : HiveBoonEvent;

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonMeleeDamageComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonMeleeDamageComponent.cs
@@ -1,0 +1,17 @@
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.FixedPoint;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._RMC14.Xenonids.ManageHive.Boons;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[Access(typeof(HiveBoonSystem))]
+public sealed partial class HiveBoonMeleeDamageComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public FixedPoint2 Amount = 5;
+
+    [DataField, AutoNetworkedField]
+    public ProtoId<DamageGroupPrototype> DamageGroup = "Brute";
+}

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
@@ -18,11 +18,14 @@ using Content.Shared._RMC14.Xenonids.Construction;
 using Content.Shared._RMC14.Xenonids.Hive;
 using Content.Shared._RMC14.Xenonids.Weeds;
 using Content.Shared.Coordinates;
+using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.GameTicking;
 using Content.Shared.Mind;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Popups;
+using Content.Shared.Roles;
+using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Configuration;
 using Robust.Shared.Map;
 using Robust.Shared.Network;
@@ -87,6 +90,10 @@ public sealed partial class HiveBoonSystem : EntitySystem
         SubscribeLocalEvent<HiveBoonActivateFireResistanceEvent>(OnActivateFireResistance);
         SubscribeLocalEvent<HiveBoonActivateLarvaSurgeEvent>(OnActivateLarvaSurge);
         SubscribeLocalEvent<HiveBoonActivateKingEvent>(OnActivateKing);
+        SubscribeLocalEvent<HiveBoonActivateEvolutionEvent>(OnActivateEvolution);
+        SubscribeLocalEvent<HiveBoonActivateAggressionEvent>(OnActivateAggression);
+
+        SubscribeLocalEvent<GetMeleeDamageEvent>(OnGetMeleeDamage);
 
         SubscribeLocalEvent<XenoComponent, RMCGetFireImmunityEvent>(OnGetTileFireImmunity);
         SubscribeLocalEvent<XenoComponent, GetIgnitionImmunityEvent>(OnGetTileFireIgnitionImmunity);
@@ -164,6 +171,16 @@ public sealed partial class HiveBoonSystem : EntitySystem
         _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has awakened 5 extra burrowed larva to join the hive!");
     }
 
+    private void OnActivateEvolution(HiveBoonActivateEvolutionEvent ev)
+    {
+        _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has hastened our growth. We will mature far quicker!");
+    }
+
+    private void OnActivateAggression(HiveBoonActivateAggressionEvent ev)
+    {
+        _xenoAnnounce.AnnounceSameHiveDefaultSound(ev.Boon, "The Queen has sharpened our claws. Our strikes will land far harder!");
+    }
+
     private void OnActivateKing(HiveBoonActivateKingEvent ev)
     {
         var pylonQuery = EntityQueryEnumerator<HivePylonComponent>();
@@ -204,6 +221,21 @@ public sealed partial class HiveBoonSystem : EntitySystem
         {
             if (_hive.FromSameHive(uid, xeno.Owner))
                 args.Ignite = false;
+        }
+    }
+
+    private void OnGetMeleeDamage(ref GetMeleeDamageEvent args)
+    {
+        if (!HasComp<XenoComponent>(args.User))
+            return;
+
+        var query = EntityQueryEnumerator<HiveBoonMeleeDamageComponent>();
+        while (query.MoveNext(out var uid, out var boon))
+        {
+            if (!_hive.FromSameHive(uid, args.User))
+                continue;
+
+            args.Damage += new DamageSpecifier(_prototype.Index(boon.DamageGroup), boon.Amount);
         }
     }
 

--- a/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
@@ -19,6 +19,78 @@
 
 - type: entity
   parent: RMCHiveBoonBase
+  id: RMCHiveBoonEvolution
+  name: Minor Boon of Evolution
+  description: Doubles evolution speed for 5 minutes.
+  components:
+  - type: HiveBoonDefinition
+    duration: 5m
+    duplicateId: RMCHiveBoonEvolution
+    event: !type:HiveBoonActivateEvolutionEvent
+  - type: EvolutionBonus
+    amount: 0.5
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAggression
+  name: Minor Boon of Aggression
+  description: Increases all xenonid damage by 5 for 5 minutes.
+  components:
+  - type: HiveBoonDefinition
+    duration: 5m
+    duplicateId: RMCHiveBoonAggression
+    event: !type:HiveBoonActivateAggressionEvent
+  - type: HiveBoonMeleeDamage
+    amount: 5
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonEvolutionMajor
+  name: Major Boon of Evolution
+  description: Doubles evolution speed for 10 minutes, and allows evolution progress without an ovipositor.
+  components:
+  - type: HiveBoonDefinition
+    cost: 2
+    pylons: 2
+    duration: 10m
+    unlockAt: 60m
+    duplicateId: RMCHiveBoonEvolutionMajor
+    event: !type:HiveBoonActivateEvolutionEvent
+  - type: EvolutionBonus
+    amount: 0.5
+  - type: EvolutionIgnoreGranter
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAggressionMajor
+  name: Major Boon of Aggression
+  description: Increases all xenonid damage by 10 for 10 minutes.
+  components:
+  - type: HiveBoonDefinition
+    cost: 2
+    pylons: 2
+    duration: 10m
+    unlockAt: 60m
+    duplicateId: RMCHiveBoonAggressionMajor
+    event: !type:HiveBoonActivateAggressionEvent
+  - type: HiveBoonMeleeDamage
+    amount: 10
+
+- type: entity
+  parent: RMCHiveBoonBase
+  id: RMCHiveBoonAdaptability
+  name: Boon of Adaptability
+  description: Allows each xenonid to change to a different caste of the same tier.
+  components:
+  - type: HiveBoonDefinition
+    cost: 2
+    pylons: 2
+    unlockAt: 60m
+    duplicateId: RMCHiveBoonAdaptability
+    event: !type:HiveBoonActivateAdaptabilityEvent
+
+- type: entity
+  parent: RMCHiveBoonBase
   id: RMCHiveBoonLarvaSurge
   name: Surge of Larva
   description: Provides 5 larva instantly to the hive.

--- a/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
+++ b/Resources/Prototypes/_RMC14/Entities/rmc_hive_boons.yml
@@ -10,7 +10,7 @@
   parent: RMCHiveBoonBase
   id: RMCHiveBoonFireResistance
   name: Boon of Fire Resistance
-  description: Makes all xenonids immune to fire for 5 minutes.
+  description: Makes all xenomorphs immune to fire for 5 minutes.
   components:
   - type: HiveBoonDefinition
     duration: 5m
@@ -34,7 +34,7 @@
   parent: RMCHiveBoonBase
   id: RMCHiveBoonAggression
   name: Minor Boon of Aggression
-  description: Increases all xenonid damage by 5 for 5 minutes.
+  description: Increases all xenomorph damage by 5 for 5 minutes.
   components:
   - type: HiveBoonDefinition
     duration: 5m
@@ -64,7 +64,7 @@
   parent: RMCHiveBoonBase
   id: RMCHiveBoonAggressionMajor
   name: Major Boon of Aggression
-  description: Increases all xenonid damage by 10 for 10 minutes.
+  description: Increases all xenomorph damage by 10 for 10 minutes.
   components:
   - type: HiveBoonDefinition
     cost: 2
@@ -80,7 +80,7 @@
   parent: RMCHiveBoonBase
   id: RMCHiveBoonAdaptability
   name: Boon of Adaptability
-  description: Allows each xenonid to change to a different caste of the same tier.
+  description: Allows each xenomorph to change to a different caste of the same tier.
   components:
   - type: HiveBoonDefinition
     cost: 2
@@ -105,7 +105,7 @@
   parent: RMCHiveBoonBase
   id: RMCHiveBoonKing
   name: His Grace
-  description: A huge behemoth of a Xenonid which can tear its way through defences and flesh alike. Requires open space around the hive core to spawn.
+  description: A huge behemoth of a xenomorph which can tear its way through defenses and flesh alike. Requires open space around the hive core to spawn.
   components:
   - type: HiveBoonDefinition
     cost: 0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds the five hive boons that were still missing from the royal resin menu:

   - Minor Boon of Evolution: 1 resin, doubles evolution speed for 5 minutes
   - Minor Boon of Aggression: 1 resin, +5 xenomorph melee damage for 5 minutes
   - Major Boon of Evolution: 2 resin and 2 pylons, doubles evolution speed for 10 minutes and lets evolution progress without an ovipositor
   - Major Boon of Aggression: 2 resin and 2 pylons, +10 xenomorph melee damage for 10 minutes
   - Boon of Adaptability: 2 resin and 2 pylons, lets every xenomorph swap to another caste of its own tier for free

Major boons unlock an hour into the round, like in CM13.

Credit for original PR goes to AitorLogedo on github.

## Why / Balance
Missing xenomorph content

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: The Queen can now buy the Minor and Major Boons of Evolution, the Minor and Major Boons of Aggression, and the Boon of Adaptability with royal resin.