### PR TITLE
Synth DR 

### DIFF
--- a/Resources/Prototypes/_RMC14/Damage/synth_modifier_sets.yml
+++ b/Resources/Prototypes/_RMC14/Damage/synth_modifier_sets.yml
@@ -14,6 +14,6 @@
     Blunt: 0.5
     Slash: 0.5
     Piercing: 0.5
-    Heat: 0.8
+    Heat: 0.3 // (so that they can burn for about as long as a working joe does, seeing as how they cant use guns even if their hacked/runaway it should be fair)
     Shock: 0.8
     Cold: 0.8

--- a/Resources/Prototypes/_RMC14/Damage/synth_modifier_sets.yml
+++ b/Resources/Prototypes/_RMC14/Damage/synth_modifier_sets.yml
@@ -14,6 +14,6 @@
     Blunt: 0.5
     Slash: 0.5
     Piercing: 0.5
-    Heat: 0.3 // (so that they can burn for about as long as a working joe does, seeing as how they cant use guns even if their hacked/runaway it should be fair)
+    Heat: 0.5 // (so that they can burn for about as long as a working joe does, seeing as how they cant use guns even if their hacked/runaway it should be fair)
     Shock: 0.8
     Cold: 0.8

--- a/Resources/Prototypes/_RMC14/Damage/synth_modifier_sets.yml
+++ b/Resources/Prototypes/_RMC14/Damage/synth_modifier_sets.yml
@@ -7,3 +7,13 @@
     Heat: 0.9
     Shock: 0.9
     Cold: 0.9
+
+- type: damageModifierSet
+  id: RMCSynthetic
+  coefficients:
+    Blunt: 0.5
+    Slash: 0.5
+    Piercing: 0.5
+    Heat: 0.5
+    Shock: 0.5
+    Cold: 0.5

--- a/Resources/Prototypes/_RMC14/Damage/synth_modifier_sets.yml
+++ b/Resources/Prototypes/_RMC14/Damage/synth_modifier_sets.yml
@@ -14,6 +14,6 @@
     Blunt: 0.5
     Slash: 0.5
     Piercing: 0.5
-    Heat: 0.5
-    Shock: 0.5
-    Cold: 0.5
+    Heat: 0.8
+    Shock: 0.8
+    Cold: 0.8

--- a/Resources/Prototypes/_RMC14/Roles/Jobs/synth.yml
+++ b/Resources/Prototypes/_RMC14/Roles/Jobs/synth.yml
@@ -117,7 +117,9 @@
   - type: ParalyzeImmuneFrom
     whitelist:
       tags:
-      - RMCSynthGrabbable
+      - RMCSynthGrabbable 
+  - type: DamageModifier
+    modifierSet: RMCSynthetic
 
 - type: entity
   id: RMCSynthHudComponents


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Synths had a DR in cm13 and for some reason working joes have it, but not the synths? figured i'd leave it roughly the same, with synths having slightly better shock/heat resistance. They also can no longer use guns, even if their hacked or a runaway. 
## Technical details
<!-- Summary of code changes for easier review. -->
All it does is add a damage modifier for synths to make them tankier like their working joe counterparts. For some reason, when synth's were made they did not have this damage resistance or it was not ported. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: synth's have DR like they do in cm13 now, slightly better then working joes. 
