### PR TITLE
Xeno QOL and bugfixes

### DIFF
--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestComponent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestComponent.cs
@@ -11,4 +11,7 @@ public sealed partial class XenoNestComponent : Component
 
     [DataField, AutoNetworkedField]
     public EntityUid? Nested;
+
+    [DataField, AutoNetworkedField]
+    public TimeSpan UnnestDelay = TimeSpan.FromSeconds(3);
 }

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoNestSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.DoAfter;
 using Content.Shared.DragDrop;
 using Content.Shared.Ghost;
 using Content.Shared.Hands.Components;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Interaction;
 using Content.Shared.Interaction.Events;
 using Content.Shared.Inventory.Events;
@@ -34,6 +35,7 @@ using Content.Shared.Popups;
 using Content.Shared.Standing;
 using Content.Shared.Stunnable;
 using Content.Shared.Throwing;
+using Content.Shared.Verbs;
 using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
@@ -94,6 +96,8 @@ public sealed partial class XenoNestSystem : EntitySystem
         SubscribeLocalEvent<XenoNestComponent, ComponentRemove>(OnNestRemove);
         SubscribeLocalEvent<XenoNestComponent, EntityTerminatingEvent>(OnNestTerminating);
         SubscribeLocalEvent<XenoNestComponent, InteractHandEvent>(OnNestInteractHand);
+        SubscribeLocalEvent<XenoNestComponent, GetVerbsEvent<InteractionVerb>>(OnNestGetVerbs);
+        SubscribeLocalEvent<XenoNestComponent, XenoUnnestDoAfterEvent>(OnUnnestDoAfter);
 
         SubscribeLocalEvent<XenoNestableComponent, BeforeRangedInteractEvent>(OnNestableBeforeRangedInteract);
         SubscribeLocalEvent<XenoNestableComponent, ShouldHandleVirtualItemInteractEvent>(OnNestableShouldHandle);
@@ -149,6 +153,65 @@ public sealed partial class XenoNestSystem : EntitySystem
     {
         DetachNested(ent, ent.Comp.Nested);
     }
+
+    private void OnNestGetVerbs(Entity<XenoNestComponent> ent, ref GetVerbsEvent<InteractionVerb> args)
+    {
+        if (!args.CanAccess || !args.CanInteract)
+            return;
+
+        if (ent.Comp.Nested is null)
+            return;
+
+        if (!HasComp<XenoComponent>(args.User) || !_hive.FromSameHive(ent.Owner, args.User))
+            return;
+
+        var user = args.User;
+        var nest = ent.Owner;
+        args.Verbs.Add(new InteractionVerb
+        {
+            Text = Loc.GetString("rmc-xeno-nest-unnest-verb"),
+            Act = () => TryStartUnnest(user, nest),
+        });
+    }
+
+    public bool TryStartUnnest(EntityUid user, Entity<XenoNestComponent?> nest)
+    {
+        if (!Resolve(nest, ref nest.Comp, false) || nest.Comp.Nested is not { } nested)
+            return false;
+
+        var ev = new XenoUnnestDoAfterEvent();
+        var doAfter = new DoAfterArgs(EntityManager, user, nest.Comp.UnnestDelay, ev, nest.Owner, nest.Owner)
+        {
+            BreakOnMove = true,
+            BreakOnDamage = true,
+        };
+
+        if (_doAfter.TryStartDoAfter(doAfter))
+        {
+            var message = Loc.GetString("rmc-xeno-nest-unnest-start", ("target", Identity.Name(nested, EntityManager, user)));
+            _popup.PopupClient(message, user, user);
+        }
+
+        return true;
+    }
+
+    private void OnUnnestDoAfter(Entity<XenoNestComponent> ent, ref XenoUnnestDoAfterEvent args)
+    {
+        if (args.Cancelled || args.Handled)
+            return;
+
+        if (ent.Comp.Nested is not { } nested)
+            return;
+
+        args.Handled = true;
+
+        if (_net.IsClient)
+            return;
+
+        DetachNested(ent.Owner, nested);
+        _adminLog.Add(LogType.RMCXenoNest, $"{ToPrettyString(args.User):user} released {ToPrettyString(nested):victim} from nest {ToPrettyString(ent.Owner):nest}");
+    }
+
 
     private void OnNestInteractHand(Entity<XenoNestComponent> ent, ref InteractHandEvent args)
     {

--- a/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoUnnestDoAfterEvent.cs
+++ b/Content.Shared/_RMC14/Xenonids/Construction/Nest/XenoUnnestDoAfterEvent.cs
@@ -1,0 +1,7 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Xenonids.Construction.Nest;
+
+[Serializable, NetSerializable]
+public sealed partial class XenoUnnestDoAfterEvent : SimpleDoAfterEvent;

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -975,13 +975,6 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
             _xenoHive.AnnounceNeedsOvipositorToSameHive(uid);
         }
 
