### PR TITLE
Add Grenade Detonation Modes

### DIFF
--- a/Content.IntegrationTests/_CMU14/Explosion/CMUGrenadeDetonationTest.cs
+++ b/Content.IntegrationTests/_CMU14/Explosion/CMUGrenadeDetonationTest.cs
@@ -1,6 +1,11 @@
 using Content.Server._CMU14.Explosion;
+using Content.Server.Explosion.EntitySystems;
+using Content.Shared._RMC14.Smoke;
+using Content.Shared.Explosion;
 using Content.Shared.Explosion.Components;
+using Robust.Shared.GameObjects;
 using Robust.Shared.Map;
+using Robust.Shared.Spawners;
 
 namespace Content.IntegrationTests._CMU14.Explosion;
 
@@ -32,6 +37,7 @@ public sealed class CMUGrenadeDetonationTest
                 {
                     Assert.That(mode.Mode, Is.EqualTo(CMUGrenadeDetonationMode.Timed));
                     Assert.That(mode.Armed, Is.False);
+                    Assert.That(mode.ImpactPayloadMultiplier, Is.EqualTo(0.75f));
                     Assert.That(timer.Delay, Is.EqualTo(expectedDelay).Within(0.001f));
                 });
             }
@@ -72,6 +78,163 @@ public sealed class CMUGrenadeDetonationTest
             }
             finally
             {
+                entMan.DeleteEntity(grenade);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ImpactModeReducesExplosionAndFragmentPayloadByTwentyFivePercent()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var system = entMan.System<CMUGrenadeDetonationSystem>();
+            var grenade = entMan.SpawnEntity("CMGrenadeFrag", MapCoordinates.Nullspace);
+
+            try
+            {
+                Assert.That(system.TrySetMode(grenade, CMUGrenadeDetonationMode.Impact), Is.True);
+
+                var explosion = new GetExplosionTriggerPropertiesEvent(110f, 8f);
+                entMan.EventBus.RaiseLocalEvent(grenade, ref explosion);
+
+                var fragments = new GetProjectileGrenadePayloadEvent(48);
+                entMan.EventBus.RaiseLocalEvent(grenade, ref fragments);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(explosion.TotalIntensity, Is.EqualTo(82.5f).Within(0.001f));
+                    Assert.That(explosion.MaxIntensity, Is.EqualTo(6f).Within(0.001f));
+                    Assert.That(fragments.Count, Is.EqualTo(36));
+                    Assert.That(fragments.DamageMultiplier, Is.EqualTo(0.75f).Within(0.001f));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(grenade);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TimedModeLeavesPayloadUnchanged()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var grenade = entMan.SpawnEntity("CMGrenadeFrag", MapCoordinates.Nullspace);
+
+            try
+            {
+                var explosion = new GetExplosionTriggerPropertiesEvent(110f, 8f);
+                entMan.EventBus.RaiseLocalEvent(grenade, ref explosion);
+
+                var fragments = new GetProjectileGrenadePayloadEvent(48);
+                entMan.EventBus.RaiseLocalEvent(grenade, ref fragments);
+
+                var spawn = new GetSpawnOnTriggerPrototypeEvent("RMCSmoke");
+                entMan.EventBus.RaiseLocalEvent(grenade, ref spawn);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(explosion.TotalIntensity, Is.EqualTo(110f));
+                    Assert.That(explosion.MaxIntensity, Is.EqualTo(8f));
+                    Assert.That(fragments.Count, Is.EqualTo(48));
+                    Assert.That(fragments.DamageMultiplier, Is.EqualTo(1f));
+                    Assert.That(spawn.Prototype.ToString(), Is.EqualTo("RMCSmoke"));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(grenade);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task GrenadeOutsideExistingM40ProfileRemainsIneligible()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var system = entMan.System<CMUGrenadeDetonationSystem>();
+            var grenade = entMan.SpawnEntity("CMGrenadeFragOld", MapCoordinates.Nullspace);
+
+            try
+            {
+                var mode = entMan.GetComponent<CMUGrenadeDetonationModeComponent>(grenade);
+                Assert.That(system.TrySetMode(grenade, CMUGrenadeDetonationMode.Impact), Is.False);
+                Assert.That(mode.Mode, Is.EqualTo(CMUGrenadeDetonationMode.Timed));
+            }
+            finally
+            {
+                entMan.DeleteEntity(grenade);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [TestCase("CMGrenadeSmoke", "RMCSmoke", "CMUImpactRMCSmoke", 2, 7.5f)]
+    [TestCase("RMCGrenadeWhitePhosphorus", "RMCSmokePhosphorusWeak", "CMUImpactRMCSmokePhosphorusWeak", 2, 1.5f)]
+    [TestCase("RMCGrenadeWhitePhosphorusCompound", "RMCSmokePhosphorus", "CMUImpactRMCSmokePhosphorus", 2, 3.75f)]
+    [TestCase("CMU14TearGasGrenade", "CMU14TearGas", "CMUImpactTearGas", 1, 9f)]
+    [TestCase("AU14GrenadeNeuroRMC", "AU14GrenadeNeuroGas", "CMUImpactNeuroGas", 3, 9f)]
+    public async Task ImpactSmokeAndChemicalPayloadsUseReducedVariant(
+        string grenadePrototype,
+        string normalPayload,
+        string impactPayload,
+        int expectedRange,
+        float expectedLifetime)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var system = entMan.System<CMUGrenadeDetonationSystem>();
+            var grenade = entMan.SpawnEntity(grenadePrototype, MapCoordinates.Nullspace);
+            var payload = EntityUid.Invalid;
+
+            try
+            {
+                Assert.That(system.TrySetMode(grenade, CMUGrenadeDetonationMode.Impact), Is.True);
+
+                var spawn = new GetSpawnOnTriggerPrototypeEvent(normalPayload);
+                entMan.EventBus.RaiseLocalEvent(grenade, ref spawn);
+                Assert.That(spawn.Prototype.ToString(), Is.EqualTo(impactPayload));
+
+                payload = entMan.SpawnEntity(impactPayload, MapCoordinates.Nullspace);
+                var smoke = entMan.GetComponent<EvenSmokeComponent>(payload);
+                var despawn = entMan.GetComponent<TimedDespawnComponent>(payload);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(smoke.Range, Is.EqualTo(expectedRange));
+                    Assert.That(despawn.Lifetime, Is.EqualTo(expectedLifetime).Within(0.001f));
+                });
+            }
+            finally
+            {
+                if (entMan.EntityExists(payload))
+                    entMan.DeleteEntity(payload);
                 entMan.DeleteEntity(grenade);
             }
         });

