### PR TITLE
Make abomination infection silent and hidden for colony infiltration

### DIFF
--- a/Content.Client/StatusIcon/StatusIconSystem.cs
+++ b/Content.Client/StatusIcon/StatusIconSystem.cs
@@ -125,8 +125,21 @@ public sealed partial class StatusIconSystem : SharedStatusIconSystem
         if (viewer == ent.Owner)
             return true;
 
-        if (data.VisibleToGhosts && HasComp<GhostComponent>(viewer))
-            return true;
+        if (viewer is { } viewerUid && TryComp<GhostComponent>(viewerUid, out var ghost))
+        {
+            bool adminGhost = ghost.CanGhostInteract;
+
+            // Regular dead-player ghosts see the icon only when VisibleToGhosts
+            // is set.
+            if (data.VisibleToGhosts && !adminGhost)
+                return true;
+
+            // Admin ghosts (aghost) see it when either flag is set. Historically
+            // VisibleToGhosts covered everyone; VisibleToAdminGhosts lets an
+            // icon be admin-ghost-only.
+            if (adminGhost && (data.VisibleToGhosts || data.VisibleToAdminGhosts))
+                return true;
+        }
 
         if (data.HideInContainer && (ent.Comp.Flags & MetaDataFlags.InContainer) != 0)
             return false;

--- a/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationInfectionSystem.cs
+++ b/Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationInfectionSystem.cs
@@ -1,17 +1,13 @@
+using Content.Server.Chat;
 using Content.Server.Chat.Systems;
-using Content.Server.Medical;
 using Content.Server.Polymorph.Systems;
 using Content.Shared._RMC14.Synth;
-using Content.Shared.Chat.Prototypes;
 using Content.Shared.Damage;
-using Content.Shared.Drunk;
 using Content.Shared.EntityEffects;
 using Content.Shared.Humanoid;
-using Content.Shared.Jittering;
 using Content.Shared.Mobs;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Polymorph;
-using Content.Shared.StatusEffect;
 using Content.Shared.Weapons.Melee.Events;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
@@ -29,31 +25,28 @@ namespace Content.Server._CMU14.Threats.Mobs.Abomination;
 
 /// <summary>
 ///     Abomination melee hits roll AbominationComponent.InfectionChance against
