### PR TITLE
Xeno acid remains toggled on use

### DIFF
--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -13,6 +13,7 @@
       state: corrosive_acid
       map: ["enum.ActionVisuals.Icon"]
   - type: TargetAction
+    repeat: true
     checkCanAccess: false
     range: 2
   - type: EntityTargetAction

--- a/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
+++ b/Resources/Prototypes/_RMC14/Actions/Xeno/xeno_offense_actions.yml
@@ -13,7 +13,7 @@
       state: corrosive_acid
       map: ["enum.ActionVisuals.Icon"]
   - type: TargetAction
-    repeat: true
+    repeat: true # CMU14
     checkCanAccess: false
     range: 2
   - type: EntityTargetAction


### PR DESCRIPTION
<!-- Guidelines: CONTRIBUTING.md at the repository root --> <!-- CMU14 -->

## About the PR
<!-- What did you change? -->
Made acid a toggle instead of the ability having to be reselected everytime you used it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Acid is frequently used to melt objects en masse, this just makes it less annoying to do so.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [contributing guidelines](CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] My tests assert behavior that can break: no locked-in values or mirrored implementation ([CONVENTIONS.md](CONVENTIONS.md#tests)).
- [X] Every change outside the CMU zones carries a CMU14 tag; new files and prototypes are in CMU zones.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Xeno acid action remains toggled until deactivated or another ability is used.