### PR TITLE
New Directional Bullet-Blocking System For Barricades

### DIFF
--- a/Content.Shared/_RMC14/Barricade/DirectionalBulletBlockerComponent.cs
+++ b/Content.Shared/_RMC14/Barricade/DirectionalBulletBlockerComponent.cs
@@ -1,0 +1,20 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared._RMC14.Barricade;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+public sealed partial class DirectionalBulletBlockerComponent : Component
+{
+    /// <summary>
+    /// Degrees cone in front of the barricade where bullets are blocked
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float FrontBlockAngle = 135f;
+
+    /// <summary>
+    /// Chance to block a bullet when it's in the blocking cone (0.0 to 1.0)
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public float BlockChance = 1.0f;
+
+}

--- a/Content.Shared/_RMC14/Barricade/DirectionalBulletBlockerSystem.cs
+++ b/Content.Shared/_RMC14/Barricade/DirectionalBulletBlockerSystem.cs
@@ -1,0 +1,62 @@
+using System.Numerics;
+using Content.Shared._RMC14.Marines;
+using Content.Shared.Projectiles;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Physics.Events;
+using Robust.Shared.Random;
+
+namespace Content.Shared._RMC14.Barricade;
+
+public sealed class DirectionalBulletBlockerSystem : EntitySystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<DirectionalBulletBlockerComponent, PreventCollideEvent>(OnPreventCollide);
+    }
+
+    private void OnPreventCollide(Entity<DirectionalBulletBlockerComponent> ent, ref PreventCollideEvent args)
+    {
+        if (!TryComp(args.OtherEntity, out ProjectileComponent? projectile))
+            return;
+
+        if (!TryComp(args.OtherEntity, out PhysicsComponent? physics))
+            return;
+
+        // Get barricade rotation
+        var barricadeRotation = _transform.GetWorldRotation(ent);
+
+        // Get projectile velocity direction
+        var projectileVelocity = physics.LinearVelocity;
+        if (projectileVelocity.LengthSquared() < 0.001f)
+            return;
+
+        var projectileDirection = projectileVelocity.Normalized();
+
+        // Calculate barricade's front direction vector (South is front for barricades)
+        var frontDirection = barricadeRotation.RotateVec(new Vector2(0, -1));
+
+        // Calculate angle between projectile direction (from barricade's perspective) and barricade front
+        // Negate projectile direction to get "direction from projectile to barricade"
+        var dotProduct = Vector2.Dot(-projectileDirection, frontDirection);
+        var angleToProjectile = MathF.Acos(Math.Clamp(dotProduct, -1f, 1f));
+        var angleDegrees = angleToProjectile * 180f / MathF.PI;
+
+        // Check if projectile is coming from behind (outside the front blocking cone)
+        // If the angle is greater than half the block angle, projectile is coming from side/behind
+        if (angleDegrees > ent.Comp.FrontBlockAngle / 2)
+        {
+            args.Cancelled = true; // Allow projectile to pass
+            return;
+        }
+
+        // Apply block chance
+        if (_random.NextFloat() > ent.Comp.BlockChance)
+        {
+            args.Cancelled = true; // Allow projectile to pass based on chance
+        }
+    }
+
+}

--- a/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_base.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Structures/Walls/Barricades/barricade_base.yml
@@ -90,6 +90,9 @@
         Heat: 2
   - type: ExaminableDamage
     messages: RMCBarricadeMessages
+  - type: DirectionalBulletBlocker
+    frontBlockAngle: 180
+    blockChance: 0.4
   - type: BarricadeBlock
     bidirectional: true
     blocking: 30


### PR DESCRIPTION


<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Implement a custom directional bullet-blocking system for barricades that has a chance to block enemy projectiles from the front while allowing friendly diagonal shots from behind to pass through. No more bullets colliding with adjacent barricades while trying to shoot diagonally. Might need to tweak blockchance.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The old collisions are not reliable; you can shoot the barricade that is right in front of you at a certain angle, and don't even think about shooting through adjacent barricades because it won't work. The reason I know this is because a guy with an AT launcher (RPG) tried to shoot a xeno (runner) with an RPG while standing at the edge of a barricade and managed to hit the barricade that is right in front of him, breaking it and dying in the process, injuring 2 of his squadmates. I am surprised that there are no bug reports of barricade collisions as of yet.

## Technical details
<!-- Summary of code changes for easier review. -->
- Uses dot product to calculate angle between projectile incoming direction and barricade front
- Barricade front defined as (0, -1) rotated by entity rotation (South-facing default)
- Negates projectile direction to calculate where the bullet comes from 

Base barricades: 180° blocking cone, 40% block chance
Sandbags: Inherits base settings
Both use BarricadeBlock for overhead shot mechanics alongside directional blocking

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->
https://medal.tv/games/imported-clips/clips/npBKWJyffRNsi5_DS?invite=cr-MSxtQTksMTk5NDM3OTI4


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Barricade collisions are now fixed! 