-///     each humanoid hit. Once infected the victim ramps from light coughs and
-///     drunkenness up to constant seizures and vomiting over CrescendoAfter
-///     minutes. Any infected death polymorphs the body into a mimic and seeds
-///     flesh kudzu at the corpse.
+///     each humanoid hit. The infection is silent: no cough, no jitter, no
+///     vomit, no drunkenness, no scream. It still kills quietly — a flat poison
+///     tick drains the host — but gives no visible warning. Any death while
+///     infected, regardless of cause, polymorphs the body into an abomination
+///     and seeds flesh kudzu at the corpse. The fear comes from the not
+///     knowing: the colony falls to its own paranoia, not to a visible disease.
 /// </summary>
 public sealed partial class AbominationInfectionSystem : EntitySystem
 {
     [Dependency] private AbominationAssimilateSystem _assimilate = default!;
-    [Dependency] private ChatSystem _chat = default!;
     [Dependency] private DamageableSystem _damageable = default!;
-    [Dependency] private SharedJitteringSystem _jitter = default!;
+    [Dependency] private EmoteOnDamageSystem _emoteOnDamage = default!;
     [Dependency] private MobStateSystem _mobState = default!;
     [Dependency] private PolymorphSystem _polymorph = default!;
     [Dependency] private IRobustRandom _random = default!;
-    [Dependency] private StatusEffectQuerySystem _statusEffects = default!;
     [Dependency] private IGameTiming _timing = default!;
     [Dependency] private SharedTransformSystem _transform = default!;
-    [Dependency] private VomitSystem _vomit = default!;
-    [Dependency] private SharedDrunkSystem _drunk = default!;
     public static readonly EntProtoId FleshKudzuSource = "AU14AbominationFleshKudzuSource";
     public static readonly ProtoId<PolymorphPrototype> TurnIntoMimic = "AbominationAssimilationToMimic";
     public static readonly ProtoId<PolymorphPrototype> TurnIntoSkitter = "AbominationAssimilationToSkitter";
     public static readonly ProtoId<PolymorphPrototype> TurnIntoSpider = "AbominationAssimilationToSpider";
-    public static readonly ProtoId<EmotePrototype> CoughEmote = "Cough";
-    public static readonly ProtoId<EmotePrototype> ScreamEmote = "Scream";
+    public const string HumanScreamEmote = "Scream";
 
     public override void Initialize()
     {
@@ -69,64 +62,34 @@ public sealed partial class AbominationInfectionSystem : EntitySystem
             = EntityQueryEnumerator<AbominationInfectionComponent>();
         while (query.MoveNext(out EntityUid uid, out AbominationInfectionComponent? infection))
         {
-            // Auto-cure: if the host survives long enough the infection burns itself out.
-            if (now - infection.InfectedAt >= infection.CureAfter)
-            {
-                if (!_mobState.IsDead(uid)) RemComp<AbominationInfectionComponent>(uid);
-
-                continue;
-            }
-
-            float severity = GetSeverity(infection, now);
-            if (severity > 0 && !infection.HasShownSymptoms)
-            {
-                infection.HasShownSymptoms = true;
-                Dirty(uid, infection);
-            }
-
-            if (severity >= 1f && !infection.HasCrescendoed)
-            {
-                infection.HasCrescendoed = true;
-                _chat.TryEmoteWithChat(uid, ScreamEmote);
-                Dirty(uid, infection);
-            }
-
-            // Flat poison tick — damage is not scaled by severity so it hits
-            // hard from the moment of infection. Drunk scales with severity.
+            // Silent poison tick — no emote, no popup, just a quiet health
+            // drain that eventually kills the host. Nobody watching can tell
+            // who is infected; the first visible sign is the corpse turning.
             if (now >= infection.NextTickAt)
             {
                 infection.NextTickAt = now + infection.TickInterval;
+
+                // Suppress the automatic damage-scream for this tick only.
+                // The poison must stay silent, but a real hit (shot/stab)
+                // should still make the host scream normally. Only restore the
+                // emote if we actually removed it, so we never invent a scream
+                // for a mob that never had one.
+                bool removedScream = false;
+                if (TryComp<EmoteOnDamageComponent>(uid, out var emoteOnDamage))
+                    removedScream = _emoteOnDamage.RemoveEmote(uid, HumanScreamEmote, emoteOnDamage, false);
+
                 _damageable.TryChangeDamage(uid, infection.TickDamage, true);
-                _statusEffects.TryAddStatusEffect<DrunkComponent>(uid, SharedDrunkSystem.DrunkKey,
-                    infection.DrunkPerTick * severity, true);
+
+                if (removedScream)
+                    _emoteOnDamage.AddEmote(uid, HumanScreamEmote, emoteOnDamage);
             }
 
-            // Coughing — interval shrinks as severity rises.
-            if (now >= infection.NextCoughAt)
-            {
-                TimeSpan coughInterval = AbominationInfectionSystem.Lerp(infection.CoughIntervalEarly,
-                    infection.CoughIntervalLate, severity);
-                infection.NextCoughAt = now + coughInterval;
-                _chat.TryEmoteWithChat(uid, CoughEmote);
-            }
+            // Silent auto-cure: survive long enough and the marker burns out.
+            if (now - infection.InfectedAt < infection.CureAfter)
+                continue;
 
-            // Jitter — interval shrinks aggressively as severity rises so it
-            // becomes near-constant near crescendo.
-            if (now >= infection.NextJitterAt)
-            {
-                TimeSpan jitterInterval = AbominationInfectionSystem.Lerp(infection.JitterIntervalEarly,
-                    infection.JitterIntervalLate, severity);
-                infection.NextJitterAt = now + jitterInterval;
-                TimeSpan burst = TimeSpan.FromSeconds(2 + 4 * severity);
-                _jitter.DoJitter(uid, burst, true, 6 + 16 * severity, 8 + 8 * severity);
-            }
-
-            // Vomiting only kicks in past the threshold and accelerates with severity.
-            if (severity >= infection.VomitSeverityThreshold && now >= infection.NextVomitAt)
-            {
-                infection.NextVomitAt = now + infection.VomitInterval;
-                _vomit.Vomit(uid);
-            }
+            if (!_mobState.IsDead(uid))
+                RemComp<AbominationInfectionComponent>(uid);
         }
     }
 
@@ -191,24 +154,28 @@ public sealed partial class AbominationInfectionSystem : EntitySystem
         TimeSpan now = _timing.CurTime;
         var infection = EnsureComp<AbominationInfectionComponent>(target);
         infection.InfectedAt = now;
-        infection.NextTickAt = now; // apply first poison tick immediately
-        infection.NextCoughAt = now + infection.CoughIntervalEarly;
-        infection.NextJitterAt = now + infection.JitterIntervalEarly;
+        infection.NextTickAt = now; // apply the first silent poison tick immediately
 
-        // Heavy flat poison — enough to kill an unassisted host in ~3 minutes
-        // (30 ticks × 8 Toxin = 240 damage over 3 min at 6 s/tick).
+        // Flat poison — kills an unassisted host in ~3 minutes. RMC humans die
+        // at 275 total damage (crit at 200), so 9 Poison every 6 s crosses the
+        // death threshold on the 31st tick at t = 180 s. Crit hits earlier,
+        // at ~2:10.
+        // Must be the damage *type* "Poison" — "Toxin" is a damage *group*
+        // (Poison + Radiation) and DamageableSystem only applies per-type keys.
         infection.TickDamage = new();
-        infection.TickDamage.DamageDict["Toxin"] = 8;
+        infection.TickDamage.DamageDict["Poison"] = 9;
         Dirty(target, infection);
     }
 
     /// <summary>
