### PR TITLE
Replaces the 6 Capital crimes for one General Capital Crime regarding Geneva

### DIFF
--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLaw.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLaw.xml
@@ -6,10 +6,12 @@
 
   ## Contents
   - [textlink="General Provisions" link="AU14CCLawGeneral"]
-  - [textlink="Corporate & Frontier Jurisdiction" link="AU14CCLawCorporate"]
-  - [textlink="Civil Citations & Arrest Procedures" link="AU14CCLawProcedures"]
+  - [textlink="Corporate and Frontier Jurisdiction" link="AU14CCLawCorporate"]
+  - [textlink="Civil Citations and Arrest Procedures" link="AU14CCLawProcedures"]
   - [textlink="Military Presence" link="AU14CCLawMilitary"]
   - [textlink="Criminal Code" link="AU14CCLawCriminalCode"]
   - [textlink="Precautionary Confinement" link="AU14CCLawPrecautionary"]
   - [textlink="Administrative Emergency Powers" link="AU14CCLawEmergency"]
+  - [textlink="Civilian Militias" link="AU14CCLawMilitia"]
+  - [textlink="Executions" link="AU14CCLawExecutions"]
 </Document>

--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawCorporate.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawCorporate.xml
@@ -7,4 +7,6 @@
   Corporate emergency powers may not be used to conceal: murder, unlawful experimentation, forced exposure to hazards, illegal imprisonment, mass-casualty negligence, or crimes against humanity.
 
   A corporate order that directly endangers civilian life without lawful justification may be refused and reported to higher authority.
+
+  Corporations, as long as they have proper holding cells and allowed by local law enforcement, may keep criminals in their own prisions as long as they can prove the living standards are decent and humane. If local law enforcment requests prisioners to be handed over, they must comply immediatedly.
 </Document>

--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawExecutions.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawExecutions.xml
@@ -1,0 +1,19 @@
+<Document>
+	# Executions
+
+    Only role allowed to be a Judge during Execution trials are Arbiters; If none are available, the execution trial may not proceeed.
+    Executions may only be allowed for Capital Crimes.
+	Executions may be sanctioned only by the joint approval of the Acting Administrator, Marshal and Judge together; Or arternatively, the Colony Administrator and Arbiter.
+	Criminals to be executed must be permitted a final meal of choice within reason and given chance to pray if they are religious, after which they must be given the option of lethal injection or firing squad.
+
+	Firing squads consist of atleast two members at minimum, they must all be part of Law Enforcement.
+	Lethal Injection consists of one trained medical professional such as a Doctor or Nurse, administering a fatal overdose of chemicals.
+
+	After a execution has been performed it is required to have a report sent to the Law Enforcement Command offices, the report should list:
+		- Personnel executed
+		- Crime
+		- Last meal
+		- Execution methods
+		- Name and rank of the personnel who permitted the execution
+		- any relevant information
+</Document>

--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawGeneral.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawGeneral.xml
@@ -6,12 +6,17 @@
   - Colony Marshals and Administration may use discretion on minor offenses unless ordered otherwise by higher authority. Law Enforcement may not have their own offenses ignored.
   - Proportional self-defense is legal. Force should be reasonable for the threat faced.
   - No person may serve more than 25 minutes in holding unless placed under permanent confinement.
-  - Execution is never legal or sanctioned.
+  - Executions is only legal for Capital crimes, and require a full trial with a judge authorizing it for the execution to be carried out.
   - Permanent confinement is reserved for extreme threats to colony safety or persons who cannot be safely released.
   - Colonial law is civilian law. Military procedure does not apply unless martial law is lawfully declared.
+  - Colonial law enforcement may not be used to enforce corporate policy unless it is a lawful safety order or emergency directive.
+  - Spirit of the Law: The laws are meant as intended by their spirit, not their exact wording.
+  - On Threats to breaking Civilian Law: Threatening to commit a Major or Capital Crime such as Unauthorized Deployment or Muder may be charged as breaking the Law as long as it's credible that the law will be broken. In cases of threats to murder, charges are to be treated as Attempted Murder.
+  - Vicarious Prosecution: With the exclusion of capital crimes, actions resulting in Neglect of Duty or crimes resulting in major bodily harm, the Victim of the crime retains the right to drop charges and request Law Enforcement or other prosecuting parties to release the defendant. If the prosecuting party continues with the arrest, they may detain the defendant for up to ten minutes, and must write to Law Enforcement Command for approval on continuing the arrest. If the ten minute mark passes or LE Command doesnt respond in time or rejects for the arrest to continue, they must release the suspect.
+  - When referring to 'Acting Administrator', this can both mean the Deputy Admin, or a Democratically elected Administrator (In the case of there being no Deputy or Colony Admin).
 
   ## CIVILIAN LEGAL AUTHORITY
