### PR TITLE
Buff XMP5A2 damage and spread

### DIFF
--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/SMGs/xmp5a6.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/SMGs/xmp5a6.yml
@@ -53,7 +53,7 @@
           - RMCMagazineRifleM54CHEAP
           - RMCMagazineRifleM54CWP
   - type: GunDamageModifier
-    multiplier: 1.1
+    multiplier: 2.1
   - type: AttachableHolder
     slots:
       rmc-aslot-barrel:

--- a/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/SMGs/xmp5a6.yml
+++ b/Resources/Prototypes/_CMU14/Entities/Weapons/Factions/HAZOPS/SMGs/xmp5a6.yml
@@ -29,7 +29,7 @@
     - Burst
     - FullAuto
     recoilUnwielded: 5
-    scatterWielded: 7
+    scatterWielded: 6
     scatterUnwielded: 19
     baseFireRate: 7.5
     burstScatterMult: 2
@@ -53,7 +53,7 @@
           - RMCMagazineRifleM54CHEAP
           - RMCMagazineRifleM54CWP
   - type: GunDamageModifier
-    multiplier: 2.1
+    multiplier: 1.35
   - type: AttachableHolder
     slots:
       rmc-aslot-barrel:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Buff XMP5 damage and spread, it was supposed to be a great gun at close range but falls off hard at range, but it wasn't good enough at close range to justify being shit at mid-long range.

**Changelog**
:cl:
- tweak: HAZOPS XMP5A6 damage modified buffed to 1.35 and spread reduced by one.