-        var evoBonus = FixedPoint2.Zero;
-        var bonuses = EntityQueryEnumerator<EvolutionBonusComponent>();
-        while (bonuses.MoveNext(out var comp))
-        {
-            evoBonus += comp.Amount;
-        }
-
         FixedPoint2? evoOverride = null;
         var overrides = EntityQueryEnumerator<EvolutionOverrideComponent>();
         while (overrides.MoveNext(out var comp))
@@ -1010,6 +1003,15 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
                 _audio.PlayEntity(comp.EvolutionReadySound, uid, uid);
                 continue;
             }
+            var evoBonus = FixedPoint2.Zero;
+            var bonuses = EntityQueryEnumerator<EvolutionBonusComponent>();
+
+            while (bonuses.MoveNext(out var bonusUid, out var bonus))
+            {
+                if (_xenoHive.FromSameHive(uid, bonusUid))
+                    evoBonus += bonus.Amount;
+            }
+
             var points = (_earlyEvoBoostBefore > _gameTicker.RoundDuration()) ? comp.EarlyPointsPerSecond : comp.PointsPerSecond;
             var gain = evoOverride ?? points + evoBonus;
             if (comp.Points < comp.Max || roundDuration < _evolutionAccumulatePointsBefore)

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -954,33 +954,25 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
 
         var time = _timing.CurTime;
         var roundDuration = _gameTicker.RoundDuration();
+
         var needsOvipositor = NeedsOvipositor();
-        var hasGranter = needsOvipositor
-            ? HasOvipositor()
-            : HasLiving<XenoEvolutionGranterComponent>(1);
+
+        var granters = EntityQueryEnumerator<XenoEvolutionGranterComponent>();
+        while (granters.MoveNext(out var uid, out var granter))
         {
+            if (granter.GotOvipositorPopup)
+                continue;
 
-            var ignoreGranter = EntityQueryEnumerator<EvolutionIgnoreGranterComponent>();
-            if (ignoreGranter.MoveNext(out _))
-                hasGranter = true;
+            granter.GotOvipositorPopup = true;
+            Dirty(uid, granter);
 
-            var granters = EntityQueryEnumerator<XenoEvolutionGranterComponent>();
-            while (granters.MoveNext(out var uid, out var granter))
-            {
-                if (granter.GotOvipositorPopup)
-                    continue;
+            _popup.PopupEntity("It is time to settle down and let your children grow.",
+                uid,
+                uid,
+                PopupType.LargeCaution
+            );
 
-                granter.GotOvipositorPopup = true;
-                Dirty(uid, granter);
-
-                _popup.PopupEntity("It is time to settle down and let your children grow.",
-                    uid,
-                    uid,
-                    PopupType.LargeCaution
-                );
-
-                _xenoHive.AnnounceNeedsOvipositorToSameHive(uid);
-            }
+            _xenoHive.AnnounceNeedsOvipositorToSameHive(uid);
         }
 
         var evoBonus = FixedPoint2.Zero;
