### PR TITLE
Makes certain vehicles visible with xeno nightvision

### DIFF
--- a/Content.CMU/Resources/Prototypes/CMU14/Vehicles/Blackfoot/vehicles.yml
+++ b/Content.CMU/Resources/Prototypes/CMU14/Vehicles/Blackfoot/vehicles.yml
@@ -4,6 +4,8 @@
   name: AD-71E Blackfoot
   description: A compact VTOL aircraft intended for multi-Z operations.
   components:
+  - type: RMCNightVisionVisible
+    priority: -2
   - type: Vehicle
     movementKind: Grid
     transferDamage: false

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
@@ -4,6 +4,8 @@
   name: armored personnel carrier
   description: A rugged armored personnel carrier outfitted for battlefield support.
   components:
+  - type: RMCNightVisionVisible # CMU14
+    priority: -2
   - type: Vehicle
     movementKind: Grid
     transferDamage: false

--- a/Resources/Prototypes/_RMC14/Vehicles/Common/turret_visuals.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Common/turret_visuals.yml
@@ -10,3 +10,5 @@
     sprite: _RMC14/Structures/Vehicles/hardpoints/humvee.rsi
     state: humveeturret
   - type: VehicleTurretVisual
+  - type: RMCNightVisionVisible # CMU14
+    priority: -1

--- a/Resources/Prototypes/_RMC14/Vehicles/Humvee/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Humvee/vehicles.yml
@@ -4,6 +4,8 @@
   name: humvee
   description: A fast armored utility vehicle outfitted for patrols and support.
   components:
+  - type: RMCNightVisionVisible # CMU14
+    priority: -2
   - type: Vehicle
     movementKind: Grid
     transferDamage: false

--- a/Resources/Prototypes/_RMC14/Vehicles/Tank/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/Tank/vehicles.yml
@@ -4,6 +4,8 @@
   name: M34A2 Longstreet
   description: "An older light tank made for all ground forces of the United Americas, although being phased out due to being outdated by the American Army and the CCAF, the longstreet still remains in service with USCM and LACN detachments in colonial sectors."
   components:
+  - type: RMCNightVisionVisible # CMU14
+    priority: -2
   - type: Vehicle
     movementKind: Grid
     transferDamage: false


### PR DESCRIPTION
<!-- Guidelines: CONTRIBUTING.md at the repository root --> <!-- CMU14 -->

## About the PR
Made xenos able to see certain vehicles through walls. This includes the various tanks, APC, humvee, blackfoot, and vehicle weapon mounts. Civilian vehicles were not included in this change because they are not round-impacting.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This decision was made mostly because of design philosophy, but is also an upstream change from RMC. The queen, for instance, is both loud _and_ large. Her position needs to be known at all times because she is a round-driving factor in the game and is extremely dangerous. This balancing should also apply to large, govfor-supporting vehicles like tanks and APCs. They need to be both visible and audible as they are very capable of round removing people with the weapons they sport, and with this change, allowing for a little more accessibility as some people may not always have access to audio cues. 

## Test plan
<!--
Spawned in all listed vehicles. Played as a xeno and observed them from behind walls.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->
<img width="981" height="555" alt="image" src="https://github.com/user-attachments/assets/d14d623a-b33d-4114-bfa8-3f65593415ba" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [contributing guidelines](CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] My tests assert behavior that can break: no locked-in values or mirrored implementation ([CONVENTIONS.md](CONVENTIONS.md#tests)).
- [X] Every change outside the CMU zones carries a CMU14 tag; new files and prototypes are in CMU zones.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Added xeno vision to large vehicles.