-    ///     Once the victim has shown any symptoms, dying turns them into an
-    ///     abomination regardless of cause — the threat reclaims the body.
-    ///     Flesh kudzu is seeded at the corpse coords before polymorph swaps the
-    ///     entity, and the victim's identity profile is pushed into the shared
-    ///     mimic pool so other mimics can wear their face. Humanoids 50/50 roll
-    ///     between mimic and skitter; animals always turn into a spider.
+    ///     Once the victim dies, the threat reclaims the body regardless of
+    ///     cause and regardless of how long they were infected — the infection
+    ///     gives no warning beforehand, so the first sign anyone gets is the
+    ///     corpse turning. Flesh kudzu is seeded at the corpse coords before
+    ///     polymorph swaps the entity, and the victim's identity profile is
+    ///     pushed into the shared mimic pool so other mimics can wear their
+    ///     face. Humanoids 50/50 roll between mimic and skitter; animals always
+    ///     turn into a spider.
     /// </summary>
     private void OnInfectedMobStateChanged(Entity<AbominationInfectionComponent> ent, ref MobStateChangedEvent args)
     {
@@ -219,9 +186,6 @@ public sealed partial class AbominationInfectionSystem : EntitySystem
         MapCoordinates coords = _transform.GetMapCoordinates(ent.Owner);
         if (coords.MapId != default(MapId))
             Spawn(FleshKudzuSource, coords);
-
-        if (!ent.Comp.HasShownSymptoms)
-            return;
 
         // Snapshot the victim's identity FIRST while the original entity still
         // exists — polymorph would otherwise delete/banish it before we can
@@ -245,15 +209,4 @@ public sealed partial class AbominationInfectionSystem : EntitySystem
 
         _polymorph.PolymorphEntity(ent.Owner, polymorphId);
     }
-
-    private float GetSeverity(AbominationInfectionComponent infection, TimeSpan now)
-    {
-        double elapsed = (now - infection.InfectedAt).TotalSeconds;
-        double total = Math.Max(1.0, infection.CrescendoAfter.TotalSeconds);
-
-        return (float)Math.Clamp(elapsed / total, 0.0, 1.0);
-    }
-
-    private static TimeSpan Lerp(TimeSpan a, TimeSpan b, float t)
-        => TimeSpan.FromSeconds(a.TotalSeconds + (b.TotalSeconds - a.TotalSeconds) * t);
 }

--- a/Content.Shared/StatusIcon/StatusIconPrototype.cs
+++ b/Content.Shared/StatusIcon/StatusIconPrototype.cs
@@ -33,6 +33,15 @@ public partial class StatusIconData : IComparable<StatusIconData>
     public bool VisibleToGhosts = true;
 
     /// <summary>
+    /// Whether or not to show the icon to admin ghosts (ghosts that can
+    /// interact, i.e. spawned via aghost) even when <see cref="VisibleToGhosts" />
+    /// is false. Lets admins see team markers without leaking them to dead
+    /// players watching as regular ghosts.
+    /// </summary>
+    [DataField]
+    public bool VisibleToAdminGhosts = false;
+
+    /// <summary>
     /// Whether or not to hide the icon when we are inside a container like a locker or a crate.
     /// </summary>
     [DataField]

--- a/Content.Shared/_CMU14/Threats/Mobs/Abomination/AbominationInfectionComponent.cs
+++ b/Content.Shared/_CMU14/Threats/Mobs/Abomination/AbominationInfectionComponent.cs
@@ -5,81 +5,35 @@ using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
 namespace Content.Shared._CMU14.Threats.Mobs.Abomination;
 
 /// <summary>