-  Civilian Court / Arbiter > Administrator > Chief Marshal > Colony Marshals > Deputized Security
+  Civilian Court / Arbiter > Colony Administrator > Chief Marshal > Deputy/Acting Administrator > Colony Marshals > Deputized Security
 
   - If a civilian court is active, it has final authority over criminal cases.
   - If no court is active, the Marshal's Office handles arrests, charges, and sentencing.
@@ -21,7 +26,11 @@
   ## COURTS AND LEGAL REVIEW
   Most offenses are processed directly by the Marshal's Office. A formal court may be convened for major/capital crimes, disputed arrests, abuse of authority, corporate misconduct, or matters of public concern.
 
-  Court proceedings may involve a judge (e.g. Arbiter or Administator), prosecutor, legal counsel, witnesses, and evidence review. Outcomes may include charges upheld, reduced, or dismissed; sentences adjusted; property returned; or licenses suspended/restored.
+  Court proceedings may involve a judge (e.g. Arbiter, Administator or Marshal), prosecutor, legal counsel, witnesses, and evidence review. Outcomes may include charges upheld, reduced, or dismissed; sentences adjusted; property returned; or licenses suspended/restored.
+
+  The Judge may not have been involved in the case beforehand. The Judge may not be a direct superior of the accused. The Judge may not have a personal relationship with the accused or victim.
 
   Legal counsel is not guaranteed but may be appointed for major or disputed cases. Court rulings are final unless overruled by Colonial High Authority.
+
+  OOC NOTE: If it says 'Colony Administartor', it means the WL role.
 </Document>

--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawMilitia.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawMilitia.xml
@@ -1,0 +1,9 @@
+<Document>
+    # Militias
+    In the case of a colony-wide emergency, Civilian Militias may be formed by the Acting Administrator or the Marshal to provide assistance to the colony as long as they follow the following rules:
+    - Militias may not be utilized for own personal gain, and should remain as a last line of defense in case of colony-wide emergencies.
+    - Militias may not arm up from Goverment or Corporate stockpiles without proper authorization from respective authorities. (Ex. Militias cant arm from CMB armories unless authorized by the Colony Administrator or the Marshal)
+    - Militias may never wear or utilize any sort of equipment that could have them mistaken for anything other than a Militia Member (Ex. Wearing a Police Uniform or Police Armors is not allowed)
+    - Militias must adhere to Colonial Law at all times, and may not take the law into their own hands. Any crimes should be reported to the respective authorities.
+    - When formed, Militias should normally report to the Marshal or Administrator for any orders. This may vary.
+</Document>

--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawProcedures.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/AU14CCLawProcedures.xml
@@ -3,7 +3,8 @@
   Minor legal alternatives to full arrest. May be issued by Marshals, Colonial Administration, or authorized department heads.
 
   Types include: warnings, fines, restitution, temporary confiscation, access or license suspension, community service, or short holding.
-  May not replace arrest for major or capital crimes. If refused, the offender serves the listed holding sentence instead.
+  This may not replace arrest for major or capital crimes.
+  If refused, the offender serves the listed holding sentence instead.
 
   # ARRESTING PROCEDURES
   [bold]Standard arrest:[/bold] Inform the suspect of the charge, order compliance, use non-lethal force unless a lethal threat is present, restrain, move to holding, process charges promptly.

--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/Crimes/AU14CCLawArmsControl.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/Crimes/AU14CCLawArmsControl.xml
@@ -3,6 +3,8 @@
 
   Weapons possession is a licensed privilege, not an unrestricted right. Unauthorized weapons are treated as a public safety threat due to pressurized habitats and volatile infrastructure.
 
+  During declared emergencies, Weapons Permits (Up to Class B) may be temporarilly removed if both the Marshal and Acting Administrator agree.
+
   ## Weapon Classes
   - [bold]Class A — Civilian Tools[/bold] (knives, hatchets, crowbars, industrial/mining/welding tools). Legal when used lawfully. Become illegal if brandished, used to threaten, carried into restricted areas, modified into weapons, or used during a crime.
   - [bold]Class B — Civilian Firearms[/bold] (pistols, shotguns, hunting rifles, low-capacity rifles). Require a Colonial Firearm License. Must be registered, serialized, and safely stored. Not openly carried in public without authorization. Concealed carry requires a separate permit.