@@ -1022,6 +1014,14 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
             var gain = evoOverride ?? points + evoBonus;
             if (comp.Points < comp.Max || roundDuration < _evolutionAccumulatePointsBefore)
             {
+
+                var hasGranter = needsOvipositor
+                    ? HasOvipositorForXeno(uid)
+                    : HasLiving<XenoEvolutionGranterComponent>(1);
+
+                if (needsOvipositor && HasEvolutionIgnoreGranter(uid))
+                    hasGranter = true;
+
                 if (needsOvipositor && comp.RequiresGranter && !hasGranter)
                     continue;
 
@@ -1032,6 +1032,18 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
                 SetPoints((uid, comp), FixedPoint2.Max(comp.Points - gain, comp.Max));
             }
         }
+    }
+
+    private bool HasEvolutionIgnoreGranter(EntityUid xeno)
+    {
+        var ignoreGranter = EntityQueryEnumerator<EvolutionIgnoreGranterComponent>();
+        while (ignoreGranter.MoveNext(out var uid, out _))
+        {
+            if (_xenoHive.FromSameHive(xeno, uid))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -19,6 +19,8 @@ using Content.Shared.Database;
 using Content.Shared.DoAfter;
 using Content.Shared.Doors.Components;
 using Content.Shared.FixedPoint;
+using Content.Shared.Follower;
+using Content.Shared.Follower.Components;
 using Content.Shared.GameTicking;
 using Content.Shared.GameTicking.Components;
 using Content.Shared.Hands.EntitySystems;
@@ -67,6 +69,7 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
     [Dependency] private SharedHandsSystem _hands = default!;
     [Dependency] private SharedContainerSystem _container = default!;
     [Dependency] private SharedXenoWeedsSystem _xenoWeeds = default!;    [Dependency] private ISharedPlaytimeManager _playtime = default!;
+    [Dependency] private readonly FollowerSystem _follower = default!;
 
     private TimeSpan _evolutionPointsRequireOvipositorAfter;
     private TimeSpan _evolutionAccumulatePointsBefore;
@@ -859,6 +862,15 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
         if (Prototype(xeno)?.ID is { } oldId)
             newRecently.Recent[oldId] = _timing.CurTime;
 
+        var followers = EntityQueryEnumerator<FollowerComponent>();
+        while (followers.MoveNext(out var uid, out var follower))
+        {
+            if (follower.Following == xeno)
+            {
+                _follower.StartFollowingEntity(uid, newXeno);
+            }
+        }
+
         return newXeno;
     }
 
@@ -943,7 +955,9 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
         var time = _timing.CurTime;
         var roundDuration = _gameTicker.RoundDuration();
         var needsOvipositor = NeedsOvipositor();
-        if (needsOvipositor)
+        var hasGranter = needsOvipositor
+            ? HasOvipositor()
+            : HasLiving<XenoEvolutionGranterComponent>(1);
         {
             var granters = EntityQueryEnumerator<XenoEvolutionGranterComponent>();
             while (granters.MoveNext(out var uid, out var granter))
@@ -959,6 +973,10 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
                     uid,
                     PopupType.LargeCaution
                 );
+
+                var ignoreGranter = EntityQueryEnumerator<EvolutionIgnoreGranterComponent>();
+                if (ignoreGranter.MoveNext(out _))
+                    hasGranter = true;
 
                 _xenoHive.AnnounceNeedsOvipositorToSameHive(uid);
             }