-///     Applied to a humanoid hit by an abomination. Symptoms ramp progressively
-///     from coughs and slight drunkenness up to constant seizures + vomiting as
-///     the infection runs its course. Any death while infected polymorphs the
-///     victim into an AU14AbominationMimic and seeds flesh kudzu at the corpse.
+///     A silent marker applied to a humanoid hit by an abomination (or injected
+///     with abomination venom). There are no visible symptoms — no cough, no
+///     jitter, no vomit, no drunkenness, no scream — so neither the host nor
+///     anyone around them can tell they carry it. The infection still works
+///     quietly: a flat poison tick drains the host until they die, and any
+///     death while infected reclaims the body as an abomination (seeding flesh
+///     kudzu at the corpse). Survive long enough and the infection burns out
+///     on its own. The horror is the not knowing — the colony falls to its own
+///     paranoia.
 /// </summary>
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState, AutoGenerateComponentPause]
 public sealed partial class AbominationInfectionComponent : Component
 {
-    /// <summary>Cough interval at the very beginning of the infection.</summary>
-    [DataField, AutoNetworkedField]
-    public TimeSpan CoughIntervalEarly = TimeSpan.FromSeconds(20);
-
-    /// <summary>Cough interval at peak severity.</summary>
-    [DataField, AutoNetworkedField]
-    public TimeSpan CoughIntervalLate = TimeSpan.FromSeconds(5);
-
-    /// <summary>How long until the infection reaches its peak (full seizures). Used to scale shaking severity.</summary>
-    [DataField, AutoNetworkedField]
-    public TimeSpan CrescendoAfter = TimeSpan.FromMinutes(8);
-
     /// <summary>How long until the infection is automatically cured if the host is still alive.</summary>
     [DataField, AutoNetworkedField]
     public TimeSpan CureAfter = TimeSpan.FromMinutes(15);
 
-    /// <summary>Drunk duration applied each tick. Scaled by severity.</summary>
-    [DataField, AutoNetworkedField]
-    public TimeSpan DrunkPerTick = TimeSpan.FromSeconds(10);
-
-    /// <summary>Has the crescendo phase been entered? (set when severity = 1).</summary>
-    [DataField, AutoNetworkedField]
-    public bool HasCrescendoed;
-
-    /// <summary>True once symptoms have begun (severity > 0). Used to gate the death-into-mimic trigger.</summary>
-    [DataField, AutoNetworkedField]
-    public bool HasShownSymptoms;
-
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan InfectedAt;
 
-    /// <summary>
-    ///     Jitter interval at severity 0 — early infection.
-    ///     Aggressive cadence so the seizures land within seconds of infection.
-    /// </summary>
-    [DataField, AutoNetworkedField]
-    public TimeSpan JitterIntervalEarly = TimeSpan.FromSeconds(8);
-
-    /// <summary>Jitter interval at peak severity — basically constant.</summary>
-    [DataField, AutoNetworkedField]
-    public TimeSpan JitterIntervalLate = TimeSpan.FromSeconds(0.5);
-
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan NextCoughAt;
-
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan NextJitterAt;
-
+    /// <summary>Next scheduled silent poison tick.</summary>
     [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
     public TimeSpan NextTickAt;
 
-    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer)), AutoNetworkedField, AutoPausedField]
-    public TimeSpan NextVomitAt;
-
-    /// <summary>Damage applied each symptom tick. Scaled by severity (0..1).</summary>
+    /// <summary>Damage applied on each silent poison tick. Flat — not scaled by severity.</summary>
     [DataField, AutoNetworkedField]
     public DamageSpecifier TickDamage = new();
 
-    /// <summary>How often the main symptom tick runs.</summary>
+    /// <summary>How often the silent poison tick fires.</summary>
     [DataField, AutoNetworkedField]
     public TimeSpan TickInterval = TimeSpan.FromSeconds(6);
-
-    /// <summary>How often the late-phase vomiting fires once severity is past <see cref="VomitSeverityThreshold" />.</summary>
-    [DataField, AutoNetworkedField]
-    public TimeSpan VomitInterval = TimeSpan.FromSeconds(10);
-
-    /// <summary>Severity threshold below which vomiting is suppressed entirely.</summary>
-    [DataField, AutoNetworkedField]
-    public float VomitSeverityThreshold = 0.6f;
 }

