### PR TITLE
Fix sentry state failures and improve stall diagnostics

### DIFF
--- a/Content.CMU/Resources/Prototypes/CMU14/ThirdParties/Military/UPP/GROM/Base/base.yml
+++ b/Content.CMU/Resources/Prototypes/CMU14/ThirdParties/Military/UPP/GROM/Base/base.yml
@@ -228,7 +228,7 @@
     - id: RMCMagazinePistolT73
       amount: 2
     - id: RMCMagazineLMGQYJ72
-      amount: 3
+      amount: 2
 
 - type: entity
   parent: RMCPouchMagazine

--- a/Content.CMU/Server/Diagnostics/Performance/CMUPerformanceErrorTracker.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUPerformanceErrorTracker.cs
@@ -1,0 +1,56 @@
+using System.Linq;
+using Serilog.Events;
+
+namespace Content.Server.CMU14.Diagnostics.Performance;
+
+/// <summary>
+/// Counts errors at their existing logging boundary, including PVS worker threads. Never renders messages,
+/// captures stacks, or writes logs from the callback. Memory is bounded even during an exception storm.
+/// </summary>
+internal sealed class CMUPerformanceErrorTracker : ILogHandler
+{
+    internal const int SourceCapacity = 32;
+    private readonly object _lock = new();
+    private readonly Dictionary<string, Source> _sources = new(StringComparer.Ordinal);
+    private long _total;
+    private long _overflow;
+
+    public void Log(string sawmillName, LogEvent message)
+    {
+        if (message.Level < LogEventLevel.Error ||
+            sawmillName is "cmu.server-performance" or "cmu.client_state")
+            return;
+
+        lock (_lock)
+        {
+            _total++;
+            if (_sources.TryGetValue(sawmillName, out var source))
+            {
+                _sources[sawmillName] = source with { Count = source.Count + 1, Last = message };
+            }
+            else if (_sources.Count < SourceCapacity)
+            {
+                _sources.Add(sawmillName, new Source(sawmillName, 1, message.Timestamp, message));
+            }
+            else
+            {
+                _overflow++;
+            }
+        }
+    }
+
+    public Snapshot Drain()
+    {
+        lock (_lock)
+        {
+            var snapshot = new Snapshot(_total, _overflow, _sources.Values.ToArray());
+            _sources.Clear();
+            _total = 0;
+            _overflow = 0;
+            return snapshot;
+        }
+    }
+
+    internal readonly record struct Source(string Sawmill, long Count, DateTimeOffset FirstAt, LogEvent Last);
+    internal sealed record Snapshot(long Total, long Overflow, Source[] Sources);
+}

--- a/Content.CMU/Server/Diagnostics/Performance/CMUPerformancePhaseTracker.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUPerformancePhaseTracker.cs
@@ -1,0 +1,53 @@
+using Robust.Shared.ContentPack;
+
+namespace Content.Server.CMU14.Diagnostics.Performance;
+
+/// <summary>Measures existing module boundaries without changing or instrumenting the engine.</summary>
+internal sealed class CMUPerformancePhaseTracker
+{
+    private readonly Dictionary<string, Phase> _phases = new();
+    private string? _previous;
+    private TimeSpan _started;
+    private uint _tick;
+
+    public void Mark(ModUpdateLevel level, TimeSpan now, uint tick)
+    {
+        string? next = level switch
+        {
+            ModUpdateLevel.InputPostEngine => "before-tick",
+            ModUpdateLevel.PreEngine => "timers-tasks-and-simulation",
+            ModUpdateLevel.PostEngine => "post-tick-and-state-send",
+            ModUpdateLevel.FramePreEngine => "engine-frame-work",
+            ModUpdateLevel.FramePostEngine => "frame-tail-wait-and-input",
+            _ => null,
+        };
+        if (next == null)
+            return;
+
+        if (_previous != null && now >= _started)
+        {
+            double ms = (now - _started).TotalMilliseconds;
+            _phases.TryGetValue(_previous, out var row);
+            _phases[_previous] = new Phase(_previous, row.Count + 1, row.TotalMs + ms,
+                Math.Max(row.MaxMs, ms), ms >= row.MaxMs ? _tick : row.WorstTick);
+        }
+        _previous = next;
+        _started = now;
+        _tick = tick;
+    }
+
+    public List<Phase> Drain()
+    {
+        var result = new List<Phase>(_phases.Values);
+        _phases.Clear();
+        return result;
+    }
+
+    public void Clear()
+    {
+        _phases.Clear();
+        _previous = null;
+    }
+
+    internal readonly record struct Phase(string Name, long Count, double TotalMs, double MaxMs, uint WorstTick);
+}

--- a/Content.CMU/Server/Diagnostics/Performance/CMUServerPerformanceDiagnosticsManager.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUServerPerformanceDiagnosticsManager.cs
@@ -8,6 +8,7 @@ using Robust.Server.DataMetrics;
 using Robust.Server.Player;
 using Robust.Shared;
 using Robust.Shared.Configuration;
+using Robust.Shared.ContentPack;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Network;
 using Robust.Shared.Profiling;
@@ -34,6 +35,8 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
 
     private readonly CMUPerformanceIncidentDetector _detector = new();
     private readonly CMUPerformanceChurnTracker _churn = new();
+    private readonly CMUPerformanceErrorTracker _errors = new();
+    private readonly CMUPerformancePhaseTracker _phases = new();
     private readonly CMUPerformanceRollingWindow _shortRates = new(ShortRateWindowSeconds);
     private readonly CMUPerformanceRollingWindow _churnRates = new(ChurnRateWindowSeconds);
 
@@ -75,6 +78,9 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
     private TimeSpan _nextBaselineTime;
     private TimeSpan _nextDetailTime;
     private TimeSpan _incidentStartTime;
+    private TimeSpan _errorWindowStart;
+    private TimeSpan _nextErrorReportTime;
+    private TimeSpan _nextStallDetailTime;
 
     private double _worstFrameMilliseconds;
     private double _worstTps = double.PositiveInfinity;
@@ -132,6 +138,12 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         }
 
         LogStartupState();
+    }
+
+    public void ObservePhase(ModUpdateLevel level)
+    {
+        if (_initialized && _enabled)
+            _phases.Mark(level, _timing.RealTime, _timing.CurTick.Value);
     }
 
     public void Update()
@@ -194,7 +206,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
 
         string reasons = CMUPerformanceIncidentDetector.FormatReasons(_detector.ActiveReasons);
         return Invariant(
-            $"enabled=true incident={_detector.Active} incidentId={_activeIncidentId} reasons={reasons} ",
+            $"enabled=true logEnabled={_config.GetCVar(CCVars.CMUServerPerformanceLogEnabled)} incident={_detector.Active} incidentId={_activeIncidentId} reasons={reasons} ",
             $"tick={observation.Tick} targetTps={observation.TargetTps:F2} achievedTps={observation.AchievedTps:F2} ",
             $"fps={observation.AverageFps:F2} frameMs={observation.FrameMilliseconds:F2} ",
             $"entities={observation.EntityCount} components={observation.ComponentCount} ",
@@ -342,6 +354,12 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
 
         CMUPerformanceIncidentEvaluation evaluation = _detector.Evaluate(sample, thresholds);
         HandleEvaluation(observation, evaluation);
+        // A severe new stall must not disappear behind an earlier churn incident's two-minute cooldown.
+        double criticalMs = _config.GetCVar(CCVars.CMUServerPerformanceCriticalStallMilliseconds);
+        if (criticalMs > 0 && observation.FrameMilliseconds >= criticalMs && now >= _nextStallDetailTime)
+            CaptureDetailedReport(observation, "critical-stall", bypassCooldown: false);
+        if (now >= _nextErrorReportTime)
+            LogErrorWindow(now);
         UpdateMetrics(observation);
         HandleHeartbeatAndBaseline(observation);
     }