--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/Crimes/AU14CCLawCapitalCrimes.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/Crimes/AU14CCLawCapitalCrimes.xml
@@ -5,7 +5,7 @@
   - Revocation of weapon licenses
   - Removal from public office or security authority
   - Possible off-world transfer or exile (if approved by the proper authority)
-  Execution remains illegal.
+  - Execution if following procedure as stated in the Executions Section
 
   ## Murder
   Killing another person with malicious intent.

--- a/Resources/ServerInfo/Guidebook/_AU14/CCLaw/Crimes/AU14CCLawMajorCrimes.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/CCLaw/Crimes/AU14CCLawMajorCrimes.xml
@@ -5,6 +5,10 @@
   Severely disrupting colony operations, emergency response, or essential services (blocking emergency response, interfering with evacuation, causing panic during emergency operations, disrupting medical triage).
   - 10 min
 
+  ## Major Vandalism
+  Property damage disrupting essential services.
+  - 12 min + repair/compensation
+
   ## Assault
   Threatening or using physical force with hostile intent.
   - 10 min unarmed | 15 min with a deadly weapon
@@ -51,7 +55,7 @@
 
   ## Possession of Restricted Biological Material
   Possessing, hiding, transporting, or selling dangerous biological material without authorization (unknown eggs, parasitic organisms, pathogen samples, infected tissue, invasive lifeform remains, unknown organic material from restricted zones).
-  - 20 min + confiscation/destruction + mandatory quarantine | Permanent confinement if colony safety endangered
+  - 25 min + confiscation/destruction + mandatory quarantine | Permanent confinement if colony safety endangered
 
   ## Harboring a Contaminated Person
   Knowingly hiding or assisting a person under quarantine or suspected of carrying a dangerous pathogen.

--- a/Resources/ServerInfo/Guidebook/_AU14/UCMJ/Crimes/AU14UCMJCapitalCrimes.xml
+++ b/Resources/ServerInfo/Guidebook/_AU14/UCMJ/Crimes/AU14UCMJCapitalCrimes.xml
@@ -23,20 +23,8 @@
   ## Desertion
     Refusing to carry out the duties essential to one’s post or abandoning one's post without authorisation, without intent to return. (Retreating from the planet when the FOB is breached is not Desertion; refusing to return when ordered is).
 
-  ## Unlawful Violence Against Civilians.
-    Violence against civilian life, if the victim was not permamently killed they may be held for thirty minutes, if the victim was permamently killed the criminal should be held in permanent confinement.
-
-  ## Desecration Upon Personal Dignity.
-    A capital crime in which a member of the military has desecrated a corpse, such as decapitating a individual after they have been incapacitated, surgically removing limbs or making public displays of corpses.
-
-  ## Depredation Upon Civilian Property
-    A capital crime in which members of the military have intentionally, plundered, pillaged or destroyed civilian property without reasonable cause. An example would be mortaring a hospital, taking colony assets such as botany trays, chemical machines, medical machines or destroyed said property.
-
-  ## Mistreatment of Prisoners
-    A capital crime in which a member of the military has subjected a captured prisoner to unnecessary violence, humiliation, denial of food, water and torture.
-
-  ## Execution of Surrendering Combatants
-    A capital crime in which a member of the military has intentionally murdered a enemy combatant after they have clearly surrendered or otherwise ceased resistance.
+  ## Breaking the Geneva Convention
+    Breaking one or more of the articles of the Geneva Convention.
 
   ## Commander Authority for Termination
     A capital crime in which the commander may order the immediate execution of a member of the military when said member has been deemed an unacceptable threat to the operation, unit and personnel under their command.


### PR DESCRIPTION
## About the PR

Replaced Six of the Captial Crimes that were supossed to be a easier alternative to Geneva, with one single Geneva-Related Capital Crime.

## Why / Balance

Geneva has around 40~ Articles, and those 6 Capital crimes don't cover all of it. By doing this change it is ensured that Players can enforce the entirety of Geneva ICly.

## Technical details
Changed Capital Crimes

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Replaced 6 Capital crimes for one Geneva Crime