--- a/Content.Shared/_RMC14/Bioscan/BioscanSystem.cs
+++ b/Content.Shared/_RMC14/Bioscan/BioscanSystem.cs
@@ -19,7 +19,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using AbominationComponent = Content.Shared._CMU14.Threats.Mobs.Abomination.AbominationComponent;
-using AbominationMimicTransformedComponent = Content.Shared._CMU14.Threats.Mobs.Abomination.AbominationMimicTransformedComponent;
 using InsurgencyRuleComponent = Content.Shared._CMU14.Threats.InsurgencyRuleComponent;
 
 namespace Content.Shared._RMC14.Bioscan;
@@ -68,9 +67,12 @@ public sealed partial class BioscanSystem : EntitySystem
     private bool TargetIsMarine(EntityUid uid) => HasComp<MarineComponent>(uid);
     private bool TargetIsThreat(EntityUid uid)
     {
+        // Disguised mimics (AbominationMimicTransformedComponent) are
+        // deliberately NOT counted here: ARES announcing their presence and
+        // location would give the threat away and kill the colony-fall
+        // paranoia. Only natural-form abominations show up on bioscan.
         return HasComp<XenoComponent>(uid)
             || HasComp<AbominationComponent>(uid)
-            || HasComp<AbominationMimicTransformedComponent>(uid)
             || HasComp<YautjaComponent>(uid)
             || HasComp<YautjaAbominationComponent>(uid);
     }

--- a/Resources/Prototypes/_CMU14/Threats/Abominations/faction_icons.yml
+++ b/Resources/Prototypes/_CMU14/Threats/Abominations/faction_icons.yml
@@ -6,6 +6,12 @@
 - type: factionIcon
   id: AbominationFaction
   priority: 11
+  # Do not show this to ordinary dead-player ghosts — a dead (and potentially
+  # revivable) colonist watching could spot the marker on a disguised mimic and
+  # carry that knowledge back. Living abominations (shell or disguised form)
+  # and admin ghosts (aghost) can still see it.
+  visibleToGhosts: false
+  visibleToAdminGhosts: true
   showTo:
     components:
     - Abomination


### PR DESCRIPTION
## About the PR
Reworks abominations for early-round colony infiltration by removing the gameplay tells that currently give an infected marine character away. The goal is to shift the focus toward paranoid roleplay: the colony shouldn't spread because of a visible outbreak on the Bioscan, but because marines start shooting each other over who looks suspicious.

This addresses the following feedback:

> "Right now aboms are terrible for colony fall mostly because they give themselves away and theres no fear RP. Remove all of the things that let you know when someone is infected."

## Why / Balance
Currently an infected human gives itself away reliably:
- The Symptoms (coughing, vomiting, jittering, drunken stumbling, crescendo) auto-play almost immediately and telegraph the infection.
- A bioscan-like threat readout exposes a "mimic" so everyone knows who to watch.
- An infection status icon is visible to ghost observers, letting ghosts also call it out.

This removes those tells. An infected character now behaves like a normal marine right up until the transformation, so detection has to come from behaviour and paranoia rather than mechanics. To partially compensate, aghosts still get the mimic marker while regular ghosts do not, keeping a degree of oversight without broadcasting the infection to everyone.

## Technical details
- `Content.Shared/_CMU14/Threats/Mobs/Abomination/AbominationInfectionComponent.cs` — stripped the infection-visible symptom fields (cough, jitter, vomit, drunk, crescendo) that played every tick.
- `Content.Server/_CMU14/Threats/Mobs/Abomination/AbominationInfectionSystem.cs` — removed the symptom system wiring and the `HasShownSymptoms` gate on the death→mimic conversion; the venom poison tick now uses `Poison` and temporarily suppresses the human `Scream` emote so each tick of venom damage no longer makes the character cry out.
- `Content.Shared/_RMC14/Bioscan/BioscanSystem.cs` — mimic-transformed entities no longer show up in the scan threat list.
- `Content.Shared/StatusIcon/StatusIconPrototype.cs` / `Content.Client/StatusIcon/StatusIconSystem.cs` — mirror icons (and the mimic icon) are only rendered to admin-ghosts, not regular ghosts; added a `VisibleToAdminGhosts` flag to the status icon data.
- `Resources/Prototypes/_CMU14/Threats/Abominations/faction_icons.yml` — marker icons set to `visibleToGhosts: false`, `visibleToAdminGhosts: true`.

## Media
No new media; this is a visibility/gameplay tweak with no new clothing or items.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.

**Changelog**
:cl:
- tweak: Infected marines no longer cough, puke, stumble or jitter, hiding the abomination infection until transformation. Health scan shows poison.
- tweak: Mimic entities no longer appear on the Bioscan threat readout.
- tweak: Mirror and mimic status icons are now only visible to admin-ghosts, not regular ghosts.