--- a/Content.IntegrationTests/_CMU14/Explosion/CMUGrenadeDetonationTest.cs
+++ b/Content.IntegrationTests/_CMU14/Explosion/CMUGrenadeDetonationTest.cs
@@ -1,0 +1,81 @@
+using Content.Server._CMU14.Explosion;
+using Content.Shared.Explosion.Components;
+using Robust.Shared.Map;
+
+namespace Content.IntegrationTests._CMU14.Explosion;
+
+[TestFixture]
+[TestOf(typeof(CMUGrenadeDetonationSystem))]
+public sealed class CMUGrenadeDetonationTest
+{
+    [TestCase("CMGrenadeHighExplosive", 4f)]
+    [TestCase("CMGrenadeFrag", 4f)]
+    [TestCase("CMGrenadeSmoke", 2.5f)]
+    public async Task TargetGrenadesHaveCMUModeAndKeepExistingFuse(
+        string prototype,
+        float expectedDelay)
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var grenade = entMan.SpawnEntity(prototype, MapCoordinates.Nullspace);
+
+            try
+            {
+                var mode = entMan.GetComponent<CMUGrenadeDetonationModeComponent>(grenade);
+                var timer = entMan.GetComponent<OnUseTimerTriggerComponent>(grenade);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(mode.Mode, Is.EqualTo(CMUGrenadeDetonationMode.Timed));
+                    Assert.That(mode.Armed, Is.False);
+                    Assert.That(timer.Delay, Is.EqualTo(expectedDelay).Within(0.001f));
+                });
+            }
+            finally
+            {
+                entMan.DeleteEntity(grenade);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ModeCanChangeBeforeArming()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+
+        await server.WaitAssertion(() =>
+        {
+            var entMan = server.EntMan;
+            var system = entMan.System<CMUGrenadeDetonationSystem>();
+            var grenade = entMan.SpawnEntity("CMGrenadeHighExplosive", MapCoordinates.Nullspace);
+
+            try
+            {
+                var component = entMan.GetComponent<CMUGrenadeDetonationModeComponent>(grenade);
+
+                Assert.That(
+                    system.TrySetMode(grenade, CMUGrenadeDetonationMode.Impact),
+                    Is.True);
+                Assert.That(component.Mode, Is.EqualTo(CMUGrenadeDetonationMode.Impact));
+
+                Assert.That(
+                    system.TrySetMode(grenade, CMUGrenadeDetonationMode.Timed),
+                    Is.True);
+                Assert.That(component.Mode, Is.EqualTo(CMUGrenadeDetonationMode.Timed));
+            }
+            finally
+            {
+                entMan.DeleteEntity(grenade);
+            }
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.cs
@@ -164,11 +164,14 @@ public sealed partial class ExplosionSystem : SharedExplosionSystem
             totalIntensity ??= RadiusToIntensity((float)radius, explosive.IntensitySlope, explosive.MaxIntensity);
         totalIntensity ??= explosive.TotalIntensity;
 
+        var properties = new GetExplosionTriggerPropertiesEvent(totalIntensity.Value, explosive.MaxIntensity);
+        RaiseLocalEvent(uid, ref properties);
+
         QueueExplosion(uid,
             explosive.ExplosionType,
-            (float)totalIntensity,
+            Math.Max(0, properties.TotalIntensity),
             explosive.IntensitySlope,
-            explosive.MaxIntensity,
+            Math.Max(0, properties.MaxIntensity),
             explosive.TileBreakScale,
             explosive.MaxTileBreak,
             explosive.CanCreateVacuum,

--- a/Content.Server/Explosion/EntitySystems/ProjectileGrenadeSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/ProjectileGrenadeSystem.cs
@@ -11,6 +11,16 @@ using Robust.Shared.Random;
 
 namespace Content.Server.Explosion.EntitySystems;
 
+/// <summary>
+/// Raised directed at a projectile grenade before its payload is spawned.
+/// </summary>
+[ByRefEvent]
+public record struct GetProjectileGrenadePayloadEvent(int Count)
+{
+    public int Count = Count;
+    public float DamageMultiplier = 1f;
+}
+
 public sealed partial class ProjectileGrenadeSystem : EntitySystem
 {
     [Dependency] private GunSystem _gun = default!;
@@ -65,6 +75,10 @@ public sealed partial class ProjectileGrenadeSystem : EntitySystem
         var shootCount = 0;
         var totalCount = component.Container.ContainedEntities.Count + component.UnspawnedCount;
 
+        var payload = new GetProjectileGrenadePayloadEvent(totalCount);
+        RaiseLocalEvent(uid, ref payload);
+        totalCount = Math.Clamp(payload.Count, 0, totalCount);
+
         // RMC14 it was sometimes dividing by 0.
         if(totalCount <= 0)
             return;
@@ -73,8 +87,14 @@ public sealed partial class ProjectileGrenadeSystem : EntitySystem
         var segmentAngle = 360 / totalCount;
 
         _spawned.Clear();
-        while (TrySpawnContents(grenadeCoord, component, out var contentUid))
+        while (shootCount < totalCount && TrySpawnContents(grenadeCoord, component, out var contentUid))
         {
+            if (TryComp(contentUid, out ProjectileComponent? projectile))
+            {
+                projectile.Damage *= Math.Max(0, payload.DamageMultiplier);
+                Dirty(contentUid, projectile);
+            }
+
             Angle angle;
             if (component.RandomAngle)
                 angle = _random.NextAngle();
@@ -95,8 +115,9 @@ public sealed partial class ProjectileGrenadeSystem : EntitySystem
                     hitEntities = ev.HitEntities;
                     angle = ev.Angle;
                 }
-                shootCount++;
             }
+
+            shootCount++;
 
             // RMC14
             EntityUid? gunUid = null;

--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -59,6 +59,15 @@ namespace Content.Server.Explosion.EntitySystems
     public record struct BeforeTriggerEvent(EntityUid Triggered, EntityUid? User, bool Cancelled = false);
 
     /// <summary>
+    /// Raised directed at an entity immediately before its SpawnOnTrigger payload is spawned.
+    /// </summary>
+    [ByRefEvent]
+    public record struct GetSpawnOnTriggerPrototypeEvent(EntProtoId Prototype)
+    {
+        public EntProtoId Prototype = Prototype;
+    }
+
+    /// <summary>
     /// Raised when timer trigger becomes active.
     /// </summary>
     [ByRefEvent]
@@ -173,18 +182,20 @@ namespace Content.Server.Explosion.EntitySystems
         private void OnSpawnTrigger(Entity<SpawnOnTriggerComponent> ent, ref TriggerEvent args)
         {
             var xform = Transform(ent);
+            var payload = new GetSpawnOnTriggerPrototypeEvent(ent.Comp.Proto);
+            RaiseLocalEvent(ent.Owner, ref payload);
 
             if (ent.Comp.mapCoords)
             {
                 var mapCoords = _transformSystem.GetMapCoordinates(ent, xform);
-                Spawn(ent.Comp.Proto, mapCoords);
+                Spawn(payload.Prototype, mapCoords);
             }
             else
             {
                 var coords = xform.Coordinates;
                 if (!coords.IsValid(EntityManager))
                     return;
-                Spawn(ent.Comp.Proto, coords);
+                Spawn(payload.Prototype, coords);
 
             }
         }

--- a/Content.Server/_CMU14/Explosion/CMUGrenadeDetonationModeComponent.cs
+++ b/Content.Server/_CMU14/Explosion/CMUGrenadeDetonationModeComponent.cs
@@ -1,0 +1,35 @@
+namespace Content.Server._CMU14.Explosion;
+
+/// <summary>
+/// CMU-owned selectable detonation behavior for compatible grenades.
+/// Timed mode leaves the upstream timer path unchanged.
+/// Impact mode arms the grenade but removes the active countdown.
+/// </summary>
+public enum CMUGrenadeDetonationMode : byte
+{
+    Timed,
+    Impact,
+}
+
+[RegisterComponent]
+[Access(typeof(CMUGrenadeDetonationSystem))]
+public sealed partial class CMUGrenadeDetonationModeComponent : Component
+{
+    /// <summary>
+    /// Selected detonation mode. Existing grenades default to their normal timed behavior.
+    /// </summary>
+    [DataField]
+    public CMUGrenadeDetonationMode Mode = CMUGrenadeDetonationMode.Timed;
+
+    /// <summary>
+    /// True after an Impact-mode grenade has been primed.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public bool Armed;
+
+    /// <summary>
+    /// Best available attribution for the entity that armed/threw/fired the grenade.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public EntityUid? ArmedBy;
+}

--- a/Content.Server/_CMU14/Explosion/CMUGrenadeDetonationModeComponent.cs
+++ b/Content.Server/_CMU14/Explosion/CMUGrenadeDetonationModeComponent.cs
@@ -1,3 +1,5 @@
+using Robust.Shared.Prototypes;
+
 namespace Content.Server._CMU14.Explosion;
 
 /// <summary>
@@ -20,6 +22,20 @@ public sealed partial class CMUGrenadeDetonationModeComponent : Component
     /// </summary>
     [DataField]
     public CMUGrenadeDetonationMode Mode = CMUGrenadeDetonationMode.Timed;
+
+    /// <summary>
+    /// Multiplier applied to payload strength while this grenade is in Impact mode.
+    /// The default of 0.75 represents a 25% reduction.
+    /// </summary>
+    [DataField]
+    public float ImpactPayloadMultiplier = 0.75f;
+
+    /// <summary>
+    /// Optional reduced payload prototype used instead of SpawnOnTrigger's normal
+    /// prototype while this grenade is in Impact mode.
+    /// </summary>
+    [DataField]
+    public EntProtoId? ImpactSpawn;
 
     /// <summary>
     /// True after an Impact-mode grenade has been primed.

--- a/Content.Server/_CMU14/Explosion/CMUGrenadeDetonationSystem.cs
+++ b/Content.Server/_CMU14/Explosion/CMUGrenadeDetonationSystem.cs
@@ -1,4 +1,6 @@
+using Content.Server._RMC14.Trigger;
 using Content.Server.Explosion.EntitySystems;
+using Content.Shared.Explosion;
 using Content.Shared.Explosion.Components;
 using Content.Shared.Popups;
 using Content.Shared.Tag;
@@ -46,7 +48,13 @@ public sealed class CMUGrenadeDetonationSystem : EntitySystem
 
         // True hard collision plus throw-end/ground fallback.
         SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, ThrowDoHitEvent>(OnThrowDoHit);
-        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, StopThrowEvent>(OnStopThrow);
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, StopThrowEvent>(OnStopThrow,
+            after: [typeof(RMCTriggerSystem)]);
+
+        // Apply reduced payload properties only to the current Impact-mode trigger.
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, GetExplosionTriggerPropertiesEvent>(OnGetExplosionProperties);
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, GetProjectileGrenadePayloadEvent>(OnGetProjectilePayload);
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, GetSpawnOnTriggerPrototypeEvent>(OnGetSpawnPayload);
 
         // Always clear CMU runtime state after any trigger path.
         SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, TriggerEvent>(OnTriggered);
@@ -295,6 +303,52 @@ public sealed class CMUGrenadeDetonationSystem : EntitySystem
     {
         ent.Comp.Armed = false;
         ent.Comp.ArmedBy = null;
+    }
+
+    private void OnGetExplosionProperties(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref GetExplosionTriggerPropertiesEvent args)
+    {
+        if (!IsImpactPayload(ent))
+            return;
+
+        var multiplier = GetImpactPayloadMultiplier(ent.Comp);
+        args.TotalIntensity *= multiplier;
+        args.MaxIntensity *= multiplier;
+    }
+
+    private void OnGetProjectilePayload(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref GetProjectileGrenadePayloadEvent args)
+    {
+        if (!IsImpactPayload(ent))
+            return;
+
+        var multiplier = GetImpactPayloadMultiplier(ent.Comp);
+        args.DamageMultiplier *= multiplier;
+
+        if (args.Count > 0)
+            args.Count = Math.Max(1, (int) MathF.Floor(args.Count * multiplier));
+    }
+
+    private void OnGetSpawnPayload(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref GetSpawnOnTriggerPrototypeEvent args)
+    {
+        if (!IsImpactPayload(ent) || ent.Comp.ImpactSpawn is not { } impactSpawn)
+            return;
+
+        args.Prototype = impactSpawn;
+    }
+
+    private bool IsImpactPayload(Entity<CMUGrenadeDetonationModeComponent> ent)
+    {
+        return IsM40Eligible(ent) && ent.Comp.Mode == CMUGrenadeDetonationMode.Impact;
+    }
+
+    private static float GetImpactPayloadMultiplier(CMUGrenadeDetonationModeComponent component)
+    {
+        return Math.Clamp(component.ImpactPayloadMultiplier, 0f, 1f);
     }
 
     /// <summary>

--- a/Content.Server/_CMU14/Explosion/CMUGrenadeDetonationSystem.cs
+++ b/Content.Server/_CMU14/Explosion/CMUGrenadeDetonationSystem.cs
@@ -1,0 +1,331 @@
+using Content.Server.Explosion.EntitySystems;
+using Content.Shared.Explosion.Components;
+using Content.Shared.Popups;
+using Content.Shared.Tag;
+using Content.Shared.Throwing;
+using Content.Shared.Verbs;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._CMU14.Explosion;
+
+/// <summary>
+/// CMU-owned Timed/Impact detonation selector.
+///
+/// The system intentionally does not duplicate HEDP, HEFA, or smoke payload behavior.
+/// Both modes ultimately use the existing TriggerSystem so upstream TriggerEvent consumers
+/// remain authoritative for explosions, fragmentation, smoke, audio, deletion, etc.
+/// </summary>
+public sealed class CMUGrenadeDetonationSystem : EntitySystem
+{
+    [Dependency] private TriggerSystem _trigger = default!;
+    [Dependency] private SharedPopupSystem _popup = default!;
+    [Dependency] private TagSystem _tag = default!;
+
+    private static readonly ProtoId<TagPrototype> M40GrenadeTag = "RMCGrenadeM40";
+
+    // Impact callbacks can be raised while ThrownItemSystem is actively enumerating
+    // ThrownItemComponent + PhysicsComponent. Never trigger/delete the grenade from
+    // inside those callbacks; process it after the callback stack unwinds.
+    private readonly Dictionary<EntityUid, EntityUid?> _pendingImpactDetonations = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        // Right-click mode selector.
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, GetVerbsEvent<AlternativeVerb>>(OnGetVerbs);
+
+        // BeforeUseTimerTriggerEvent is raised as a broadcast event by TriggerSystem.OnUse.
+        SubscribeLocalEvent<BeforeUseTimerTriggerEvent>(OnBeforeUseTimerTrigger);
+
+        // Covers both hand priming and the existing RMC grenade-launcher timer path.
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, ActiveTimerTriggerEvent>(OnActiveTimerTrigger);
+
+        // Keep the best user attribution available once the grenade is actually thrown.
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, ThrownEvent>(OnThrown);
+
+        // True hard collision plus throw-end/ground fallback.
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, ThrowDoHitEvent>(OnThrowDoHit);
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, StopThrowEvent>(OnStopThrow);
+
+        // Always clear CMU runtime state after any trigger path.
+        SubscribeLocalEvent<CMUGrenadeDetonationModeComponent, TriggerEvent>(OnTriggered);
+    }
+
+    private void OnGetVerbs(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref GetVerbsEvent<AlternativeVerb> args)
+    {
+        if (!IsM40Eligible(ent) ||
+            !args.CanInteract ||
+            !args.CanAccess ||
+            args.Hands == null)
+        {
+            return;
+        }
+
+        var next = ent.Comp.Mode == CMUGrenadeDetonationMode.Timed
+            ? CMUGrenadeDetonationMode.Impact
+            : CMUGrenadeDetonationMode.Timed;
+
+        var nextName = GetModeName(next);
+        var locked = IsModeLocked(ent);
+
+        // Do not capture the ref event argument in the verb callback.
+        var user = args.User;
+        var uid = ent.Owner;
+        var component = ent.Comp;
+
+        args.Verbs.Add(new AlternativeVerb
+        {
+            Text = Loc.GetString("cmu-grenade-detonation-mode-toggle", ("mode", nextName)),
+            Disabled = locked,
+            Priority = 1,
+            Act = () => TrySetMode(uid, next, user, component),
+        });
+    }
+
+    /// <summary>
+    /// Public CMU API for changing grenade detonation mode.
+    /// Mode changes are rejected after the grenade has been armed or a timer is active.
+    /// </summary>
+    public bool TrySetMode(
+        EntityUid uid,
+        CMUGrenadeDetonationMode mode,
+        EntityUid? user = null,
+        CMUGrenadeDetonationModeComponent? component = null)
+    {
+        if (!Resolve(uid, ref component, false) || !IsM40Eligible(uid))
+            return false;
+
+        if (IsModeLocked((uid, component)))
+        {
+            if (user != null)
+            {
+                _popup.PopupEntity(
+                    Loc.GetString("cmu-grenade-detonation-mode-locked"),
+                    uid,
+                    user.Value);
+            }
+
+            return false;
+        }
+
+        component.Mode = mode;
+
+        if (user != null)
+        {
+            _popup.PopupEntity(
+                Loc.GetString(
+                    "cmu-grenade-detonation-mode-set",
+                    ("mode", GetModeName(mode))),
+                uid,
+                user.Value);
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Prevents re-arming an already armed Impact-mode grenade.
+    ///
+    /// IMPORTANT: This handler intentionally does NOT start the timer for a newly
+    /// primed Impact grenade. The normal TriggerSystem.OnUse flow must remain in
+    /// control so every existing arming veto (including the pre-emergency/peace
+    /// restriction) gets a chance to cancel BeforeUseTimerTriggerEvent.
+    ///
+    /// If no upstream rule cancels the use, TriggerSystem starts the normal timer
+    /// and raises ActiveTimerTriggerEvent. OnActiveTimerTrigger then converts that
+    /// approved timer into CMU Impact mode by removing the countdown.
+    /// </summary>
+    private void OnBeforeUseTimerTrigger(ref BeforeUseTimerTriggerEvent args)
+    {
+        if (args.Cancelled ||
+            !IsM40Eligible(args.Timer) ||
+            !TryComp(args.Timer, out CMUGrenadeDetonationModeComponent? mode) ||
+            mode.Mode != CMUGrenadeDetonationMode.Impact)
+        {
+            return;
+        }
+
+        // Do not permit repeated use after an impact grenade has already been
+        // approved and armed. For the first use, do nothing here and allow the
+        // upstream timer pipeline (and all of its rule checks) to continue.
+        if (mode.Armed)
+            args.Cancelled = true;
+    }
+
+    /// <summary>
+    /// Converts an APPROVED timer activation on an Impact-mode grenade into
+    /// impact arming.
+    ///
+    /// This event is deliberately the authorization boundary for Impact mode:
+    /// if the normal grenade-use pipeline is vetoed (for example by the
+    /// pre-emergency/peace restriction), ActiveTimerTriggerEvent never occurs and
+    /// the grenade never becomes armed.
+    ///
+    /// This also keeps the existing RMC grenade-launcher path working without
+    /// editing RMCTriggerSystem: the launcher starts its normal timer, this handler
+    /// sees ActiveTimerTriggerEvent, and CMU removes the countdown.
+    /// </summary>
+    private void OnActiveTimerTrigger(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref ActiveTimerTriggerEvent args)
+    {
+        if (!IsM40Eligible(ent) ||
+            ent.Comp.Mode != CMUGrenadeDetonationMode.Impact)
+        {
+            return;
+        }
+
+        if (!ent.Comp.Armed)
+        {
+            ent.Comp.Armed = true;
+            ent.Comp.ArmedBy = args.User;
+        }
+        else if (ent.Comp.ArmedBy == null && args.User != null)
+        {
+            ent.Comp.ArmedBy = args.User;
+        }
+
+        // Deferred removal lets all ActiveTimerTriggerEvent subscribers observe
+        // the same normal priming event/component before the countdown disappears.
+        RemCompDeferred<ActiveTimerTriggerComponent>(ent);
+    }
+
+    private void OnThrown(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref ThrownEvent args)
+    {
+        if (!IsM40Eligible(ent) ||
+            ent.Comp.Mode != CMUGrenadeDetonationMode.Impact ||
+            !ent.Comp.Armed ||
+            args.User == null)
+        {
+            return;
+        }
+
+        ent.Comp.ArmedBy = args.User;
+    }
+
+    private void OnThrowDoHit(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref ThrowDoHitEvent args)
+    {
+        if (!IsM40Eligible(ent) ||
+            ent.Comp.Mode != CMUGrenadeDetonationMode.Impact ||
+            !ent.Comp.Armed)
+        {
+            return;
+        }
+
+        QueueImpactDetonation(ent, ent.Comp.ArmedBy ?? args.Component.Thrower);
+    }
+
+    private void OnStopThrow(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref StopThrowEvent args)
+    {
+        if (!IsM40Eligible(ent) ||
+            ent.Comp.Mode != CMUGrenadeDetonationMode.Impact ||
+            !ent.Comp.Armed)
+        {
+            return;
+        }
+
+        // StopThrowEvent is raised while ThrownItemSystem may still be inside its
+        // EntityQueryEnumerator. Queue the trigger instead of detonating inline.
+        QueueImpactDetonation(ent, ent.Comp.ArmedBy);
+    }
+
+    private void QueueImpactDetonation(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        EntityUid? user)
+    {
+        if (!IsM40Eligible(ent) ||
+            ent.Comp.Mode != CMUGrenadeDetonationMode.Impact ||
+            !ent.Comp.Armed ||
+            TerminatingOrDeleted(ent))
+        {
+            return;
+        }
+
+        // Clear immediately so ThrowDoHit -> StopThrow cannot enqueue twice.
+        ent.Comp.Armed = false;
+        ent.Comp.ArmedBy = null;
+
+        _pendingImpactDetonations[ent.Owner] = user;
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_pendingImpactDetonations.Count == 0)
+            return;
+
+        // Snapshot + clear first. Trigger() can raise more events or delete entities.
+        var pending = new List<KeyValuePair<EntityUid, EntityUid?>>(_pendingImpactDetonations);
+        _pendingImpactDetonations.Clear();
+
+        foreach (var entry in pending)
+        {
+            var uid = entry.Key;
+            var user = entry.Value;
+
+            if (TerminatingOrDeleted(uid) ||
+                !IsM40Eligible(uid) ||
+                !TryComp(uid, out CMUGrenadeDetonationModeComponent? mode) ||
+                mode.Mode != CMUGrenadeDetonationMode.Impact)
+            {
+                continue;
+            }
+
+            // The launcher/hand priming path should already have removed this
+            // deferred, but make certain no countdown can fire after impact.
+            RemComp<ActiveTimerTriggerComponent>(uid);
+
+            _trigger.Trigger(uid, user);
+        }
+    }
+
+    private void OnTriggered(
+        Entity<CMUGrenadeDetonationModeComponent> ent,
+        ref TriggerEvent args)
+    {
+        ent.Comp.Armed = false;
+        ent.Comp.ArmedBy = null;
+    }
+
+    /// <summary>
+    /// Selectable detonation is restricted to the RMC M40 / 30mm grenade family.
+    /// This remains authoritative even if the CMU component is inherited by a
+    /// legacy grenade prototype such as an M15 or M12.
+    /// </summary>
+    private bool IsM40Eligible(EntityUid uid)
+    {
+        return _tag.HasTag(uid, M40GrenadeTag);
+    }
+
+    private bool IsM40Eligible(Entity<CMUGrenadeDetonationModeComponent> ent)
+    {
+        return IsM40Eligible(ent.Owner);
+    }
+
+    private bool IsModeLocked(Entity<CMUGrenadeDetonationModeComponent> ent)
+    {
+        return ent.Comp.Armed || HasComp<ActiveTimerTriggerComponent>(ent);
+    }
+
+    private string GetModeName(CMUGrenadeDetonationMode mode)
+    {
+        return mode switch
+        {
+            CMUGrenadeDetonationMode.Timed =>
+                Loc.GetString("cmu-grenade-detonation-mode-timed"),
+            CMUGrenadeDetonationMode.Impact =>
+                Loc.GetString("cmu-grenade-detonation-mode-impact"),
+            _ => mode.ToString(),
+        };
+    }
+}

--- a/Content.Shared/Explosion/ExplosionEvents.cs
+++ b/Content.Shared/Explosion/ExplosionEvents.cs
@@ -4,6 +4,18 @@ using Content.Shared.Inventory;
 namespace Content.Shared.Explosion;
 
 /// <summary>
+/// Raised directed at an explosive immediately before its explosion is queued.
+/// Allows entity-specific systems to adjust the strength of that single explosion
+/// without mutating the explosive component or its prototype.
+/// </summary>
+[ByRefEvent]
+public record struct GetExplosionTriggerPropertiesEvent(float TotalIntensity, float MaxIntensity)
+{
+    public float TotalIntensity = TotalIntensity;
+    public float MaxIntensity = MaxIntensity;
+}
+
+/// <summary>
 ///     Raised directed at an entity to determine its explosion resistance, probably right before it is about to be
 ///     damaged by one.
 /// </summary>

--- a/Resources/Locale/en-US/_CMU14/grenade-detonation.ftl
+++ b/Resources/Locale/en-US/_CMU14/grenade-detonation.ftl
@@ -1,0 +1,6 @@
+cmu-grenade-detonation-mode-timed = timed
+cmu-grenade-detonation-mode-impact = impact
+
+cmu-grenade-detonation-mode-toggle = Set detonation mode: {$mode}
+cmu-grenade-detonation-mode-set = Detonation mode set to {$mode}.
+cmu-grenade-detonation-mode-locked = The detonation mode cannot be changed after the grenade is armed.

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/RMC/Throwable/grenades.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/RMC/Throwable/grenades.yml
@@ -41,6 +41,8 @@
   description: A small grenade containing a vial of deadly nerve gas. Usually knocks out the targets for long enough to allow RMCs to take them out. You can almost hear your Instructor's screaming in the back of your head, mentioning something about a gas mask. It is set to detonate in 3.5 seconds.
   suffix: RM
   components:
+  - type: CMUGrenadeDetonationMode
+    impactSpawn: CMUImpactNeuroGas
   - type: Sprite
     sprite: _AU14/Weapons/Grenades/RMC/HSDP.rsi
   - type: SpawnOnTrigger

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Shared/grenade_detonation_payloads.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Shared/grenade_detonation_payloads.yml
@@ -1,0 +1,56 @@
+- type: entity
+  parent: RMCSmoke
+  id: CMUImpactRMCSmoke
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 7.5
+  - type: EvenSmoke
+    spawn: CMUImpactRMCSmoke
+    range: 2
+
+- type: entity
+  parent: RMCSmokePhosphorusWeak
+  id: CMUImpactRMCSmokePhosphorusWeak
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 1.5
+  - type: EvenSmoke
+    spawn: RMCSmokePhosphorusNoSpreadWeak
+    initialSpread: 2
+    range: 2
+
+- type: entity
+  parent: RMCSmokePhosphorus
+  id: CMUImpactRMCSmokePhosphorus
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 3.75
+  - type: EvenSmoke
+    spawn: RMCSmokePhosphorusNoSpreadStrong
+    initialSpread: 2
+    range: 2
+
+- type: entity
+  parent: CMU14TearGas
+  id: CMUImpactTearGas
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 9
+  - type: EvenSmoke
+    spawn: CMUImpactTearGas
+    range: 1
+
+- type: entity
+  parent: AU14GrenadeNeuroGas
+  id: CMUImpactNeuroGas
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: TimedDespawn
+    lifetime: 9
+  - type: EvenSmoke
+    spawn: CMUImpactNeuroGas
+    range: 3

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Shared/teargas_grenade.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Shared/teargas_grenade.yml
@@ -6,6 +6,8 @@
   name: M19-NL gas grenade
   description: Sometimes referred to as the "Fogger", the M19 nonlethal gas grenade was intended for boarding actions against pirate vessels or putting down civil unrest, saturating spaces with an irritating aerosol with temporary neuromuscular effects.
   components:
+  - type: CMUGrenadeDetonationMode
+    impactSpawn: CMUImpactTearGas
   - type: Sprite
     sprite: _CMU14/Objects/Weapons/Grenades/M19TearGas.rsi
   - type: SpawnOnTrigger

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -31,6 +31,7 @@
   abstract: true
   id: RMCM40DPTags
   components:
+  - type: CMUGrenadeDetonationMode
   - type: Tag
     tags:
     - Grenade
@@ -327,6 +328,7 @@
   name: M07 Training Grenade
   description: A harmless reusable version of the 30mm HEDP, used for training. Capable of being loaded into a grenade launcher, or thrown by hand.
   components:
+  - type: CMUGrenadeDetonationMode
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Grenades/m07training.rsi
   - type: SoundOnTrigger

--- a/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -100,6 +100,8 @@
   name: 30mm HSDP smoke grenade
   description: The 30mm HSDP is a small, but powerful smoke grenade. Based off the same platform as the 30mm HEDP. It is set to detonate in 2.5 seconds.
   components:
+  - type: CMUGrenadeDetonationMode
+    impactSpawn: CMUImpactRMCSmoke
   - type: OnUseTimerTrigger
     delay: 2.5
   - type: Sprite
@@ -367,6 +369,8 @@
   name: 30mm WPDP white phosphorus grenade
   description: The 30mm WPDP is a small, but powerful phosphorus grenade. It is set to detonate in 2 seconds.
   components:
+  - type: CMUGrenadeDetonationMode
+    impactSpawn: CMUImpactRMCSmokePhosphorusWeak
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Grenades/m40wpdp.rsi
   - type: OnUseTimerTrigger
@@ -388,6 +392,8 @@
   name: 30mm CCDP chemical compound grenade
   description: The 30mm CCDP is a small, but powerful chemical compound grenade, similar in effect to WPDP. Word on the block says that the CCDP doesn't actually release White Phosphorus, but some other chemical developed in We-Ya labs.
   components:
+  - type: CMUGrenadeDetonationMode
+    impactSpawn: CMUImpactRMCSmokePhosphorus
   - type: Sprite
     sprite: _RMC14/Objects/Weapons/Grenades/ied.rsi
   - type: SpawnOnTrigger


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
HEDP and all other 30mm class grenades under the same type have been given the ability to cycle between their normal timed detonation state, and a more volatile, impact detonation state. Which will cause the grenade to instantly release its payload upon the throw cycle ending, or upon hitting an object.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This was a change to make grenades more lore accurate, as 30mm HEDP and other classes all had a multi-fuse selector system. Ontop of this, grenades are now FAR more effective, as users can toggle impact modes and remove the window for reaction on many strong grenade types. This may require tweaking in the future depending on how strong this turns out to be.
## Technical details
<!-- Summary of code changes for easier review. -->
Added CMUGrenadeDetonationMode.cs, edited RMC_14 grenades.yml file to create the CMUGreandeDetonationMode tag.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

https://github.com/user-attachments/assets/b8aa58db-167b-4abc-847d-5822c4062d05



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: Operator
- add: Grenade Detonation Modes [Impact+Timed]
- tweak: Gave all 30mm grenade types the GrenadeDetonationMode tag, allowing all 30mm base types [starting with HEDP] to toggle between an impact mode and explosive mode.