@@ -477,6 +495,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         bool bypassCooldown)
     {
         _detailPending = false;
+        _nextStallDetailTime = observation.RealTime + TimeSpan.FromSeconds(30);
         if (!bypassCooldown)
         {
             double cooldown = Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceDetailCooldown));
@@ -504,6 +523,14 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             $"baselineComponentsAdded={baseline.ComponentsAdded} currentComponentsAdded={current.ComponentsAdded}"));
 
         LogProfile(profile, top);
+        foreach (var phase in _phases.Drain().OrderByDescending(row => row.MaxMs))
+        {
+            _sawmill.Warning(Invariant(
+                $"[CMU-PERF] phase-window incidentId={_activeIncidentId} phase={phase.Name} ",
+                $"calls={phase.Count} totalMs={phase.TotalMs:F3} maxMs={phase.MaxMs:F3} worstTick={phase.WorstTick} ",
+                $"includesWait={phase.Name == "frame-tail-wait-and-input"}"));
+        }
+        LogErrorWindow(observation.RealTime);
         LogChurnRows("prototype-churn", CMUPerformanceChurnTracker.GetPrototypeRows(baseline, current, top));
         LogChurnRows("component-churn", CMUPerformanceChurnTracker.GetComponentRows(baseline, current, top));
         LogChurnRows("map-creates", CMUPerformanceChurnTracker.GetMapCreationRows(baseline, current, top));
@@ -523,6 +550,31 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         _profileIndexOffset = _profiler.Buffer.IndexWriteOffset + 1;
         _maxAllocatedFrameSinceSample = null;
         _allocationBreachPending = false;
+    }
+
+    private void LogErrorWindow(TimeSpan now)
+    {
+        var errors = _errors.Drain();
+        double seconds = Math.Max(0.001, (now - _errorWindowStart).TotalSeconds);
+        _errorWindowStart = now;
+        _nextErrorReportTime = now + TimeSpan.FromSeconds(30);
+        if (errors.Total == 0)
+            return;
+
+        _sawmill.Warning(Invariant(
+            $"[CMU-PERF] error-window incidentId={_activeIncidentId} tick={_timing.CurTick.Value} ",
+            $"windowSeconds={seconds:F3} errors={errors.Total} errorsPerSecond={errors.Total / seconds:F1} ",
+            $"overflowErrors={errors.Overflow} correlationOnly=true"));
+        foreach (var source in errors.Sources.OrderByDescending(source => source.Count).Take(4))
+        {
+            string sample = CMURecentServerErrors.Format(new(0, source.Sawmill, source.Last));
+            if (sample.Length > 2048)
+                sample = sample[..2048] + " [truncated; see original error]";
+            _sawmill.Warning(Invariant(
+                $"[CMU-PERF] error-source incidentId={_activeIncidentId} source={SanitizeName(source.Sawmill)} ",
+                $"count={source.Count} firstAt={source.FirstAt:O} lastAt={source.Last.Timestamp:O} ",
+                $"sample={sample}"));
+        }
     }
 
     private void CapturePendingDetailIfReady(in CMUServerPerformanceObservation observation)
@@ -804,6 +856,9 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         _entityManager.ComponentAdded += OnComponentAdded;
         _entityManager.ComponentRemoved += OnComponentRemoved;
         _entityManager.AfterEntityFlush += OnAfterEntityFlush;
+        _logManager.RootSawmill.AddHandler(_errors);
+        _errorWindowStart = _timing.RealTime;
+        _nextErrorReportTime = _errorWindowStart + TimeSpan.FromSeconds(30);
         _eventsHooked = true;
     }
 
@@ -818,6 +873,9 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         _entityManager.ComponentAdded -= OnComponentAdded;
         _entityManager.ComponentRemoved -= OnComponentRemoved;
         _entityManager.AfterEntityFlush -= OnAfterEntityFlush;
+        _logManager.RootSawmill.RemoveHandler(_errors);
+        _errors.Drain();
+        _phases.Clear();
         _eventsHooked = false;
     }
 