@@ -1003,7 +1021,7 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
             var gain = evoOverride ?? points + evoBonus;
             if (comp.Points < comp.Max || roundDuration < _evolutionAccumulatePointsBefore)
             {
-                if (needsOvipositor && comp.RequiresGranter && !HasOvipositorForXeno(uid))
+                if (needsOvipositor && comp.RequiresGranter && !hasGranter)
                     continue;
 
                 SetPoints((uid, comp), comp.Points + gain);

--- a/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Evolution/XenoEvolutionSystem.cs
@@ -959,6 +959,11 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
             ? HasOvipositor()
             : HasLiving<XenoEvolutionGranterComponent>(1);
         {
+
+            var ignoreGranter = EntityQueryEnumerator<EvolutionIgnoreGranterComponent>();
+            if (ignoreGranter.MoveNext(out _))
+                hasGranter = true;
+
             var granters = EntityQueryEnumerator<XenoEvolutionGranterComponent>();
             while (granters.MoveNext(out var uid, out var granter))
             {
@@ -973,10 +978,6 @@ public sealed partial class XenoEvolutionSystem : EntitySystem
                     uid,
                     PopupType.LargeCaution
                 );
-
-                var ignoreGranter = EntityQueryEnumerator<EvolutionIgnoreGranterComponent>();
-                if (ignoreGranter.MoveNext(out _))
-                    hasGranter = true;
 
                 _xenoHive.AnnounceNeedsOvipositorToSameHive(uid);
             }

--- a/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/ManageHive/Boons/HiveBoonSystem.cs
@@ -183,14 +183,15 @@ public sealed partial class HiveBoonSystem : EntitySystem
 
     private void OnActivateKing(HiveBoonActivateKingEvent ev)
     {
+
+        if (ev.Core is not { } core)
+            return;
+
         var pylonQuery = EntityQueryEnumerator<HivePylonComponent>();
         while (pylonQuery.MoveNext(out var uid, out _))
         {
             _area.TrySetCanOrbitalBombardRoofing(uid, false);
         }
-
-        if (ev.Core is not { } core)
-            return;
 
         var cocoon = SpawnAtPosition(KingCocoonId, core.ToCoordinates());
         _hive.SetHive(cocoon, ev.Hive);

--- a/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Rest/XenoRestSystem.cs
@@ -16,6 +16,7 @@ using Content.Shared._RMC14.Xenonids.Sweep;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Actions;
 using Content.Shared.Interaction.Events;
+using Content.Shared.Movement.Components;
 using Content.Shared.Movement.Events;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Popups;
@@ -30,6 +31,7 @@ public sealed partial class XenoRestSystem : EntitySystem
     [Dependency] private SharedAppearanceSystem _appearance = default!;
     [Dependency] private SharedPopupSystem _popup = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private readonly SharedRMCActionsSystem _rmcActions = default!;
 
     public override void Initialize()
     {
@@ -213,5 +215,42 @@ public sealed partial class XenoRestSystem : EntitySystem
     public bool IsResting(Entity<XenoRestingComponent?> ent)
     {
         return Resolve(ent, ref ent.Comp, false);
+    }
+
+    public bool TryRestAction(Entity<XenoComponent?> ent, bool ignoreCooldown = false, bool ignoreEnabled = false)
+    {
+        if (!Resolve(ent, ref ent.Comp, false))
+            return false;
+
+        foreach (var (actionId, actionComp) in _rmcActions.GetActionsWithEvent<XenoRestActionEvent>(ent))
+        {
+            if (actionComp.AttachedEntity != ent.Owner)
+                continue;
+
+            if (!ignoreEnabled && actionComp is not { Enabled: true })
+                continue;
+
+            if (!ignoreCooldown && actionComp.Cooldown.HasValue && actionComp.Cooldown.Value.End > _timing.CurTime)
+                continue;
+
+            _actions.PerformAction(ent.Owner, (actionId, actionComp));
+            return true;
+        }
+
+        // Xeno had no rest action for some reason.
+        return false;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        // If a resting xeno tries to move while resting, unrest them if possible.
+        var query = EntityQueryEnumerator<XenoRestingComponent, InputMoverComponent>();
+        while (query.MoveNext(out var xeno, out var rest, out var mover))
+        {
+            if (rest.Running && mover.HasDirectionalMovement)
+                TryRestAction(xeno);
+        }
     }
 }

--- a/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
+++ b/Content.Shared/_RMC14/Xenonids/Weeds/SharedXenoWeedsSystem.cs
@@ -28,6 +28,7 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Prototypes;
+using Content.Shared.Tag;
 using Content.Shared.Whitelist;
 using Robust.Shared.Configuration;
 using Robust.Shared.Containers;
@@ -70,6 +71,9 @@ public abstract partial class SharedXenoWeedsSystem : EntitySystem
     [Dependency] private SharedXenoAnnounceSystem _xenoAnnounce = default!;
     [Dependency] private WeedboundWallSystem _weedboundWall = default!;
     [Dependency] private DesignerNodeBindingSystem _designerBinding = default!;
+    [Dependency] private readonly TagSystem _tags = default!;
+
+    private static readonly ProtoId<TagPrototype> PlatformTag = "Platform";
 
     private readonly HashSet<EntityUid> _toUpdate = new();
     private readonly HashSet<EntityUid> _intersecting = new();
@@ -629,7 +633,8 @@ public abstract partial class SharedXenoWeedsSystem : EntitySystem
             foreach (var entity in entities)
             {
                 if (!HasComp<ClimbableComponent>(entity) && !HasComp<RMCReactorPoweredLightComponent>(entity) ||
-                    HasComp<BarricadeComponent>(entity))
+                    HasComp<BarricadeComponent>(entity) ||
+                    _tags.HasTag(entity, PlatformTag))
                     continue;
 
                 _popup.PopupClient(Loc.GetString("rmc-xeno-weeds-blocked"),

--- a/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
+++ b/Resources/Locale/en-US/_RMC14/xeno/xeno-nest.ftl
@@ -12,6 +12,9 @@ cm-xeno-nest-failed-cant-there = We can't create a nest there!
 cm-xeno-nest-failed-cant-already-there = There is already someone nested there!
 rmc-xeno-nest-failed-dead = This host is dead.
 
+rmc-xeno-nest-unnest-verb = Release host
+rmc-xeno-nest-unnest-start = We begin working {$target} free from the nest...
+
 cm-xeno-nest-break-out-start-self = You start struggling to free yourself from the resin nest...
 cm-xeno-nest-break-out-start-others = {$user} starts struggling against the resin nest!
 cm-xeno-nest-break-out-struggle-others = {$user} thrashes against the resin, trying to break free!

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Devices/binoculars.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Devices/binoculars.yml
@@ -53,7 +53,7 @@
   description: A military-issued monocular.
   components:
   # Start _CMU14
-  - type: Item 
+  - type: Item
     heldPrefix: monocular
   # End _CMU14
   - type: Sprite
@@ -223,7 +223,7 @@
   - type: PointLight
     enabled: true
     radius: 3
-  - type: RMCNightVisionVisibleInView
+  - type: RMCNightVisionVisible
 
 - type: entity
   parent: RMCRangefinderTarget

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Doors/DoubleDoors/base-double-doors.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Doors/DoubleDoors/base-double-doors.yml
@@ -20,7 +20,7 @@
         mask:
         - FullTileMask
         layer:
-        - FullTileLayer
+        - AirlockLayer
 
 - type: entity
   abstract: true


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ports of qol and bugfixes from RMC. Boon bugfixes by me

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed larva and facehuggers being unable to fit under single-entity double doors.
- tweak: Laser designator lasers are visible through walls with nightvision.
- tweak: Xenos that try to move while resting will now wake up. No more fat-fingering the rest key during combat and paying the price.
- fix: Fixed Major Evolution boon not working when queen was out of ovi.
- fix: Made some boons check for hive, to avoid issues when two or more hives exist at the same time.
- fix: Fixed being unable to weed on tiles with ledges or platforms.
- fix: Fixed ghosts not following xenos after they evolve.
- add: Xenos can now release nested hosts with right click verb. You must target the nest sprite to do this.