### PR TITLE
Sort abilities properly for immature and matured queens

### DIFF
--- a/Content.Server/_RMC14/Actions/RMCActionsSystem.cs
+++ b/Content.Server/_RMC14/Actions/RMCActionsSystem.cs
@@ -15,6 +15,7 @@ public sealed partial class RMCActionsSystem : SharedRMCActionsSystem
     [Dependency] private IComponentFactory _componentFactory = default!;
     [Dependency] private RMCActionsManager _manager = default!;
     [Dependency] private IPrototypeManager _prototypes = default!;
+    [Dependency] private readonly ISharedPlayerManager _player = default!;
 
     private readonly Dictionary<(NetUserId User, EntProtoId Id), RMCActionOrderData> _toUpdate = new();
     private string _actionComponentName = string.Empty;
@@ -28,6 +29,7 @@ public sealed partial class RMCActionsSystem : SharedRMCActionsSystem
 
         SubscribeNetworkEvent<RMCActionOrderChangeEvent>(OnActionOrder);
 
+        SubscribeLocalEvent<RMCActionOrderComponent, ComponentStartup>(OnOrderStartup); // CMU14
         SubscribeLocalEvent<RMCActionOrderComponent, PlayerAttachedEvent>(OnOrderAttached);
     }
 
@@ -73,15 +75,37 @@ public sealed partial class RMCActionsSystem : SharedRMCActionsSystem
         }
     }
 
+    // CMU14 method
+    private void OnOrderStartup(Entity<RMCActionOrderComponent> ent, ref ComponentStartup args)
+    {
+        // Entities swap this component out to change which order they use, e.g. queen maturing into extra abilities.
+        if (_player.TryGetSessionByEntity(ent, out var player))
+            LoadOrder(ent, player);
+    }
+
+    // CMU14 method
     private void OnOrderAttached(Entity<RMCActionOrderComponent> ent, ref PlayerAttachedEvent args)
     {
-        if (_manager.GetOrder(args.Player.UserId, ent.Comp.Id) is not { } order)
+        LoadOrder(ent, args.Player);
+    }
+
+    // CMU14 method
+    private void LoadOrder(Entity<RMCActionOrderComponent> ent, ICommonSession player)
+    {
+        if (_manager.GetOrder(player.UserId, ent.Comp.Id) is not { } order)
             return;
 
         ent.Comp.Order = order.Actions;
         ent.Comp.HiddenActions = order.HiddenActions;
         ent.Comp.HiddenActionsKnown = order.HiddenActionsKnown;
         Dirty(ent);
+
+        // The actions saved under this id are not the ones the client sorted itself by, so make it sort again.
+        var ev = new RMCActionOrderLoadedEvent(
+            order.Actions.ToList(),
+            order.HiddenActions.ToList(),
+            order.HiddenActionsKnown);
+        RaiseNetworkEvent(ev, player);
     }
 
     private void OnLoaded(ICommonSession user, Dictionary<EntProtoId, RMCActionOrderData>? allActions)

--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/queen.yml
@@ -245,6 +245,9 @@
     addComponents:
     - type: XenoScreech
     - type: XenoQueenSpit
+    # CMU14 - Overwrites the immature order, so matured queens order their extra abilities correctly
+    - type: RMCActionOrder
+      id: CMXenoQueen
     addActions:
     - ActionXenoScreech
     - ActionXenoQueenSpit
@@ -318,12 +321,17 @@
     components:
     - type: RMCGibOnDeath
 
+# CMU14 - Queens start immature, so this is the id their action bar order is saved under until they mature
+- type: entity
+  abstract: true
+  id: CMXenoQueenImmature
+
 - type: entity
   parent: RMCXenoQueenBase
   id: CMXenoQueen
   components:
   - type: RMCActionOrder
-    id: CMXenoQueen
+    id: CMXenoQueenImmature
   # - type: XenoEvolution #can be enabled for events like april fools.
   #   strains:
   #   - RMCXenoQueenMaid


### PR DESCRIPTION
<!-- Guidelines: CONTRIBUTING.md at the repository root --> <!-- CMU14 -->

## About the PR
Queens would constantly have to sort their action bar upon spawning due to both immature and mature states having different abilities. This makes it so that you don't have to re-sort your ability bar every round as queen both when you spawn and when you mature.

## Why / Balance
QOL

## Technical details
Added `OnOrderStartup` method to reload a player's saved action order when their actionorder comp is initialized or replaced, so their action bar is correctly updated when their action order changes. Moved the action-order loading logic from `OnOrderAttached` into the `LoadOrder()` method.

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Spawned in xeno queen, sorted abilities for both immature and mature states. 
Reboot localhost to simulate starting new round(too lazy to golobby), make sure that ability ordering for both states remain the same. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [contributing guidelines](CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] My tests assert behavior that can break: no locked-in values or mirrored implementation ([CONVENTIONS.md](CONVENTIONS.md#tests)).
- [X] Every change outside the CMU zones carries a CMU14 tag; new files and prototypes are in CMU zones.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Queen now has separate ability bar ordering for both immature and mature states to avoid having to redo them every time you spawn in.