@@ -854,7 +912,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
     {
         bool metrics = _config.GetCVar(CVars.MetricsEnabled);
         _sawmill.Info(Invariant(
-            $"[CMU-PERF] startup enabled={_enabled} profiler={_profiler.IsEnabled} ",
+            $"[CMU-PERF] startup enabled={_enabled} logEnabled={_config.GetCVar(CCVars.CMUServerPerformanceLogEnabled)} profiler={_profiler.IsEnabled} ",
             $"profilerEnabledByDiagnostics={_profilerEnabledByDiagnostics} metrics={metrics} ",
             $"sampleSeconds={Math.Max(0.1, _config.GetCVar(CCVars.CMUServerPerformanceSampleInterval)):F2} ",
             $"stallMs={Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds)):F1} ",

--- a/Content.CMU/Server/Diagnostics/Performance/ICMUServerPerformanceDiagnostics.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/ICMUServerPerformanceDiagnostics.cs
@@ -1,9 +1,12 @@
+using Robust.Shared.ContentPack;
+
 namespace Content.Server.CMU14.Diagnostics.Performance;
 
 public interface ICMUServerPerformanceDiagnostics
 {
     void Initialize();
     void Update();
+    void ObservePhase(ModUpdateLevel level);
     void Shutdown();
     string GetStatus();
     bool CaptureManualReport();

--- a/Content.CMU/Server/Diagnostics/Performance/README.md
+++ b/Content.CMU/Server/Diagnostics/Performance/README.md
@@ -11,6 +11,7 @@ It never automatically invokes `serverperf deep` or retains per-entity details. 
 ## Default behavior
 
 - Diagnostics and healthy one-minute heartbeats are enabled.
+- Log output is enabled by default (`cmu.server_performance.log_enabled = true`). An explicit saved false value still mutes it; `cmuperf status` and runtime configuration should be checked when deploying to an existing server.
 - A real frame of 250 ms opens an incident immediately; 1,000 ms is critical.
 - TPS or average FPS below 80% of target for three seconds opens an incident.
 - Recovery requires all triggers to remain healthy for ten seconds; low-TPS/FPS signals must first reach 95% of target.
@@ -18,6 +19,8 @@ It never automatically invokes `serverperf deep` or retains per-entity details. 
 - The flight-recorder profiler is enabled during startup so the completed frames before a trigger are still in its ring.
 - Disabling the monitor unhooks its ECS event handlers and disables the profiler only when the monitor still owns that enablement; an administrator-owned profiler is left alone.
 - Detailed reports have a two-minute cooldown. Incident opening/updates/recovery are never hidden by that cooldown.
+- Critical stalls can force a fresh detailed report during an existing incident, at most once every 30 seconds, so a later severe stall is not lost behind an earlier churn report.
+- Error counts and representative existing errors are attached to detailed reports and summarized every 30 seconds when nonzero. At most 32 sources are retained and four samples are emitted, each capped at 2,048 characters. These identify coincident failures, not proof of CPU/GC attribution.
 - Healthy churn baselines refresh every five minutes and at startup/round boundaries.
 
 ## Log records
@@ -50,6 +53,8 @@ The principal records are:
 | `ecs-churn` | Top prototype/component net growth or map creation since the healthy baseline. |
 | `inbound-network-message` | Top decoded inbound message types during the latest sample interval. |
 | `detail-suppressed` | Scalar incident was recorded, but detailed parsing was still on cooldown. |
+| `error-window` / `error-source` | Error rate, source counts, and bounded samples, including failures on PVS worker threads. |
+| `phase-window` | Wall time between module callbacks, with the worst tick: simulation/timers/tasks, post-tick work and state sending, engine frame work, and frame tail/wait/input. The last category includes idle time and is not a CPU measurement. Windows accumulate since the previous detailed report. |
 
 Every incident line has a stable `incidentId`. Group all rows with the same ID before drawing conclusions.
 
@@ -64,6 +69,11 @@ Every incident line has a stable `incidentId`. Group all rows with the same ID b
 7. Inspect send/receive rates. Message-type attribution is decoded **inbound** traffic only; the engine does not expose per-type outbound totals through this API.
 8. Correlate the incident window with external heap/RSS, GC pause, CPU, and thread-pool metrics.
 9. If memory continues rising, take two dumps several minutes apart under comparable load and compare surviving type/root growth.
+
+Use `phase-window` to distinguish a long simulation tick from a long post-tick/state-send interval when the
+profiler has no finer PVS scope. `post-tick-and-state-send` includes content post-tick callbacks and game-state
+generation/serialization/sending; it does not separate those substeps or identify GC pauses. Pair it with
+`error-source` and external runtime metrics before attributing a stall to a particular method.
 
 ## Admin commands
 
@@ -97,6 +107,7 @@ All automatic-monitor CVars are server-only and archived. In the table, the firs
 | CVar | Default | Effect |
 | --- | ---: | --- |
 | `cmu.server_performance.enabled` | `true` | Master switch. |
+| `log_enabled` | `true` | Write diagnostic logs; does not control metrics or collection. |
 | `sample_interval` | `1` s | Full observation cadence; hard stalls are still checked every frame. |
 | `warmup` | `30` s | Suppresses rate/growth triggers after startup or a new round. Hard stalls/allocation/network remain active. |
 | `heartbeat_interval` | `60` s | Healthy log heartbeat; `0` disables it. |

--- a/Content.CMU/Server/Insurgency/Sapper/SapperSnareSystem.cs
+++ b/Content.CMU/Server/Insurgency/Sapper/SapperSnareSystem.cs
@@ -62,7 +62,7 @@ public sealed partial class SapperSnareSystem : EntitySystem
     private void OnSnareTriggered(EntityUid uid, SapperSnareComponent comp, ref TriggerEvent args)
     {
         // The step gate already spared friendlies, but re-check in case something else set it off.
-        if (args.User is not { } tripper || HasComp<CLFMemberComponent>(tripper))
+        if (args.User is not { } tripper || TerminatingOrDeleted(tripper) || HasComp<CLFMemberComponent>(tripper))
             return;
 
         if (HasComp<SapperSnaredComponent>(tripper))
@@ -103,8 +103,11 @@ public sealed partial class SapperSnareSystem : EntitySystem
     private void OnSnaredShutdown(Entity<SapperSnaredComponent> ent, ref ComponentShutdown args)
     {
         // Free their movement immediately (in case they were cut loose early, before the root expired).
-        RemComp<RMCRootedComponent>(ent);
-        _speed.RefreshMovementSpeedModifiers((ent.Owner, null));
+        if (!TerminatingOrDeleted(ent.Owner))
+        {
+            RemComp<RMCRootedComponent>(ent);
+            _speed.RefreshMovementSpeedModifiers((ent.Owner, null));
+        }
 
         // Take the cuffs off by deleting them - the snare's cuffs are conjured by the trap, so they vanish
         // with it instead of leaving a free pair on the floor. Removal from the container cleans up the

--- a/Content.Client/Paper/UI/StampWidget.xaml.cs
+++ b/Content.Client/Paper/UI/StampWidget.xaml.cs
@@ -25,7 +25,7 @@ public sealed partial class StampWidget : PanelContainer
 
     public StampDisplayInfo StampInfo {
         set {
-            StampedByLabel.Text = Loc.GetString(value.StampedName);
+            StampedByLabel.Text = value.GetDisplayName();
             StampedByLabel.FontColorOverride = value.StampedColor;
             ModulateSelfOverride = value.StampedColor;
         }

--- a/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
+++ b/Content.Client/Weapons/Ranged/Systems/GunSystem.Ballistic.cs
@@ -1,4 +1,5 @@
 using Content.Client.Stack;
+using Content.Shared.Stacks;
 using Content.Shared.Weapons.Ranged.Components;
 using Content.Shared.Weapons.Ranged.Events;
 using Robust.Shared.Map;
@@ -43,7 +44,8 @@ public sealed partial class GunSystem
         {
             ent.Comp.UnspawnedCount--;
             ammoEnt = Spawn(ent.Comp.Proto, coordinates);
-            _stack.SetCount(ammoEnt.Value, 1);
+            if (TryComp<StackComponent>(ammoEnt, out var stack))
+                _stack.SetCount((ammoEnt.Value, stack), 1);
             EnsureShootable(ammoEnt.Value);
         }
 

--- a/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
+++ b/Content.IntegrationTests/Tests/Preferences/ServerDbSqliteTests.cs
@@ -8,6 +8,7 @@ using Content.Shared.Humanoid;
 using Content.Shared.Humanoid.Markings;
 using Content.Shared.Humanoid.Prototypes;
 using Content.Shared.Preferences;
+using Content.Shared.Roles;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Robust.Shared.Configuration;
@@ -136,6 +137,31 @@ namespace Content.IntegrationTests.Tests.Preferences
             await db.SaveCharacterSlotAsync(username, null, 1);
             var prefs = await db.GetPlayerPreferencesAsync(username);
             Assert.That(prefs!.Profiles, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task ReplacingHighPriorityJobPreservesUniquePriorityAndOtherPreferences()
+        {
+            var db = GetDb(Pair.Server);
+            var user = NewUserId();
+            var original = CharlieCharlieson().WithJobPriorities(new Dictionary<ProtoId<JobPrototype>, JobPriority>
+            {
+                ["FirstJob"] = JobPriority.High, ["SecondJob"] = JobPriority.Low,
+            });
+            await db.InitPrefsAsync(user, original);
+            foreach (var job in new[] { "SecondJob", "FirstJob", "SecondJob" })
+            {
+                var updated = original.WithJobPriority(job, JobPriority.High);
+                await db.SaveCharacterSlotAsync(user, updated, 0);
+                var prefs = await db.GetPlayerPreferencesAsync(user);
+                var saved = prefs!.Profiles.Single();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(saved.Jobs.Count(row => row.Priority == DbJobPriority.High), Is.EqualTo(1));
+                    Assert.That(saved.Jobs.Single(row => row.Priority == DbJobPriority.High).JobName, Is.EqualTo(job));
+                    Assert.That(saved.CharacterName, Is.EqualTo(original.Name));
+                });
+            }
         }
 
         [Test]

--- a/Content.IntegrationTests/_CMU14/Diagnostics/SessionLogRegressionTest.cs
+++ b/Content.IntegrationTests/_CMU14/Diagnostics/SessionLogRegressionTest.cs
@@ -1,0 +1,131 @@
+using System.Linq;
+using Content.Shared._RMC14.Emplacements;
+using Content.Shared._RMC14.Sensor;
+using Content.Shared.Actions;
+using Content.Shared.Actions.Components;
+using Content.Shared.Buckle.Components;
+using Content.Shared.CMU14.Insurgency.Sapper;
+using Content.Shared.Interaction;
+using Content.Shared.Paper;
+using Content.Shared.Storage;
+using Content.Shared.Trigger;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.CMU14.Diagnostics;
+
+[TestFixture]
+public sealed class SessionLogRegressionTest
+{
+    [Test]
+    public async Task SuccessiveMountOperatorsCanUseDismountAction()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var actions = entities.System<SharedActionsSystem>();
+            var mount = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var mountComponent = entities.AddComponent<WeaponMountComponent>(mount);
+            var strap = entities.AddComponent<StrapComponent>(mount);
+            var weapon = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            typeof(WeaponMountComponent).GetField(nameof(mountComponent.MountedEntity))!.SetValue(mountComponent, weapon);
+            EntityUid? sharedAction = null;
+
+            for (var i = 0; i < 2; i++)
+            {
+                var user = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+                var buckle = entities.AddComponent<BuckleComponent>(user);
+                typeof(BuckleComponent).GetField(nameof(buckle.BuckledTo))!.SetValue(buckle, mount);
+                var strapped = new StrappedEvent((mount, strap), (user, buckle));
+                entities.EventBus.RaiseLocalEvent(mount, ref strapped);
+
+                var actionId = mountComponent.DismountActionEntity!.Value;
+                var action = entities.GetComponent<ActionComponent>(actionId);
+                sharedAction ??= actionId;
+                Assert.That(actionId, Is.EqualTo(sharedAction));
+                Assert.That(action.Container, Is.EqualTo(mount));
+                Assert.That(action.AttachedEntity, Is.EqualTo(user));
+                actions.PerformAction(user, (actionId, action));
+                Assert.That(buckle.Buckled, Is.False, "The action must be raised on the current operator.");
+                Assert.That(entities.HasComponent<WeaponControllerComponent>(user), Is.False);
+                Assert.That(action.AttachedEntity, Is.Null);
+                entities.DeleteEntity(user);
+            }
+            entities.DeleteEntity(mount);
+            entities.DeleteEntity(weapon);
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task SnareIgnoresDeletedTriggerUser()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var snare = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            entities.AddComponent<SapperSnareComponent>(snare);
+            var user = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            entities.DeleteEntity(user);
+            var ev = new TriggerEvent(user);
+            Assert.DoesNotThrow(() => entities.EventBus.RaiseLocalEvent(snare, ref ev));
+            Assert.That(entities.EntityExists(snare), Is.True);
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [TestCase(SensorTowerState.On)]
+    [TestCase(SensorTowerState.Off)]
+    public async Task RepairedSensorTowerIgnoresOrdinaryTools(SensorTowerState state)
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var tower = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var component = entities.AddComponent<SensorTowerComponent>(tower);
+            typeof(SensorTowerComponent).GetField(nameof(component.State))!.SetValue(component, state);
+            typeof(SensorTowerComponent).GetField(nameof(component.SkillLevel))!.SetValue(component, 0);
+            var user = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var tool = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var ev = new InteractUsingEvent(user, tool, tower, EntityCoordinates.Invalid);
+            Assert.DoesNotThrow(() => entities.EventBus.RaiseLocalEvent(tower, ev));
+            Assert.That(component.State, Is.EqualTo(state));
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task CustomStampLabelsAndStockLocalizationBothDisplay()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false });
+        await pair.Server.WaitAssertion(() =>
+        {
+            foreach (var label in new[] { "like pizza", "like crackers", "HUMINT CLASSIFIED" })
+                Assert.That(new StampDisplayInfo { StampedName = label }.GetDisplayName(), Is.EqualTo(label));
+            const string stock = "stamp-component-stamped-name-default";
+            Assert.That(new StampDisplayInfo { StampedName = stock }.GetDisplayName(), Is.EqualTo(Loc.GetString(stock)));
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task GromMachinegunnerBeltFitsAllStartingItems()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var entities = pair.Server.EntMan;
+            EntProtoId prototype = "AU14BeltSmartGunOperatorPistolUPPFull";
+            var belt = entities.SpawnEntity(prototype, MapCoordinates.Nullspace);
+            var items = entities.GetComponent<StorageComponent>(belt).Container.ContainedEntities;
+            Assert.That(items, Has.Count.EqualTo(5));
+            Assert.That(items.Count(item => entities.GetComponent<MetaDataComponent>(item).EntityPrototype?.ID == "RMCMagazineLMGQYJ72"), Is.EqualTo(2));
+            entities.DeleteEntity(belt);
+        });
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/_RMC14/Networking/SentryLaptopStateTest.cs
+++ b/Content.IntegrationTests/_RMC14/Networking/SentryLaptopStateTest.cs
@@ -1,0 +1,83 @@
+using Content.Shared._RMC14.Sentry.Laptop;
+using Content.Shared._RMC14.Sentry;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.Tests._RMC14.Networking;
+
+[TestFixture]
+public sealed class SentryLaptopStateTest
+{
+    [Test]
+    public async Task DeletingSentryCleansEveryLaptopIncludingAnAlreadyRemovedLink()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var sentry = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            entities.AddComponent<SentryComponent>(sentry);
+            var first = entities.AddComponent<SentryLaptopComponent>(entities.SpawnEntity(null, MapCoordinates.Nullspace));
+            var second = entities.AddComponent<SentryLaptopComponent>(entities.SpawnEntity(null, MapCoordinates.Nullspace));
+            foreach (var laptop in new[] { first, second })
+            {
+                typeof(SentryLaptopComponent).GetField(nameof(laptop.SentryCustomNames))!.SetValue(laptop,
+                    new Dictionary<EntityUid, string> { [sentry] = "Named sentry" });
+            }
+            typeof(SentryLaptopComponent).GetField(nameof(first.LinkedSentries))!.SetValue(first,
+                new HashSet<EntityUid> { sentry });
+            // The second laptop's link was already removed by the device-link system.
+            entities.DeleteEntity(sentry);
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.LinkedSentries, Is.Empty);
+                Assert.That(first.SentryCustomNames, Is.Empty);
+                Assert.That(second.SentryCustomNames, Is.Empty);
+            });
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task DeletedNamedSentriesDoNotBreakNetworkState()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var owner = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var live = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var deleted = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var otherDeleted = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var laptop = entities.AddComponent<SentryLaptopComponent>(owner);
+            typeof(SentryLaptopComponent).GetField(nameof(laptop.LinkedSentries))!.SetValue(laptop,
+                new HashSet<EntityUid> { live, deleted, otherDeleted });
+            typeof(SentryLaptopComponent).GetField(nameof(laptop.SentryCustomNames))!.SetValue(laptop,
+                new Dictionary<EntityUid, string>
+                {
+                    [live] = "Working sentry", [deleted] = "Deleted sentry", [otherDeleted] = "Other deleted sentry",
+                });
+            typeof(SentryLaptopComponent).GetField(nameof(laptop.Watchers))!.SetValue(laptop, new List<EntityUid> { deleted });
+            typeof(SentryLaptopComponent).GetField(nameof(laptop.CurrentCamera))!.SetValue(laptop, (EntityUid?) deleted);
+            entities.DeleteEntity(deleted);
+            entities.DeleteEntity(otherDeleted);
+
+            // Exercise the actual PVS state-generation path, including the dictionary-key collision from the log.
+            var state = entities.GetComponentState(entities.EventBus, laptop, null, GameTick.Zero)!;
+            object Field(string name) => state.GetType().GetField(name)?.GetValue(state)
+                                         ?? state.GetType().GetProperty(name)!.GetValue(state);
+            Assert.Multiple(() =>
+            {
+                Assert.That((HashSet<NetEntity>) Field(nameof(laptop.LinkedSentries)),
+                    Is.EquivalentTo(new[] { entities.GetNetEntity(live) }));
+                var names = (Dictionary<NetEntity, string>) Field(nameof(laptop.SentryCustomNames));
+                Assert.That(names, Has.Count.EqualTo(1));
+                Assert.That(names[entities.GetNetEntity(live)], Is.EqualTo("Working sentry"));
+                Assert.That((List<NetEntity>) Field(nameof(laptop.Watchers)), Is.Empty);
+                Assert.That(Field(nameof(laptop.CurrentCamera)), Is.EqualTo(NetEntity.Invalid));
+            });
+        });
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/_RMC14/Networking/StaleEntityStateTest.cs
+++ b/Content.IntegrationTests/_RMC14/Networking/StaleEntityStateTest.cs
@@ -1,8 +1,11 @@
 using Content.Shared._RMC14.Cassette;
+using Content.Shared._RMC14.Construction;
+using Content.Shared._RMC14.Sentry.Laptop;
 using Content.Shared._RMC14.Xenonids.ManageHive.Boons;
 using Content.Shared._RMC14.Xenonids.Parasite;
 using Content.Shared._RMC14.Xenonids.Sentinel;
 using Content.Shared.Botany.Items.Components;
+using Content.Shared.Placeable;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Ranged.Components;
 using Robust.Shared.GameObjects;
@@ -16,6 +19,7 @@ namespace Content.IntegrationTests.Tests._RMC14.Networking;
 public sealed class StaleEntityStateTest
 {
     [TestCase(typeof(ProjectileComponent), nameof(ProjectileComponent.Shooter))]
+    [TestCase(typeof(RMCConstructionPreventCollideComponent), nameof(RMCConstructionPreventCollideComponent.Target))]
     [TestCase(typeof(ProjectileComponent), nameof(ProjectileComponent.Weapon))]
     [TestCase(typeof(XenoIntoxicatedComponent), nameof(XenoIntoxicatedComponent.LastSource))]
     [TestCase(typeof(XenoParasiteComponent), nameof(XenoParasiteComponent.InfectedVictim))]
@@ -73,6 +77,27 @@ public sealed class StaleEntityStateTest
             ownerNet = entities.GetNetEntity(owner);
             sourceNet = entities.GetNetEntity(source);
 
+            // Opening/power follow the parent surface when a laptop first enters the client's PVS.
+            var table = entities.SpawnEntity(null, map.GridCoords);
+            entities.AddComponent<PlaceableSurfaceComponent>(table);
+            entities.System<SharedTransformSystem>().SetParent(owner, table);
+
+            var collision = entities.AddComponent<RMCConstructionPreventCollideComponent>(owner);
+            collision.Target = source;
+            collision.Range = 3f;
+            components.Add(collision);
+
+            var laptop = entities.AddComponent<SentryLaptopComponent>(owner);
+            SetField(laptop, nameof(laptop.IsOpen), true);
+            SetField(laptop, nameof(laptop.IsPowered), true);
+            SetField(laptop, nameof(laptop.Range), 42f);
+            SetField(laptop, nameof(laptop.MaxLinkedSentries), 5);
+            SetField(laptop, nameof(laptop.LinkedSentries), new HashSet<EntityUid> { source });
+            SetField(laptop, nameof(laptop.SentryCustomNames), new Dictionary<EntityUid, string> { [source] = "North gate" });
+            SetField(laptop, nameof(laptop.Watchers), new List<EntityUid> { source });
+            SetField(laptop, nameof(laptop.CurrentCamera), (EntityUid?) source);
+            components.Add(laptop);
+
             var projectile = entities.AddComponent<ProjectileComponent>(owner);
             projectile.Shooter = source;
             projectile.Weapon = source;
@@ -116,6 +141,8 @@ public sealed class StaleEntityStateTest
                 var entities = pair.Client.EntMan;
                 var clientOwner = entities.GetEntity(ownerNet);
                 var expected = deleted ? EntityUid.Invalid : entities.GetEntity(sourceNet);
+                var collision = entities.GetComponent<RMCConstructionPreventCollideComponent>(clientOwner);
+                var laptop = entities.GetComponent<SentryLaptopComponent>(clientOwner);
                 var projectile = entities.GetComponent<ProjectileComponent>(clientOwner);
                 var intoxicated = entities.GetComponent<XenoIntoxicatedComponent>(clientOwner);
                 var parasite = entities.GetComponent<XenoParasiteComponent>(clientOwner);
@@ -123,6 +150,25 @@ public sealed class StaleEntityStateTest
                 var boons = entities.GetComponent<HiveBoonsComponent>(clientOwner);
                 Assert.Multiple(() =>
                 {
+                    Assert.That(collision.Target, Is.EqualTo(expected));
+                    Assert.That(collision.Range, Is.EqualTo(3f));
+                    Assert.That(laptop.IsOpen, Is.True);
+                    Assert.That(laptop.IsPowered, Is.True);
+                    Assert.That(laptop.Range, Is.EqualTo(42f));
+                    Assert.That(laptop.MaxLinkedSentries, Is.EqualTo(5));
+                    Assert.That(laptop.CurrentCamera, Is.EqualTo(expected));
+                    if (deleted)
+                    {
+                        Assert.That(laptop.LinkedSentries, Is.Empty);
+                        Assert.That(laptop.SentryCustomNames, Is.Empty);
+                        Assert.That(laptop.Watchers, Is.Empty);
+                    }
+                    else
+                    {
+                        Assert.That(laptop.LinkedSentries, Is.EquivalentTo(new[] { expected }));
+                        Assert.That(laptop.SentryCustomNames[expected], Is.EqualTo("North gate"));
+                        Assert.That(laptop.Watchers, Is.EqualTo(new[] { expected }));
+                    }
                     Assert.That(projectile.Shooter, Is.EqualTo(expected));
                     Assert.That(projectile.Weapon, Is.EqualTo(expected));
                     Assert.That(projectile.MaxFixedRange, Is.EqualTo(17f));

--- a/Content.Server/Database/ServerDbBase.cs
+++ b/Content.Server/Database/ServerDbBase.cs
@@ -109,6 +109,9 @@ namespace Content.Server.Database
                 return;
             }
 
+            // EF can insert the replacement high-priority job before deleting the old one. PostgreSQL's
+            // filtered unique index checks each statement, so flush removals first in the same transaction.
+            await using var transaction = await db.DbContext.Database.BeginTransactionAsync();
             var oldProfile = db.DbContext.Profile
                 .Include(p => p.Preference)
                 .Where(p => p.Preference.UserId == userId.UserId)
@@ -122,6 +125,12 @@ namespace Content.Server.Database
                 .Include(p => p.SquadPreference)
                 .AsSplitQuery()
                 .SingleOrDefault(h => h.Slot == slot);
+
+            if (oldProfile is { Jobs.Count: > 0 })
+            {
+                oldProfile.Jobs.Clear();
+                await db.DbContext.SaveChangesAsync();
+            }
 
             var newProfile = ConvertProfiles(humanoid, slot, oldProfile);
             if (oldProfile == null)
@@ -138,6 +147,7 @@ namespace Content.Server.Database
             }
 
             await db.DbContext.SaveChangesAsync();
+            await transaction.CommitAsync();
         }
 
         private static async Task DeleteCharacterSlot(ServerDbContext db, NetUserId userId, int slot)

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -176,6 +176,7 @@ namespace Content.Server.Entry
         public override void Update(ModUpdateLevel level, FrameEventArgs frameEventArgs)
         {
             base.Update(level, frameEventArgs);
+            _performanceDiagnostics.ObservePhase(level);
 
             switch (level)
             {

--- a/Content.Server/Movement/Systems/PullController.cs
+++ b/Content.Server/Movement/Systems/PullController.cs
@@ -106,7 +106,7 @@ public sealed partial class PullController : VirtualController
     private bool OnRequestMovePulledObject(ICommonSession? session, EntityCoordinates coords, EntityUid uid)
     {
         if (session?.AttachedEntity is not { } player ||
-            !player.IsValid())
+            !player.IsValid() || !coords.IsValid(EntityManager))
         {
             return false;
         }

--- a/Content.Server/_RMC14/Sentry/SentryLaptopSystem.cs
+++ b/Content.Server/_RMC14/Sentry/SentryLaptopSystem.cs
@@ -256,6 +256,7 @@ public sealed partial class SentryLaptopSystem : SharedSentryLaptopSystem
 
     private void OnSentryShutdown(Entity<SentryComponent> sentry, ref ComponentShutdown args)
     {
+        UnlinkSentryFromLaptops(sentry);
         var sentryNet = GetNetEntity(sentry.Owner);
         var watchers = EntityQueryEnumerator<SentryLaptopWatcherComponent>();
 

--- a/Content.Shared/CCVar/CCVars.CMU.PerformanceDiagnostics.cs
+++ b/Content.Shared/CCVar/CCVars.CMU.PerformanceDiagnostics.cs
@@ -14,7 +14,7 @@ public sealed partial class CCVars
     ///     Enable the [CMU-PERF] log output. Doesn't influence normal metrics/collection, profiler or incident trackers.
     /// </summary>
     public static readonly CVarDef<bool> CMUServerPerformanceLogEnabled =
-        CVarDef.Create("cmu.server_performance.log_enabled", false, CVar.SERVERONLY | CVar.ARCHIVE);
+        CVarDef.Create("cmu.server_performance.log_enabled", true, CVar.SERVERONLY | CVar.ARCHIVE);
 
     /// <summary>
     ///     Seconds between full performance observations. Hard frame stalls are checked every server frame.

--- a/Content.Shared/Paper/PaperSystem.cs
+++ b/Content.Shared/Paper/PaperSystem.cs
@@ -104,7 +104,7 @@ public sealed partial class PaperSystem : EntitySystem
             if (entity.Comp.StampedBy.Count > 0)
             {
                 var commaSeparated =
-                    string.Join(", ", entity.Comp.StampedBy.Select(s => Loc.GetString(s.StampedName)));
+                    string.Join(", ", entity.Comp.StampedBy.Select(s => s.GetDisplayName()));
                 args.PushMarkup(
                     Loc.GetString(
                         "paper-component-examine-detail-stamped-by",

--- a/Content.Shared/Paper/StampComponent.cs
+++ b/Content.Shared/Paper/StampComponent.cs
@@ -22,6 +22,12 @@ public partial struct StampDisplayInfo
 
     [DataField("stampedColor")]
     public Color StampedColor;
+
+    /// <summary>Custom stamp labels are literal text; stock stamps use localization IDs.</summary>
+    public readonly string GetDisplayName()
+    {
+        return Loc.TryGetString(StampedName, out var localized) ? localized : StampedName;
+    }
 };
 
 [RegisterComponent]

--- a/Content.Shared/_RMC14/Construction/RMCConstructionPreventCollideComponent.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionPreventCollideComponent.cs
@@ -2,12 +2,12 @@
 
 namespace Content.Shared._RMC14.Construction;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 public sealed partial class RMCConstructionPreventCollideComponent : Component
 {
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float Range = 0.75f;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? Target;
 }

--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.State.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.State.cs
@@ -1,0 +1,29 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Construction;
+
+public sealed partial class RMCConstructionSystem
+{
+    private void OnPreventCollideGetState(Entity<RMCConstructionPreventCollideComponent> ent, ref ComponentGetState args)
+    {
+        TryGetNetEntity(ent.Comp.Target, out var target);
+        args.State = new RMCConstructionPreventCollideComponentState(ent.Comp.Range, target);
+    }
+
+    private void OnPreventCollideHandleState(Entity<RMCConstructionPreventCollideComponent> ent, ref ComponentHandleState args)
+    {
+        if (args.Current is not RMCConstructionPreventCollideComponentState state)
+            return;
+
+        ent.Comp.Range = state.Range;
+        ent.Comp.Target = EnsureEntity<RMCConstructionPreventCollideComponent>(state.Target, ent);
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class RMCConstructionPreventCollideComponentState(float range, NetEntity? target) : ComponentState
+{
+    public float Range { get; } = range;
+    public NetEntity? Target { get; } = target;
+}

--- a/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
+++ b/Content.Shared/_RMC14/Construction/RMCConstructionSystem.cs
@@ -19,6 +19,7 @@ using Content.Shared.Physics;
 using Content.Shared.Popups;
 using Content.Shared.Stacks;
 using Robust.Shared.Map;
+using Robust.Shared.GameStates;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Collision.Shapes;
@@ -60,6 +61,8 @@ public sealed partial class RMCConstructionSystem : EntitySystem
         SubscribeLocalEvent<DropshipHijackLandedEvent>(OnDropshipHijackLanded);
 
         SubscribeLocalEvent<RMCConstructionPreventCollideComponent, PreventCollideEvent>(OnConstructionPreventCollide);
+        SubscribeLocalEvent<RMCConstructionPreventCollideComponent, ComponentGetState>(OnPreventCollideGetState);
+        SubscribeLocalEvent<RMCConstructionPreventCollideComponent, ComponentHandleState>(OnPreventCollideHandleState);
 
         SubscribeLocalEvent<RMCConstructionItemComponent, UseInHandEvent>(OnUseInHand);
         SubscribeLocalEvent<RMCConstructionItemComponent, RMCConstructionBuildDoAfterEvent>(OnBuildDoAfter);

--- a/Content.Shared/_RMC14/Emplacements/SharedWeaponMountSystem.cs
+++ b/Content.Shared/_RMC14/Emplacements/SharedWeaponMountSystem.cs
@@ -504,7 +504,8 @@ public abstract partial class SharedWeaponMountSystem : EntitySystem
             _scope.StartScoping((weapon, scope), args.Buckle);
         }
 
-        _actions.AddAction(args.Buckle, ref ent.Comp.DismountActionEntity, ent.Comp.DismountAction, args.Buckle);
+        // The mount owns this reusable action; successive operators only receive it temporarily.
+        _actions.AddAction(args.Buckle, ref ent.Comp.DismountActionEntity, ent.Comp.DismountAction, ent.Owner);
     }
 
     private void OnUnStrapped(Entity<WeaponMountComponent> ent, ref UnstrappedEvent args)

--- a/Content.Shared/_RMC14/Entrenching/BarricadeSystem.cs
+++ b/Content.Shared/_RMC14/Entrenching/BarricadeSystem.cs
@@ -844,6 +844,10 @@ public sealed partial class BarricadeSystem : EntitySystem
         grid = default;
         tileRef = default;
 
+        // A repeated dig do-after can outlive the grid that supplied its original coordinates.
+        if (!coordinates.IsValid(EntityManager))
+            return false;
+
         if (checkUseDelay &&
             TryComp(tool, out UseDelayComponent? useDelay) &&
             _useDelay.IsDelayed((tool, useDelay)))

--- a/Content.Shared/_RMC14/Localizations/RMCLocalizationManager.cs
+++ b/Content.Shared/_RMC14/Localizations/RMCLocalizationManager.cs
@@ -86,7 +86,8 @@ public sealed partial class RMCLocalizationManager
             return true;
         }
 
-        if (_entity.GetComponent<MetaDataComponent>(entity).EntityPrototype is not {} prototype)
+        if (!_entity.TryGetComponent<MetaDataComponent>(entity, out var metadata) ||
+            metadata.EntityPrototype is not {} prototype)
         {
             value = null;
             return false;

--- a/Content.Shared/_RMC14/Sensor/SensorTowerSystem.cs
+++ b/Content.Shared/_RMC14/Sensor/SensorTowerSystem.cs
@@ -189,6 +189,9 @@ public sealed partial class SensorTowerSystem : EntitySystem
             return;
         }
 
+        if (ent.Comp.State is SensorTowerState.Off or SensorTowerState.On)
+            return;
+
         var correctQuality = ent.Comp.State switch
         {
             SensorTowerState.Weld => ent.Comp.WeldingQuality,

--- a/Content.Shared/_RMC14/Sentry/Laptop/SentryLaptopComponent.cs
+++ b/Content.Shared/_RMC14/Sentry/Laptop/SentryLaptopComponent.cs
@@ -5,32 +5,32 @@ using Robust.Shared.Serialization;
 
 namespace Content.Shared._RMC14.Sentry.Laptop;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedSentryLaptopSystem))]
 public sealed partial class SentryLaptopComponent : Component
 {
-    [DataField, AutoNetworkedField]
+    [DataField]
     public bool IsOpen;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public bool IsPowered;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public float Range = 20f;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public HashSet<EntityUid> LinkedSentries = new();
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public int MaxLinkedSentries = 99;
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public Dictionary<EntityUid, string> SentryCustomNames = new();
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public List<EntityUid> Watchers = new();
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public EntityUid? CurrentCamera;
 
 }

--- a/Content.Shared/_RMC14/Sentry/Laptop/SharedSentryLaptopSystem.State.cs
+++ b/Content.Shared/_RMC14/Sentry/Laptop/SharedSentryLaptopSystem.State.cs
@@ -1,0 +1,74 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Sentry.Laptop;
+
+public abstract partial class SharedSentryLaptopSystem
+{
+    private void OnLaptopGetState(Entity<SentryLaptopComponent> ent, ref ComponentGetState args)
+    {
+        // PVS builds states in parallel. Filter copies rather than repairing gameplay collections here.
+        // Several deleted dictionary keys would otherwise all become NetEntity.Invalid and collide.
+        var sentries = new HashSet<NetEntity>();
+        foreach (var sentry in ent.Comp.LinkedSentries)
+        {
+            if (TryGetNetEntity(sentry, out var net) && net != NetEntity.Invalid)
+                sentries.Add(net.Value);
+        }
+
+        var names = new Dictionary<NetEntity, string>();
+        foreach (var (sentry, name) in ent.Comp.SentryCustomNames)
+        {
+            if (TryGetNetEntity(sentry, out var net) && net != NetEntity.Invalid)
+                names.Add(net.Value, name);
+        }
+
+        var watchers = new List<NetEntity>();
+        foreach (var watcher in ent.Comp.Watchers)
+        {
+            if (TryGetNetEntity(watcher, out var net) && net != NetEntity.Invalid)
+                watchers.Add(net.Value);
+        }
+
+        TryGetNetEntity(ent.Comp.CurrentCamera, out var camera);
+        args.State = new SentryLaptopComponentState
+        {
+            IsOpen = ent.Comp.IsOpen,
+            IsPowered = ent.Comp.IsPowered,
+            Range = ent.Comp.Range,
+            LinkedSentries = sentries,
+            MaxLinkedSentries = ent.Comp.MaxLinkedSentries,
+            SentryCustomNames = names,
+            Watchers = watchers,
+            CurrentCamera = camera,
+        };
+    }
+
+    private void OnLaptopHandleState(Entity<SentryLaptopComponent> ent, ref ComponentHandleState args)
+    {
+        if (args.Current is not SentryLaptopComponentState state)
+            return;
+
+        ent.Comp.IsOpen = state.IsOpen;
+        ent.Comp.IsPowered = state.IsPowered;
+        ent.Comp.Range = state.Range;
+        EnsureEntitySet<SentryLaptopComponent>(state.LinkedSentries, ent, ent.Comp.LinkedSentries);
+        ent.Comp.MaxLinkedSentries = state.MaxLinkedSentries;
+        EnsureEntityDictionary<SentryLaptopComponent, string>(state.SentryCustomNames, ent, ent.Comp.SentryCustomNames);
+        EnsureEntityList<SentryLaptopComponent>(state.Watchers, ent, ent.Comp.Watchers);
+        ent.Comp.CurrentCamera = EnsureEntity<SentryLaptopComponent>(state.CurrentCamera, ent);
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class SentryLaptopComponentState : ComponentState
+{
+    public bool IsOpen { get; init; }
+    public bool IsPowered { get; init; }
+    public float Range { get; init; }
+    public HashSet<NetEntity> LinkedSentries { get; init; } = new();
+    public int MaxLinkedSentries { get; init; }
+    public Dictionary<NetEntity, string> SentryCustomNames { get; init; } = new();
+    public List<NetEntity> Watchers { get; init; } = new();
+    public NetEntity? CurrentCamera { get; init; }
+}

--- a/Content.Shared/_RMC14/Sentry/Laptop/SharedSentryLaptopSystem.cs
+++ b/Content.Shared/_RMC14/Sentry/Laptop/SharedSentryLaptopSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Weapons.Ranged.Systems;
 using Content.Shared.DeviceNetwork.Components;
 using Robust.Shared.GameObjects;
 using Robust.Shared.Containers;
+using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
 using SentryAlertEvent = Content.Shared._RMC14.Sentry.Laptop.SentryAlertEvent;
@@ -58,6 +59,8 @@ public abstract partial class SharedSentryLaptopSystem : EntitySystem
         SubscribeLocalEvent<SentryLaptopComponent, ComponentShutdown>(OnLaptopShutdown);
         SubscribeLocalEvent<SentryLaptopComponent, ActivatableUIOpenAttemptEvent>(OnLaptopUIOpenAttempt);
         SubscribeLocalEvent<SentryLaptopComponent, EntParentChangedMessage>(OnLaptopParentChanged);
+        SubscribeLocalEvent<SentryLaptopComponent, ComponentGetState>(OnLaptopGetState);
+        SubscribeLocalEvent<SentryLaptopComponent, ComponentHandleState>(OnLaptopHandleState);
 
         SubscribeLocalEvent<SentryLaptopLinkedComponent, ComponentShutdown>(OnSentryLinkedShutdown);
 
@@ -499,22 +502,43 @@ public abstract partial class SharedSentryLaptopSystem : EntitySystem
 
     public void UnlinkSentry(Entity<SentryLaptopComponent> laptop, EntityUid sentry)
     {
-        if (!laptop.Comp.LinkedSentries.Remove(sentry))
+        // Device-link cleanup may already have removed the cached link. Names must still be removed.
+        var changed = laptop.Comp.LinkedSentries.Remove(sentry);
+        changed |= laptop.Comp.SentryCustomNames.Remove(sentry);
+
+        if (TryComp<DeviceLinkSourceComponent>(laptop, out var source) &&
+            TryComp<DeviceLinkSinkComponent>(sentry, out var sink))
+            _deviceLink.RemoveSinkFromSource(laptop, sentry, source, sink);
+
+        if (TryComp<SentryLaptopLinkedComponent>(sentry, out var linked) && linked.LinkedLaptop == laptop.Owner)
+        {
+            linked.LinkedLaptop = null;
+            if (linked.LifeStage < ComponentLifeStage.Stopping)
+                RemComp<SentryLaptopLinkedComponent>(sentry);
+        }
+
+        if (!changed)
             return;
 
-        if (TryComp<DeviceLinkSinkComponent>(sentry, out var sink))
-            _deviceLink.RemoveAllFromSink(sentry, sink);
-
-        laptop.Comp.SentryCustomNames.Remove(sentry);
-        RemComp<SentryLaptopLinkedComponent>(sentry);
-
-        if (TryComp<SentryTargetingComponent>(sentry, out var targeting))
+        if (!TerminatingOrDeleted(sentry) && TryComp<SentryTargetingComponent>(sentry, out var targeting))
             _sentryTargeting.ResetToDefault((sentry, targeting));
 
         if (laptop.Comp.LinkedSentries.Count == 0)
             SetPowered(laptop, false);
 
         Dirty(laptop);
+    }
+
+    protected void UnlinkSentryFromLaptops(EntityUid sentry)
+    {
+        // A device can be linked to multiple laptops, while its legacy backlink stores only one.
+        var query = EntityQueryEnumerator<SentryLaptopComponent>();
+        while (query.MoveNext(out var uid, out var laptop))
+        {
+            if (!TerminatingOrDeleted(uid) &&
+                (laptop.LinkedSentries.Contains(sentry) || laptop.SentryCustomNames.ContainsKey(sentry)))
+                UnlinkSentry((uid, laptop), sentry);
+        }
     }
 
     private void UnlinkAllSentries(Entity<SentryLaptopComponent> laptop)
@@ -642,15 +666,25 @@ public abstract partial class SharedSentryLaptopSystem : EntitySystem
     {
         var linked = new List<EntityUid>();
 
-        if (TryComp<DeviceLinkSourceComponent>(laptop, out var source))
+        if (_net.IsServer && TryComp<DeviceLinkSourceComponent>(laptop, out var source))
         {
             foreach (var sink in source.LinkedPorts.Keys)
             {
-                if (HasComp<SentryComponent>(sink))
+                if (!TerminatingOrDeleted(sink) && HasComp<SentryComponent>(sink))
                     linked.Add(sink);
             }
 
-            laptop.Comp.LinkedSentries = linked.ToHashSet();
+            foreach (var stale in laptop.Comp.LinkedSentries.Concat(laptop.Comp.SentryCustomNames.Keys).Distinct().ToArray())
+            {
+                if (!linked.Contains(stale))
+                    UnlinkSentry(laptop, stale);
+            }
+
+            if (!laptop.Comp.LinkedSentries.SetEquals(linked))
+            {
+                laptop.Comp.LinkedSentries = linked.ToHashSet();
+                Dirty(laptop);
+            }
             return linked;
         }
 

--- a/Content.Tests/Server/_CMU14/Diagnostics/Performance/CMUPerformanceErrorTrackerTest.cs
+++ b/Content.Tests/Server/_CMU14/Diagnostics/Performance/CMUPerformanceErrorTrackerTest.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Content.Server.CMU14.Diagnostics.Performance;
+using NUnit.Framework;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Content.Tests.Server.CMU14.Diagnostics.Performance;
+
+[TestFixture]
+public sealed class CMUPerformanceErrorTrackerTest
+{
+    [Test]
+    public void ConcurrentStormIsCountedWithoutRetainingEveryException()
+    {
+        var tracker = new CMUPerformanceErrorTracker();
+        var message = Message(LogEventLevel.Error);
+        Parallel.For(0, 10000, _ => tracker.Log("system.pvs", message));
+        var snapshot = tracker.Drain();
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Total, Is.EqualTo(10000));
+            Assert.That(snapshot.Sources, Has.Length.EqualTo(1));
+            Assert.That(snapshot.Sources[0].Count, Is.EqualTo(10000));
+            Assert.That(snapshot.Sources[0].Last, Is.SameAs(message));
+            Assert.That(tracker.Drain().Total, Is.Zero);
+        });
+    }
+
+    [Test]
+    public void BoundsSourcesAndIgnoresDiagnosticFeedback()
+    {
+        var tracker = new CMUPerformanceErrorTracker();
+        for (var i = 0; i < 100; i++)
+            tracker.Log($"source{i}", Message(LogEventLevel.Error));
+        tracker.Log("system.pvs", Message(LogEventLevel.Warning));
+        tracker.Log("cmu.server-performance", Message(LogEventLevel.Error));
+        tracker.Log("cmu.client_state", Message(LogEventLevel.Error));
+        var snapshot = tracker.Drain();
+        Assert.Multiple(() =>
+        {
+            Assert.That(snapshot.Total, Is.EqualTo(100));
+            Assert.That(snapshot.Sources, Has.Length.EqualTo(CMUPerformanceErrorTracker.SourceCapacity));
+            Assert.That(snapshot.Overflow + snapshot.Sources.Sum(source => source.Count), Is.EqualTo(100));
+        });
+        tracker.Log("system.pvs", Message(LogEventLevel.Error));
+        Assert.That(tracker.Drain().Sources.Single().Sawmill, Is.EqualTo("system.pvs"));
+    }
+
+    private static LogEvent Message(LogEventLevel level) => new(DateTimeOffset.UtcNow, level,
+        new InvalidOperationException("network state failed"), new MessageTemplateParser().Parse("state failure"),
+        Array.Empty<LogEventProperty>());
+}

--- a/Content.Tests/Server/_CMU14/Diagnostics/Performance/CMUPerformancePhaseTrackerTest.cs
+++ b/Content.Tests/Server/_CMU14/Diagnostics/Performance/CMUPerformancePhaseTrackerTest.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq;
+using Content.Server.CMU14.Diagnostics.Performance;
+using NUnit.Framework;
+using Robust.Shared.ContentPack;
+
+namespace Content.Tests.Server.CMU14.Diagnostics.Performance;
+
+[TestFixture]
+public sealed class CMUPerformancePhaseTrackerTest
+{
+    [Test]
+    public void SeparatesStateSendStallFromSimulationAndIdleTime()
+    {
+        var phases = new CMUPerformancePhaseTracker();
+        phases.Mark(ModUpdateLevel.PreEngine, TimeSpan.Zero, 100);
+        phases.Mark(ModUpdateLevel.PostEngine, TimeSpan.FromMilliseconds(10), 100);
+        phases.Mark(ModUpdateLevel.FramePreEngine, TimeSpan.FromMilliseconds(12010), 100);
+        phases.Mark(ModUpdateLevel.FramePostEngine, TimeSpan.FromMilliseconds(12011), 100);
+        phases.Mark(ModUpdateLevel.InputPostEngine, TimeSpan.FromMilliseconds(13011), 101);
+        var rows = phases.Drain();
+        Assert.Multiple(() =>
+        {
+            Assert.That(rows.Single(row => row.Name == "timers-tasks-and-simulation").MaxMs, Is.EqualTo(10));
+            Assert.That(rows.Single(row => row.Name == "post-tick-and-state-send").MaxMs, Is.EqualTo(12000));
+            Assert.That(rows.Single(row => row.Name == "post-tick-and-state-send").WorstTick, Is.EqualTo(100));
+            Assert.That(rows.Single(row => row.Name == "frame-tail-wait-and-input").MaxMs, Is.EqualTo(1000));
+            Assert.That(phases.Drain(), Is.Empty);
+        });
+        phases.Clear();
+        phases.Mark(ModUpdateLevel.PreEngine, TimeSpan.FromSeconds(20), 200);
+        Assert.That(phases.Drain(), Is.Empty, "Reset must not attribute downtime to a running tick.");
+    }
+}

--- a/Resources/Prototypes/_RMC14/Actions/Marines/marine_action_items.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Marines/marine_action_items.yml
@@ -506,6 +506,7 @@
   components:
   - type: Action
     itemIconStyle: NoItem
+    raiseOnUser: true
   - type: Sprite
     layers:
     - sprite: _RMC14/Actions/marine_emplacement_actions.rsi


### PR DESCRIPTION
## About the PR

Deleted sentries could remain in laptop links and custom-name dictionaries. Several deleted keys then became the same invalid network ID, throwing during state generation and repeatedly disrupting state delivery. The supplied session logs contained an error flood alongside movement delays.

Filter outgoing laptop state without mutating gameplay collections on PVS worker threads, clean up all affected laptops when a sentry is removed, and safely serialize stale construction collision targets.

## Technical details

- Fix additional log failures involving deleted snare users, repaired sensor-tower interactions, reusable dismount actions, non-stack cartridge prediction, custom stamp labels, stale localization/dig/pull targets, and character job-priority replacement.
- Make the UPP GROM sidearm belt fit its capacity by loading two QYJ magazines instead of three.
- Enable CMU performance log output by default. Add bounded, thread-safe error counts and samples plus wall-time measurements between existing module callbacks.
- Allow a severe new stall to produce a fresh detailed report during an existing incident, capped at once every 30 seconds.

## Test plan

- 19 focused integration checks passed, including live/deleted entity replication, sentry cleanup, successive dismount operators, sensor towers, snares, stamps, belt contents, SQLite job-priority replacement, and client sandbox validation.
- 18 diagnostics unit tests passed, including a 10,000-error concurrent storm and phase timing attribution.
- Client, server, and shared content compiled; `git diff --check` passed.
- Tests used a separate output directory because a running local server locked the usual output files. The existing files changed by this PR were identical on the tested checkout and the current master base.
- PostgreSQL and production stall recovery still require live verification. Remaining unexplained engine errors are not claimed fixed.

For a live check, link and name multiple sentries, delete them, and confirm movement/state delivery remains responsive without repeated laptop serialization errors. Use `cmuperf report` to inspect `phase-window`, `error-window`, and `error-source` records.

## Breaking changes

Client and server must use matching content builds because the component-state contracts changed. Existing servers with an explicit `cmu.server_performance.log_enabled = false` setting must enable it to receive the new logs. Phase timings and coincident errors aid diagnosis; they do not prove CPU or GC attribution.

## Media

Bug fixes and diagnostics; no visual showcase required.

**Changelog**
:cl:
- fix: Fixed deleted sentries causing repeated network-state failures and delayed updates.
- fix: Fixed several equipment, interaction, stamp, and character-save errors.
- admin: Added bounded error summaries and phase timings to server stall reports.
