### PR TITLE
Fix area-power synchronization errors and improve stall diagnostics

### DIFF
--- a/Content.CMU/Client/Diagnostics/CMUClientStateHealthSystem.cs
+++ b/Content.CMU/Client/Diagnostics/CMUClientStateHealthSystem.cs
@@ -1,0 +1,75 @@
+using Content.Shared.CCVar;
+using Content.Shared.CMU14.Diagnostics;
+using Robust.Client.GameStates;
+using Robust.Shared.Configuration;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Network;
+using Robust.Shared.Timing;
+
+namespace Content.Client.CMU14.Diagnostics;
+
+/// <summary>Reports state-application callbacks, independently of receipt ACKs and predicted simulation ticks.</summary>
+public sealed partial class CMUClientStateHealthSystem : EntitySystem
+{
+    [Dependency] private IClientGameStateManager _states = default!;
+    [Dependency] private IClientNetManager _net = default!;
+    [Dependency] private IConfigurationManager _config = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    private GameTick _appliedTick;
+    private TimeSpan _appliedAt;
+    private TimeSpan _nextReport;
+    private bool _enabled;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _states.GameStateApplied += OnStateApplied;
+        _net.ClientConnectStateChanged += OnConnectionChanged;
+        Subs.CVar(_config, CCVars.CMUClientStateHealthEnabled, value => _enabled = value, true);
+    }
+
+    public override void Shutdown()
+    {
+        _states.GameStateApplied -= OnStateApplied;
+        _net.ClientConnectStateChanged -= OnConnectionChanged;
+        base.Shutdown();
+    }
+
+    private void OnConnectionChanged(ClientConnectionState state)
+    {
+        _appliedTick = GameTick.Zero;
+        _nextReport = _timing.RealTime + TimeSpan.FromSeconds(5);
+    }
+
+    private void OnStateApplied(GameStateAppliedArgs args)
+    {
+        // Reapplying the same state is not forward progress.
+        if (args.AppliedState.ToSequence <= _appliedTick)
+            return;
+        _appliedTick = args.AppliedState.ToSequence;
+        _appliedAt = _timing.RealTime;
+    }
+
+    public override void FrameUpdate(float frameTime)
+    {
+        if (!_enabled || !_net.IsConnected || _timing.RealTime < _nextReport)
+            return;
+        ReportHealth();
+    }
+
+    internal void ReportHealth()
+    {
+        _nextReport = _timing.RealTime + TimeSpan.FromSeconds(5);
+        var fps = _timing.FramesPerSecondAvg;
+        RaiseNetworkEvent(new CMUClientStateHealthEvent
+        {
+            AppliedTick = _appliedTick,
+            AppliedAgeSeconds = _appliedTick == GameTick.Zero ? -1 : (_timing.RealTime - _appliedAt).TotalSeconds,
+            BufferedStates = _states.StateCount,
+            TargetBuffer = _states.TargetBufferSize,
+            // No completed frame samples can produce infinity. Keep application evidence usable.
+            AverageFps = double.IsFinite(fps) && fps is >= 0 and <= 10000 ? fps : -1,
+        });
+    }
+}

--- a/Content.CMU/Resources/Prototypes/CMU14/ThirdParties/Insurgents/CLF/Survivors/third_party.yml
+++ b/Content.CMU/Resources/Prototypes/CMU14/ThirdParties/Insurgents/CLF/Survivors/third_party.yml
@@ -53,7 +53,7 @@
   leadersToSpawn:
     AU14CLFSurvLeader: 1
   gruntsToSpawn:
-    AU14JobCLFSurvFighter: 2
+    AU14CLFSurvFighter: 2
     AU14JCLFSurvSurgeon: 1
   scalewithpop: false
   spawnTogether: true

--- a/Content.CMU/Server/Diagnostics/CMUClientStateDiagnosticsSystem.cs
+++ b/Content.CMU/Server/Diagnostics/CMUClientStateDiagnosticsSystem.cs
@@ -1,6 +1,9 @@
 using System.Text;
+using System.Linq;
+using Content.Server.CMU14.Diagnostics.Performance;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
+using Content.Shared.CMU14.Diagnostics;
 using Content.Shared.GameTicking;
 using Robust.Server.GameStates;
 using Robust.Server.Player;
@@ -12,8 +15,8 @@ using Robust.Shared.Timing;
 namespace Content.Server.CMU14.Diagnostics;
 
 /// <summary>
-/// Observes the existing state-request/ACK stream without changing PVS or asking clients for more data.
-/// ACKs mean a state was received, not that applying it (or rendering) succeeded.
+/// Correlates the state-request/ACK stream with bounded client-reported application progress.
+/// Diagnostic evidence never changes PVS, and receipt ACKs do not prove successful application/rendering.
 /// </summary>
 public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
 {
@@ -28,6 +31,7 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
     [Dependency] private IPlayerManager _players = default!;
     [Dependency] private GameTicker _ticker = default!;
     [Dependency] private IGameTiming _timing = default!;
+    [Dependency] private ICMUServerPerformanceDiagnostics _performance = default!;
 
     private readonly Dictionary<ICommonSession, ClientTrace> _clients = new();
     private readonly CMURecentServerErrors _errors = new();
@@ -44,12 +48,16 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
     private long _suppressed;
     private int _disconnected;
     private long _lastErrorId;
+    private long _initialRequests;
+    private long _recoveryRequests;
+    private long _syncSequence;
 
     public override void Initialize()
     {
         base.Initialize();
         _sawmill = _logManager.GetSawmill(SawmillName);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
+        SubscribeNetworkEvent<CMUClientStateHealthEvent>(OnHealthReport);
         Subs.CVar(_cfg, CCVars.CMUClientStateDiagnosticsEnabled, SetEnabled, true);
     }
 
@@ -88,6 +96,8 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
             _requests = 0;
             _suppressed = 0;
             _disconnected = 0;
+            _initialRequests = 0;
+            _recoveryRequests = 0;
         }
     }
 
@@ -138,9 +148,23 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
         trace.SameTickRequests = trace.Requests > 0 && trace.RequestedTick == tick ? trace.SameTickRequests + 1 : 1;
         trace.Requests++;
         trace.WindowRequests++;
+        trace.LastRequestAt = now;
+        trace.LastMissingEntity = missingEntity;
+        if (tick == GameTick.Zero)
+        {
+            _initialRequests++;
+            trace.WindowInitialRequests++;
+        }
+        else
+        {
+            _recoveryRequests++;
+            trace.WindowRecoveryRequests++;
+        }
         trace.RequestedTick = tick;
         trace.AckAtRequest = trace.LastAck;
         _requests++;
+        if (trace.WindowRecoveryRequests >= 3)
+            StartSyncIncident(session, trace, "repeated-full-state-requests", now);
 
         if (now < trace.NextDetail || !TryTakeDetail(now))
         {
@@ -153,13 +177,14 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
         _sawmill.Warning(
             $"full-state-request user={session.UserId} name=\"{SafeName(session.Name)}\" status={session.Status} " +
             $"round={_ticker.RoundId} phase={_ticker.RunLevel} serverTick={_timing.CurTick} requestedTick={tick} " +
+            $"requestKind={(tick == GameTick.Zero ? "initial-or-manual" : "recovery")} syncIncidentId={trace.SyncIncidentId} " +
             $"firstRequestedTick={trace.FirstRequestedTick} requests={trace.Requests} sameTickRequests={trace.SameTickRequests} " +
-            $"suppressedDetails={trace.Suppressed} sinceFirstRequestSeconds={(now - trace.FirstRequestAt).TotalSeconds:F1} " +
+            $"suppressedDetails={trace.Suppressed} sinceFirstRequestSeconds={Age(now, trace.FirstRequestAt)} " +
             $"lastReceivedAck={trace.LastAck?.ToString() ?? "unknown"} ackAgeSeconds={Age(now, trace.LastAckAt)} " +
             $"pingMs={session.Ping} attached=[{DescribeEntity(session.AttachedEntity)}] " +
             $"missingNetEntity={missingEntity?.ToString() ?? "none"} missing=[{DescribeEntity(GetEntity(missingEntity))}] " +
             $"cleanupTick={_cleanupTick?.ToString() ?? "none"} cleanupAgeSeconds={Age(now, _lastCleanup)} " +
-            "clientAppliedState=unknown");
+            $"{DescribeHealth(trace, now)} {_performance.GetCorrelationContext()}");
         trace.Suppressed = 0;
         WriteRecentErrors(now);
     }
@@ -169,7 +194,8 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
         if (args.NewStatus != SessionStatus.Disconnected || !_clients.Remove(args.Session, out var trace))
             return;
 
-        if (trace.Requests == 0)
+        if ((trace.Requests == 0 && trace.SyncIncidentId == 0) ||
+            trace.SyncIncidentId == 0 && _timing.RealTime - trace.LastRequestAt > TimeSpan.FromMinutes(1))
             return;
 
         _disconnected++;
@@ -178,8 +204,10 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
         {
             _sawmill.Warning(
                 $"disconnect-after-state-request user={args.Session.UserId} round={_ticker.RoundId} " +
+                $"syncIncidentId={trace.SyncIncidentId} secondsSinceLastRequest={Age(_timing.RealTime, trace.LastRequestAt)} " +
                 $"serverTick={_timing.CurTick} requests={trace.Requests} requestedTick={trace.RequestedTick} " +
-                $"lastReceivedAck={trace.LastAck?.ToString() ?? "unknown"} clientAppliedState=unknown");
+                $"lastReceivedAck={trace.LastAck?.ToString() ?? "unknown"} {DescribeHealth(trace, _timing.RealTime)} " +
+                _performance.GetCorrelationContext());
         }
     }
 
@@ -215,10 +243,14 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
         var affected = 0;
         var repeated = 0;
         var ackAdvanced = 0;
+        var activeSync = 0;
         var samples = new StringBuilder();
-        foreach (var (session, trace) in _clients)
+        foreach (var (session, trace) in _clients.OrderByDescending(pair => pair.Value.WindowRecoveryRequests))
         {
-            if (trace.WindowRequests == 0)
+            TryCloseSyncIncident(session, trace, now);
+            if (trace.SyncIncidentId != 0)
+                activeSync++;
+            if (trace.WindowRequests == 0 && trace.SyncIncidentId == 0)
                 continue;
 
             affected++;
@@ -229,30 +261,128 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
             if (affected <= MaxSummarySamples)
             {
                 samples.Append($" user={session.UserId}/tick={trace.RequestedTick}/requests={trace.WindowRequests}" +
-                               $"/ack={trace.LastAck?.ToString() ?? "unknown"}");
+                               $"/recoveryRequests={trace.WindowRecoveryRequests}/syncIncidentId={trace.SyncIncidentId}" +
+                               $"/missingNetEntity={trace.LastMissingEntity?.ToString() ?? "none"}" +
+                               $"/ack={trace.LastAck?.ToString() ?? "unknown"}/ackLagTicks={AckLag(trace)}" +
+                               $"/ackAgeSeconds={Age(now, trace.LastAckAt)} [{DescribeHealth(trace, now)}]");
             }
 
             trace.WindowRequests = 0;
+            trace.WindowInitialRequests = 0;
+            trace.WindowRecoveryRequests = 0;
         }
 
-        if (_requests > 0 || _disconnected > 0)
+        if (_requests > 0 || _disconnected > 0 || activeSync > 0)
         {
             _sawmill.Warning(
                 $"state-request-summary reason={reason} round={_ticker.RoundId} phase={_ticker.RunLevel} " +
-                $"serverTick={_timing.CurTick} windowSeconds={(now - _windowStart).TotalSeconds:F1} " +
+                $"serverTick={_timing.CurTick} windowSeconds={Age(now, _windowStart)} " +
                 $"requests={_requests} affectedConnectedClients={affected} repeatedClients={repeated} " +
+                $"initialOrManualRequests={_initialRequests} recoveryRequests={_recoveryRequests} activeSyncClients={activeSync} " +
                 $"ackAdvancedAfterLastRequestClients={ackAdvanced} disconnectedAfterRequest={_disconnected} " +
                 $"suppressedDetails={_suppressed} cleanupTick={_cleanupTick?.ToString() ?? "none"} " +
                 $"cleanupAgeSeconds={Age(now, _lastCleanup)} samples=[{samples}] " +
-                "clientAppliedState=unknown");
+                _performance.GetCorrelationContext());
             WriteRecentErrors(now);
         }
 
         _requests = 0;
         _suppressed = 0;
         _disconnected = 0;
+        _initialRequests = 0;
+        _recoveryRequests = 0;
         _windowStart = now;
         _nextSummary = now + ReportInterval;
+    }
+
+    private void OnHealthReport(CMUClientStateHealthEvent msg, EntitySessionEventArgs args) =>
+        ObserveHealth(args.SenderSession, msg);
+
+    internal void ObserveHealth(ICommonSession session, CMUClientStateHealthEvent msg)
+    {
+        if (!_enabled || !_cfg.GetCVar(CCVars.CMUClientStateHealthEnabled) ||
+            msg.AppliedTick > _timing.CurTick || !double.IsFinite(msg.AppliedAgeSeconds) ||
+            !double.IsFinite(msg.AverageFps) || msg.AppliedAgeSeconds < -1 || msg.AppliedAgeSeconds > 86400 ||
+            msg.AppliedTick != GameTick.Zero && msg.AppliedAgeSeconds < 0 ||
+            msg.AverageFps < -1 || msg.AverageFps > 10000 ||
+            msg.BufferedStates < 0 || msg.BufferedStates > 65536 || msg.TargetBuffer < 0 || msg.TargetBuffer > 65536)
+            return;
+
+        var now = _timing.RealTime;
+        var trace = GetTrace(session);
+        if (trace.HealthAt is { } last && now - last < TimeSpan.FromSeconds(2))
+            return;
+        trace.HealthAt = now;
+        // Retain scalar values rather than a mutable message object supplied by the caller.
+        trace.Health = new CMUClientStateHealthEvent
+        {
+            AppliedTick = msg.AppliedTick, AppliedAgeSeconds = msg.AppliedAgeSeconds,
+            BufferedStates = msg.BufferedStates, TargetBuffer = msg.TargetBuffer, AverageFps = msg.AverageFps,
+        };
+        if (_ticker.RunLevel == GameRunLevel.InRound && !_timing.Paused &&
+            msg.AppliedTick != GameTick.Zero && msg.AppliedAgeSeconds >= 10 &&
+            _timing.CurTick.Value - msg.AppliedTick.Value >= _timing.TickRate * 5)
+        {
+            StartSyncIncident(session, trace, "client-reported-application-stall", now);
+        }
+    }
+
+    private void StartSyncIncident(ICommonSession session, ClientTrace trace, string reason, TimeSpan now)
+    {
+        if (trace.SyncIncidentId != 0)
+            return;
+        trace.SyncIncidentId = ++_syncSequence;
+        trace.SyncStartedAt = now;
+        // A sync report gets its own bounded capture opportunity even when server TPS is healthy.
+        _performance.RequestSyncReport(trace.SyncIncidentId);
+        if (!TryTakeDetail(now))
+            return;
+        _sawmill.Warning(
+            $"sync-incident-open syncIncidentId={trace.SyncIncidentId} reason={reason} user={session.UserId} " +
+            $"round={_ticker.RoundId} phase={_ticker.RunLevel} serverTick={_timing.CurTick} " +
+            $"requestedTick={trace.RequestedTick} windowRecoveryRequests={trace.WindowRecoveryRequests} " +
+            $"sameTickRequests={trace.SameTickRequests} missingNetEntity={trace.LastMissingEntity?.ToString() ?? "none"} " +
+            $"missing=[{DescribeEntity(GetEntity(trace.LastMissingEntity))}] " +
+            $"lastReceivedAck={trace.LastAck?.ToString() ?? "unknown"} ackLagTicks={AckLag(trace)} " +
+            $"{DescribeHealth(trace, now)} {_performance.GetCorrelationContext()}");
+        WriteRecentErrors(now);
+    }
+
+    private void TryCloseSyncIncident(ICommonSession session, ClientTrace trace, TimeSpan now)
+    {
+        if (trace.SyncIncidentId == 0 || now - trace.LastRequestAt < ReportInterval)
+            return;
+        bool applied = trace.Health is { } health && trace.HealthAt is { } healthAt &&
+                       now - healthAt < TimeSpan.FromSeconds(10) && health.AppliedTick > trace.RequestedTick &&
+                       health.AppliedAgeSeconds is >= 0 and < 5;
+        bool received = trace.LastAck is { } ack && ack > trace.RequestedTick && trace.LastAckAt is { } ackAt &&
+                        now - ackAt < TimeSpan.FromSeconds(5) && now - trace.LastRequestAt >= TimeSpan.FromMinutes(1);
+        // Fresh stalled application telemetry takes precedence over receipt ACKs.
+        if (!applied && (!received || trace.HealthAt is { } at && now - at < TimeSpan.FromSeconds(10)))
+            return;
+        if (TryTakeDetail(now))
+        {
+            _sawmill.Warning(
+                $"sync-incident-close syncIncidentId={trace.SyncIncidentId} user={session.UserId} " +
+                $"outcome={(applied ? "client-reported-application-progress" : "requests-stopped-receipt-progress-only")} " +
+                $"durationSeconds={Age(now, trace.SyncStartedAt)} {DescribeHealth(trace, now)} " +
+                _performance.GetCorrelationContext());
+        }
+        trace.SyncIncidentId = 0;
+    }
+
+    private long AckLag(ClientTrace trace) => trace.LastAck is { } ack
+        ? Math.Max(0, (long)_timing.CurTick.Value - ack.Value) : -1;
+
+    private string DescribeHealth(ClientTrace trace, TimeSpan now)
+    {
+        if (trace.Health is not { } health)
+            return "clientAppliedState=unknown";
+        return CMUServerPerformanceDiagnosticsManager.Invariant(
+            $"clientAppliedState=client-reported clientAppliedTick={health.AppliedTick} ",
+            $"clientAppliedAgeSeconds={health.AppliedAgeSeconds:F2} clientAppliedLagTicks={Math.Max(0, (long)_timing.CurTick.Value - health.AppliedTick.Value)} ",
+            $"healthReportAgeSeconds={Age(now, trace.HealthAt)} bufferedStates={health.BufferedStates} ",
+            $"targetBuffer={health.TargetBuffer} clientAvgFps={health.AverageFps:F2}");
     }
 
     private void WriteRecentErrors(TimeSpan now)
@@ -306,5 +436,13 @@ public sealed class CMUClientStateDiagnosticsSystem : EntitySystem
         public long SameTickRequests;
         public long WindowRequests;
         public long Suppressed;
+        public TimeSpan LastRequestAt;
+        public long WindowInitialRequests;
+        public long WindowRecoveryRequests;
+        public long SyncIncidentId;
+        public TimeSpan SyncStartedAt;
+        public TimeSpan? HealthAt;
+        public CMUClientStateHealthEvent? Health;
+        public NetEntity? LastMissingEntity;
     }
 }

--- a/Content.CMU/Server/Diagnostics/Performance/CMUPerformancePhaseTracker.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUPerformancePhaseTracker.cs
@@ -6,6 +6,8 @@ namespace Content.Server.CMU14.Diagnostics.Performance;
 internal sealed class CMUPerformancePhaseTracker
 {
     private readonly Dictionary<string, Phase> _phases = new();
+    private Phase _frameWorst;
+    public Phase LastFrameWorst { get; private set; }
     private string? _previous;
     private TimeSpan _started;
     private uint _tick;
@@ -18,11 +20,24 @@ internal sealed class CMUPerformancePhaseTracker
             ModUpdateLevel.PreEngine => "timers-tasks-and-simulation",
             ModUpdateLevel.PostEngine => "post-tick-and-state-send",
             ModUpdateLevel.FramePreEngine => "engine-frame-work",
-            ModUpdateLevel.FramePostEngine => "frame-tail-wait-and-input",
+            ModUpdateLevel.FramePostEngine => "content-frame-callbacks",
             _ => null,
         };
         if (next == null)
             return;
+
+        Mark(next, now, tick);
+        if (level == ModUpdateLevel.InputPostEngine)
+        {
+            LastFrameWorst = _frameWorst;
+            _frameWorst = default;
+        }
+    }
+
+    public void EndFrameCallbacks(TimeSpan now, uint tick) => Mark("frame-tail-wait-and-input", now, tick);
+
+    private void Mark(string next, TimeSpan now, uint tick)
+    {
 
         if (_previous != null && now >= _started)
         {
@@ -30,6 +45,8 @@ internal sealed class CMUPerformancePhaseTracker
             _phases.TryGetValue(_previous, out var row);
             _phases[_previous] = new Phase(_previous, row.Count + 1, row.TotalMs + ms,
                 Math.Max(row.MaxMs, ms), ms >= row.MaxMs ? _tick : row.WorstTick);
+            if (ms >= _frameWorst.MaxMs)
+                _frameWorst = new Phase(_previous, 1, ms, ms, _tick);
         }
         _previous = next;
         _started = now;
@@ -47,6 +64,8 @@ internal sealed class CMUPerformancePhaseTracker
     {
         _phases.Clear();
         _previous = null;
+        _frameWorst = default;
+        LastFrameWorst = default;
     }
 
     internal readonly record struct Phase(string Name, long Count, double TotalMs, double MaxMs, uint WorstTick);

--- a/Content.CMU/Server/Diagnostics/Performance/CMUPerformanceProfilerReader.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUPerformanceProfilerReader.cs
@@ -8,7 +8,10 @@ internal readonly record struct CMUPerformanceProfileFrame(
     long? Frame,
     double TimeSeconds,
     long AllocatedBytes,
-    int TickCount);
+    int TickCount,
+    bool Partial = false,
+    long? FirstTick = null,
+    long? LastTick = null);
 
 internal readonly record struct CMUPerformanceProfileSample(
     string Kind,
@@ -35,7 +38,17 @@ internal sealed record CMUPerformanceProfileReport(
     IReadOnlyList<CMUPerformanceProfileSample> Samples,
     IReadOnlyList<CMUPerformanceProfileCounter> Counters,
     int EventsRead,
-    bool Truncated);
+    bool Truncated,
+    CMUPerformanceProfileCoverage Coverage);
+
+internal readonly record struct CMUPerformanceProfileCoverage(
+    string Status,
+    int EventCapacity,
+    int IndexCapacity,
+    int IndexedFrames,
+    int OverwrittenFrames,
+    int PartialFrames,
+    long UnindexedEvents);
 
 internal readonly record struct CMUPerformanceProfileCandidate(
     long Offset,
@@ -72,15 +85,16 @@ internal static class CMUPerformanceProfilerReader
         for (long offset = start; offset < buffer.IndexWriteOffset; offset++)
         {
             ref ProfIndex index = ref buffer.Index(offset);
-            if (!IsValidFrame(buffer, index, validLogStart))
+            if (!TryGetRetainedRange(buffer, index, validLogStart, out var startPos))
                 continue;
 
             TimeAndAllocSample timing = GetFrameTiming(buffer, index);
             if (found && timing.Alloc < frame.AllocatedBytes)
                 continue;
 
-            int tickCount = GetTickCount(profiler, buffer, index);
-            frame = new(offset, TryGetFrameNumber(profiler, buffer, index), timing.Time, timing.Alloc, tickCount);
+            int tickCount = GetTickCount(profiler, buffer, index, startPos);
+            bool partial = startPos != index.StartPos;
+            frame = new(offset, partial ? null : TryGetFrameNumber(profiler, buffer, index), timing.Time, timing.Alloc, tickCount, partial);
             found = true;
         }
 
@@ -94,7 +108,7 @@ internal static class CMUPerformanceProfilerReader
         int eventLimit)
     {
         if (!profiler.IsEnabled)
-            return new([], [], [], 0, false);
+            return new([], [], [], 0, false, new("disabled", 0, 0, 0, 0, 0, 0));
 
         ProfBuffer buffer = profiler.Buffer;
         int framesToRead = Math.Clamp(frameLimit, 1, 128);
@@ -103,20 +117,40 @@ internal static class CMUPerformanceProfilerReader
         long validIndexStart = Math.Max(0, buffer.IndexWriteOffset - buffer.IndexBuffer.LongLength);
         var candidates = new List<CMUPerformanceProfileCandidate>((int) Math.Min(int.MaxValue,
             buffer.IndexWriteOffset - validIndexStart));
+        int indexed = 0;
+        int overwritten = 0;
+        int partialFrames = 0;
+        long lastEnd = 0;
         for (long offset = validIndexStart; offset < buffer.IndexWriteOffset; offset++)
         {
             ref ProfIndex index = ref buffer.Index(offset);
-            if (!IsValidFrame(buffer, index, validLogStart))
+            if (index.Type != ProfIndexType.Frame)
                 continue;
+            indexed++;
+            lastEnd = Math.Max(lastEnd, index.EndPos);
+            if (!TryGetRetainedRange(buffer, index, validLogStart, out var startPos))
+            {
+                if (index.StartPos < validLogStart)
+                    overwritten++;
+                continue;
+            }
+            if (startPos != index.StartPos)
+                partialFrames++;
 
             TimeAndAllocSample timing = GetFrameTiming(buffer, index);
             candidates.Add(new(
                 offset,
                 timing.Time,
                 timing.Alloc,
-                GetTickCount(profiler, buffer, index),
-                index.EndPos - index.StartPos));
+                GetTickCount(profiler, buffer, index, startPos),
+                index.EndPos - startPos));
         }
+
+        var coverage = new CMUPerformanceProfileCoverage(
+            candidates.Count > 0 ? (partialFrames > 0 ? "partial-history" : "available") :
+            indexed == 0 ? "no-completed-frames" : overwritten > 0 ? "history-overwritten" : "invalid-frame-data",
+            buffer.LogBuffer.Length, buffer.IndexBuffer.Length, indexed, overwritten, partialFrames,
+            lastEnd > 0 ? Math.Max(0, buffer.LogWriteOffset - lastEnd) : 0);
 
         IReadOnlyList<long> selectedOffsets = SelectFrameOffsets(
             candidates,
@@ -124,7 +158,7 @@ internal static class CMUPerformanceProfilerReader
             eventsToRead,
             out bool truncated);
         if (selectedOffsets.Count == 0)
-            return new([], [], [], 0, false);
+            return new([], [], [], 0, false, coverage);
 
         var indices = selectedOffsets.ToList();
         var frames = new List<CMUPerformanceProfileFrame>(indices.Count);
@@ -136,20 +170,17 @@ internal static class CMUPerformanceProfilerReader
         {
             ref ProfIndex index = ref buffer.Index(offset);
             TimeAndAllocSample frameTiming = GetFrameTiming(buffer, index);
-            frames.Add(new(
-                offset,
-                TryGetFrameNumber(profiler, buffer, index),
-                frameTiming.Time,
-                frameTiming.Alloc,
-                GetTickCount(profiler, buffer, index)));
-
-            long start = index.StartPos;
+            long start = Math.Max(index.StartPos, validLogStart);
             long remaining = eventsToRead - eventsRead;
             if (index.EndPos - start > remaining)
             {
                 start = index.EndPos - remaining;
                 truncated = true;
             }
+
+            bool partial = start != index.StartPos;
+            long? firstTick = null;
+            long? lastTick = null;
 
             for (long logOffset = start; logOffset < index.EndPos && eventsRead < eventsToRead; logOffset++)
             {
@@ -158,6 +189,11 @@ internal static class CMUPerformanceProfilerReader
                 switch (log.Type)
                 {
                     case ProfLogType.Value:
+                        if (log.Value.Value.Type == ProfValueType.Int64 && profiler.GetString(log.Value.StringId) == "Tick")
+                        {
+                            firstTick ??= log.Value.Value.Int64;
+                            lastTick = log.Value.Value.Int64;
+                        }
                         AddValue(profiler, entitySystemNames, samples, counters, log.Value);
                         break;
                     case ProfLogType.GroupEnd:
@@ -171,6 +207,10 @@ internal static class CMUPerformanceProfilerReader
                         break;
                 }
             }
+
+            frames.Add(new(offset, partial ? null : TryGetFrameNumber(profiler, buffer, index),
+                frameTiming.Time, frameTiming.Alloc, GetTickCount(profiler, buffer, index, start),
+                partial, firstTick, lastTick));
         }
 
         return new(
@@ -178,7 +218,8 @@ internal static class CMUPerformanceProfilerReader
             samples.Values.Select(sample => sample.ToRow()).ToArray(),
             counters.Values.Select(counter => counter.ToRow()).ToArray(),
             eventsRead,
-            truncated);
+            truncated,
+            coverage);
     }
 
     internal static IReadOnlyList<long> SelectFrameOffsets(
@@ -301,13 +342,17 @@ internal static class CMUPerformanceProfilerReader
         counter.Add(value);
     }
 
-    private static bool IsValidFrame(ProfBuffer buffer, ProfIndex index, long validLogStart)
+    internal static bool TryGetRetainedRange(ProfBuffer buffer, ProfIndex index, long validLogStart, out long start)
     {
-        return index.Type == ProfIndexType.Frame &&
-               index.StartPos >= validLogStart &&
-               index.StartPos >= 0 &&
-               index.EndPos > index.StartPos &&
-               index.EndPos <= buffer.LogWriteOffset;
+        start = Math.Max(index.StartPos, validLogStart);
+        if (index.Type != ProfIndexType.Frame || index.StartPos < 0 || index.EndPos <= start ||
+            index.EndPos > buffer.LogWriteOffset)
+            return false;
+
+        // A frame can overwrite its own beginning. Its retained end still contains the full frame's
+        // timing/allocation and finished scopes; report that tail explicitly as partial evidence.
+        ref ProfLog end = ref buffer.Log(index.EndPos - 1);
+        return end.Type == ProfLogType.GroupEnd && end.GroupEnd.Value.Type == ProfValueType.TimeAllocSample;
     }
 
     private static long? TryGetFrameNumber(ProfManager profiler, ProfBuffer buffer, ProfIndex index)
@@ -331,9 +376,9 @@ internal static class CMUPerformanceProfilerReader
         return end.GroupEnd.Value.TimeAllocSample;
     }
 
-    private static int GetTickCount(ProfManager profiler, ProfBuffer buffer, ProfIndex index)
+    private static int GetTickCount(ProfManager profiler, ProfBuffer buffer, ProfIndex index, long start)
     {
-        for (long offset = index.StartPos; offset < index.EndPos; offset++)
+        for (long offset = index.EndPos - 1; offset >= start; offset--)
         {
             ref ProfLog log = ref buffer.Log(offset);
             if (log.Type != ProfLogType.Value ||
@@ -344,7 +389,7 @@ internal static class CMUPerformanceProfilerReader
             return Math.Max(0, log.Value.Value.Int32);
         }
 
-        return 0;
+        return -1;
     }
 
     private sealed class SampleAccumulator(string kind, string name, bool entitySystem)

--- a/Content.CMU/Server/Diagnostics/Performance/CMUServerPerformanceDiagnosticsManager.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUServerPerformanceDiagnosticsManager.cs
@@ -89,6 +89,20 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
     private long _profileIndexOffset;
     private CMUPerformanceProfileFrame? _maxAllocatedFrameSinceSample;
     private bool _allocationBreachPending;
+    private long _pendingSyncIncidentId;
+    private TimeSpan _nextSyncDetailTime;
+    private TimeSpan _nextStallLogTime;
+    private TimeSpan? _lastStallTime;
+    private uint _lastStallTick;
+    private double _lastStallMs;
+    private int _stallFrames;
+    private int _gameplayStallFrames;
+    private int _suppressedStallLogs;
+    private double _stallFrameTotalMs;
+    private long? _retryProfileAfterIndex;
+    private long _retryProfileIncidentId;
+    private long _retryProfileSyncIncidentId;
+    private TimeSpan _lastDetailTime;
 
     // Cached observable metric values. Callbacks never enumerate game state.
     private long _metricEnabled;
@@ -119,6 +133,9 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             return;
 
         _initialized = true;
+        // Respect explicit config/command-line values. More history survives a busy frame by default.
+        _config.OverrideDefault(CVars.ProfBufferSize, Math.Max(65536, _config.GetCVar(CVars.ProfBufferSize)));
+        _config.OverrideDefault(CVars.ProfIndexSize, Math.Max(512, _config.GetCVar(CVars.ProfIndexSize)));
         _enabled = _config.GetCVar(CCVars.CMUServerPerformanceDiagnosticsEnabled);
         _metricEnabled = _enabled ? 1 : 0;
         _ticker = _entitySystemManager.GetEntitySystem<GameTicker>();
@@ -146,6 +163,28 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             _phases.Mark(level, _timing.RealTime, _timing.CurTick.Value);
     }
 
+    public void EndFrameCallbacks()
+    {
+        if (_initialized && _enabled)
+            _phases.EndFrameCallbacks(_timing.RealTime, _timing.CurTick.Value);
+    }
+
+    public void RequestSyncReport(long syncIncidentId)
+    {
+        if (_initialized && _enabled && _pendingSyncIncidentId == 0 && _timing.RealTime >= _nextSyncDetailTime)
+            _pendingSyncIncidentId = syncIncidentId;
+    }
+
+    public string GetCorrelationContext()
+    {
+        var now = _timing.RealTime;
+        return Invariant(
+            $"perfIncidentId={_activeIncidentId} serverTps={_lastObservation?.AchievedTps ?? 0:F2} ",
+            $"serverTpsValid={_lastObservation?.TpsValid ?? false} perfSampleAgeSeconds={(_lastObservation == null ? -1 : (now - _lastObservation.RealTime).TotalSeconds):F2} ",
+            $"lastStallTick={_lastStallTick} lastStallMs={_lastStallMs:F2} ",
+            $"lastStallAgeSeconds={(_lastStallTime == null ? -1 : (now - _lastStallTime.Value).TotalSeconds):F2}");
+    }
+
     public void Update()
     {
         if (!_initialized)
@@ -155,6 +194,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             return;
 
         TimeSpan now = _timing.RealTime;
+        RetryCompletedProfile();
         _metricLastCompletedTick = _timing.CurTick.Value;
         bool allocationBreach = ProbeProfiler(now);
 
@@ -173,7 +213,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         double stallThreshold = Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds));
         bool hardStall = stallThreshold > 0 &&
                          _timing.RealFrameTime.TotalMilliseconds >= stallThreshold;
-        if (!hardStall && !allocationBreach && now < _nextSampleTime)
+        if (!hardStall && !allocationBreach && _pendingSyncIncidentId == 0 && now < _nextSampleTime)
             return;
 
         Sample(now);
@@ -210,7 +250,9 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             $"tick={observation.Tick} targetTps={observation.TargetTps:F2} achievedTps={observation.AchievedTps:F2} ",
             $"fps={observation.AverageFps:F2} frameMs={observation.FrameMilliseconds:F2} ",
             $"entities={observation.EntityCount} components={observation.ComponentCount} ",
-            $"players={observation.Players} profiler={_profiler.IsEnabled} metrics={_config.GetCVar(CVars.MetricsEnabled)}");
+            $"players={observation.Players} profiler={_profiler.IsEnabled} metrics={_config.GetCVar(CVars.MetricsEnabled)} ",
+            $"profilerEventCapacity={_profiler.Buffer.LogBuffer.Length} profilerIndexCapacity={_profiler.Buffer.IndexBuffer.Length} ",
+            $"churnIncidents={_config.GetCVar(CCVars.CMUServerPerformanceChurnIncidents)} capturePhase=input-post-engine");
     }
 
     public bool CaptureManualReport()
@@ -354,10 +396,21 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
 
         CMUPerformanceIncidentEvaluation evaluation = _detector.Evaluate(sample, thresholds);
         HandleEvaluation(observation, evaluation);
+        if (thresholds.StallMilliseconds > 0 && observation.FrameMilliseconds >= thresholds.StallMilliseconds)
+            RecordStall(observation);
         // A severe new stall must not disappear behind an earlier churn incident's two-minute cooldown.
         double criticalMs = _config.GetCVar(CCVars.CMUServerPerformanceCriticalStallMilliseconds);
-        if (criticalMs > 0 && observation.FrameMilliseconds >= criticalMs && now >= _nextStallDetailTime)
-            CaptureDetailedReport(observation, "critical-stall", bypassCooldown: false);
+        bool gameplayStall = IsGameplay(observation) && thresholds.StallMilliseconds > 0 &&
+                             observation.FrameMilliseconds >= thresholds.StallMilliseconds;
+        if ((gameplayStall || criticalMs > 0 && observation.FrameMilliseconds >= criticalMs) && now >= _nextStallDetailTime)
+            CaptureDetailedReport(observation, gameplayStall ? "gameplay-stall" : "critical-stall", bypassCooldown: false);
+        if (_pendingSyncIncidentId != 0)
+        {
+            _nextSyncDetailTime = now + TimeSpan.FromSeconds(30);
+            if (_lastDetailTime != now)
+                CaptureDetailedReport(observation, "client-sync", bypassCooldown: true);
+            _pendingSyncIncidentId = 0;
+        }
         if (now >= _nextErrorReportTime)
             LogErrorWindow(now);
         UpdateMetrics(observation);
@@ -422,6 +475,8 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
                     $"previousReasons={CMUPerformanceIncidentDetector.FormatReasons(evaluation.PreviousReasons)} ",
                     $"worstFrameMs={_worstFrameMilliseconds:F2} worstTps={FiniteOrZero(_worstTps):F2} ",
                     $"worstFps={FiniteOrZero(_worstFps):F2} worstAllocatedBytes={_worstAllocatedBytes} ",
+                    $"stallFrames={_stallFrames} gameplayStallFrames={_gameplayStallFrames} stallFrameTotalMs={_stallFrameTotalMs:F2} ",
+                    $"suppressedStallLogs={_suppressedStallLogs} durationIncludesRecoveryAndOtherTriggers=true ",
                     $"suppressedDetailReports={_suppressedDetailReports}"));
                 _metricIncidentActive = 0;
                 _activeIncidentId = 0;
@@ -489,13 +544,49 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             $"nextSeconds={baselineSeconds:F1}"));
     }
 
+    private void RecordStall(in CMUServerPerformanceObservation observation)
+    {
+        _stallFrames++;
+        _stallFrameTotalMs += observation.FrameMilliseconds;
+        if (IsGameplay(observation))
+            _gameplayStallFrames++;
+        _lastStallTime = observation.RealTime;
+        _lastStallTick = observation.Tick;
+        _lastStallMs = observation.FrameMilliseconds;
+        if (observation.RealTime < _nextStallLogTime)
+        {
+            _suppressedStallLogs++;
+            return;
+        }
+
+        _nextStallLogTime = observation.RealTime + TimeSpan.FromSeconds(1);
+        var phase = _phases.LastFrameWorst;
+        _sawmill.Warning(Invariant(
+            $"[CMU-PERF] stall incidentId={_activeIncidentId} scope={Scope(observation)} round={observation.RoundId} ",
+            $"observedTick={observation.Tick} frameMs={observation.FrameMilliseconds:F2} stallFrames={_stallFrames} ",
+            $"phase={phase.Name ?? "unknown"} phaseMaxMs={phase.MaxMs:F3} phaseWorstTick={phase.WorstTick} ",
+            $"includesWait={phase.Name == "frame-tail-wait-and-input"} phaseWindow=input-to-input ",
+            $"players={observation.Players} attachedPlayers={observation.AttachedPlayers} ",
+            $"achievedTps={observation.AchievedTps:F2} tpsValid={observation.TpsValid} suppressedStallLogs={_suppressedStallLogs}"));
+    }
+
+    private static bool IsGameplay(in CMUServerPerformanceObservation observation) =>
+        observation.RoundState == "InRound" && !observation.Paused && observation.RoundSeconds >= 30;
+
+    private static string Scope(in CMUServerPerformanceObservation observation) =>
+        observation.Paused ? "paused" : IsGameplay(observation) ? "gameplay" : observation.RoundState == "InRound" ? "round-start" :
+        observation.RoundState == "PostRound" ? "post-round" : observation.Tick <= 1 ? "startup" : "lobby-or-loading";
+
     private void CaptureDetailedReport(
         in CMUServerPerformanceObservation observation,
         string source,
         bool bypassCooldown)
     {
         _detailPending = false;
-        _nextStallDetailTime = observation.RealTime + TimeSpan.FromSeconds(30);
+        _lastDetailTime = observation.RealTime;
+        double stallMs = _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds);
+        if (stallMs > 0 && observation.FrameMilliseconds >= stallMs)
+            _nextStallDetailTime = observation.RealTime + TimeSpan.FromSeconds(30);
         if (!bypassCooldown)
         {
             double cooldown = Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceDetailCooldown));
@@ -515,9 +606,18 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             systemNames,
             frames,
             maxEvents);
+        if (profile.Frames.Count == 0 && _profiler.IsEnabled)
+        {
+            // Input processing can itself be slow. Its current frame is not indexed until this
+            // callback returns, so make one retry next frame without waiting for the detail cooldown.
+            _retryProfileAfterIndex = _profiler.Buffer.IndexWriteOffset;
+            _retryProfileIncidentId = _activeIncidentId;
+            _retryProfileSyncIncidentId = _pendingSyncIncidentId;
+        }
 
         _sawmill.Warning(Invariant(
             $"[CMU-PERF] detail-begin incidentId={_activeIncidentId} source={source} profiler={_profiler.IsEnabled} ",
+            $"syncIncidentId={_pendingSyncIncidentId} scope={Scope(observation)} observedTick={observation.Tick} ",
             $"profileFrames={profile.Frames.Count} profileEvents={profile.EventsRead} truncated={profile.Truncated} ",
             $"baselineEntitiesCreated={baseline.EntitiesCreated} currentEntitiesCreated={current.EntitiesCreated} ",
             $"baselineComponentsAdded={baseline.ComponentsAdded} currentComponentsAdded={current.ComponentsAdded}"));
@@ -531,9 +631,12 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
                 $"includesWait={phase.Name == "frame-tail-wait-and-input"}"));
         }
         LogErrorWindow(observation.RealTime);
-        LogChurnRows("prototype-churn", CMUPerformanceChurnTracker.GetPrototypeRows(baseline, current, top));
-        LogChurnRows("component-churn", CMUPerformanceChurnTracker.GetComponentRows(baseline, current, top));
-        LogChurnRows("map-creates", CMUPerformanceChurnTracker.GetMapCreationRows(baseline, current, top));
+        if (source == "manual" || _config.GetCVar(CCVars.CMUServerPerformanceChurnIncidents))
+        {
+            LogChurnRows("prototype-churn", CMUPerformanceChurnTracker.GetPrototypeRows(baseline, current, top));
+            LogChurnRows("component-churn", CMUPerformanceChurnTracker.GetComponentRows(baseline, current, top));
+            LogChurnRows("map-creates", CMUPerformanceChurnTracker.GetMapCreationRows(baseline, current, top));
+        }
 
         foreach (CMUNetworkMessageRate message in observation.MessageRates.Take(top))
         {
@@ -577,6 +680,25 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         }
     }
 
+    private void RetryCompletedProfile()
+    {
+        if (_retryProfileAfterIndex is not { } index || _profiler.Buffer.IndexWriteOffset <= index)
+            return;
+        _retryProfileAfterIndex = null;
+        if (_retryProfileIncidentId != _activeIncidentId)
+            return;
+        var names = _entitySystemManager.GetEntitySystemTypes().Select(type => type.Name).ToHashSet(StringComparer.Ordinal);
+        var report = CMUPerformanceProfilerReader.Capture(_profiler, names,
+            _config.GetCVar(CCVars.CMUServerPerformanceProfileFrames),
+            _config.GetCVar(CCVars.CMUServerPerformanceProfileMaxEvents));
+        _sawmill.Warning(Invariant(
+            $"[CMU-PERF] profile-retry incidentId={_activeIncidentId} syncIncidentId={_retryProfileSyncIncidentId} observedTick={_timing.CurTick} ",
+            $"reason=frame-completed originalIndex={index} currentIndex={_profiler.Buffer.IndexWriteOffset} ",
+            $"profileFrames={report.Frames.Count} profileEvents={report.EventsRead}"));
+        LogProfile(report, Math.Clamp(_config.GetCVar(CCVars.CMUServerPerformanceReportTop), 1, 25));
+        _profileIndexOffset = _profiler.Buffer.IndexWriteOffset + 1;
+    }
+
     private void CapturePendingDetailIfReady(in CMUServerPerformanceObservation observation)
     {
         if (!_detailPending || observation.RealTime < _nextDetailTime)
@@ -587,11 +709,24 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
 
     private void LogProfile(CMUPerformanceProfileReport profile, int top)
     {
+        var coverage = profile.Coverage;
+        _sawmill.Warning(Invariant(
+            $"[CMU-PERF] profile-coverage incidentId={_activeIncidentId} status={coverage.Status} ",
+            $"eventCapacity={coverage.EventCapacity} indexCapacity={coverage.IndexCapacity} indexedFrames={coverage.IndexedFrames} ",
+            $"overwrittenFrames={coverage.OverwrittenFrames} partialFrames={coverage.PartialFrames} unindexedEvents={coverage.UnindexedEvents} ",
+            $"eventBudgetTruncated={profile.Truncated} frameTimeIncludesSleep=false"));
         if (profile.Frames.Count == 0)
         {
+            string action = coverage.Status switch
+            {
+                "disabled" => "enable-prof.enabled-before-reproduction",
+                "no-completed-frames" => "wait-for-first-completed-frame",
+                "history-overwritten" => "increase-prof.buffer_size-and-capture-before-catchup",
+                _ => "inspect-profiler-frame-data",
+            };
             _sawmill.Warning(Invariant(
                 $"[CMU-PERF] profile-unavailable incidentId={_activeIncidentId} enabled={_profiler.IsEnabled} ",
-                $"hint=enable-profiler-before-incident"));
+                $"reason={coverage.Status} action={action}"));
             return;
         }
 
@@ -601,7 +736,9 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         {
             _sawmill.Warning(Invariant(
                 $"[CMU-PERF] profile-frame incidentId={_activeIncidentId} index={frame.IndexOffset} frame={frame.Frame?.ToString(CultureInfo.InvariantCulture) ?? "unknown"} ",
-                $"timeMs={frame.TimeSeconds * 1000:F3} allocatedBytes={frame.AllocatedBytes} ticks={frame.TickCount}"));
+                $"timeMs={frame.TimeSeconds * 1000:F3} allocatedBytes={frame.AllocatedBytes} ticks={frame.TickCount} ",
+                $"partial={frame.Partial} firstRetainedTick={frame.FirstTick?.ToString(CultureInfo.InvariantCulture) ?? "unknown"} ",
+                $"lastRetainedTick={frame.LastTick?.ToString(CultureInfo.InvariantCulture) ?? "unknown"}"));
         }
 
         LogProfileRows("system-time", profile.Samples
@@ -621,9 +758,11 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             .OrderByDescending(row => row.TotalAllocatedBytes)
             .Take(Math.Min(top, 5)));
 
-        foreach (CMUPerformanceProfileCounter counter in profile.Counters
+        var gcCounters = profile.Counters.Where(row => row.Name is "Gen 0 Count" or "Gen 1 Count" or "Gen 2 Count");
+        foreach (CMUPerformanceProfileCounter counter in gcCounters.Concat(profile.Counters
+                     .Except(gcCounters)
                      .OrderByDescending(row => row.Total)
-                     .Take(Math.Min(top, 10)))
+                     .Take(Math.Min(top, 10))))
         {
             _sawmill.Warning(Invariant(
                 $"[CMU-PERF] profile-counter incidentId={_activeIncidentId} name={SanitizeName(counter.Name)} ",
@@ -663,7 +802,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         string severity)
     {
         return Invariant(
-            $"[CMU-PERF] {kind} incidentId={incidentId} severity={severity} ",
+            $"[CMU-PERF] {kind} incidentId={incidentId} severity={severity} scope={Scope(observation)} ",
             $"reasons={CMUPerformanceIncidentDetector.FormatReasons(reasons)} tick={observation.Tick} ",
             $"round={observation.RoundId} roundState={observation.RoundState} roundSeconds={observation.RoundSeconds:F1} ",
             $"paused={observation.Paused} warmup={observation.SuppressRateTriggers} ",
@@ -790,6 +929,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         _maxAllocatedFrameSinceSample = null;
         _allocationBreachPending = false;
         _nextProfilerProbeTime = now;
+        _retryProfileAfterIndex = null;
         double warmupSeconds = Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceWarmup));
         _warmupUntil = now + TimeSpan.FromSeconds(warmupSeconds);
         _warmupBaselinePending = warmupSeconds > 0;
@@ -914,6 +1054,8 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         _sawmill.Info(Invariant(
             $"[CMU-PERF] startup enabled={_enabled} logEnabled={_config.GetCVar(CCVars.CMUServerPerformanceLogEnabled)} profiler={_profiler.IsEnabled} ",
             $"profilerEnabledByDiagnostics={_profilerEnabledByDiagnostics} metrics={metrics} ",
+            $"profilerEventCapacity={_profiler.Buffer.LogBuffer.Length} profilerIndexCapacity={_profiler.Buffer.IndexBuffer.Length} ",
+            $"capturePhase=input-post-engine churnIncidents={_config.GetCVar(CCVars.CMUServerPerformanceChurnIncidents)} ",
             $"sampleSeconds={Math.Max(0.1, _config.GetCVar(CCVars.CMUServerPerformanceSampleInterval)):F2} ",
             $"stallMs={Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds)):F1} ",
             $"criticalStallMs={Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceCriticalStallMilliseconds)):F1}"));
@@ -935,6 +1077,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
 
     private CMUPerformanceIncidentThresholds ReadThresholds()
     {
+        bool churn = _config.GetCVar(CCVars.CMUServerPerformanceChurnIncidents);
         return new(
             Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds)),
             Math.Clamp(_config.GetCVar(CCVars.CMUServerPerformanceLowTpsRatio), 0, 1),
@@ -942,10 +1085,10 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceBreachDuration)),
             Math.Clamp(_config.GetCVar(CCVars.CMUServerPerformanceRecoveryRatio), 0, 1),
             Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceRecoveryDuration)),
-            Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceEntityGrowthPerMinute)),
-            Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceEntityChurnPerMinute)),
-            Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceComponentGrowthPerMinute)),
-            Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceComponentChurnPerMinute)),
+            churn ? Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceEntityGrowthPerMinute)) : 0,
+            churn ? Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceEntityChurnPerMinute)) : 0,
+            churn ? Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceComponentGrowthPerMinute)) : 0,
+            churn ? Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceComponentChurnPerMinute)) : 0,
             Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceSendMiBPerSecond)) * BytesPerMiB,
             Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceReceiveMiBPerSecond)) * BytesPerMiB,
             Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceAllocationMiBPerFrame)) * BytesPerMiB);
@@ -981,6 +1124,10 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
 
     private void ResetWorst(in CMUServerPerformanceObservation observation)
     {
+        _stallFrames = 0;
+        _gameplayStallFrames = 0;
+        _stallFrameTotalMs = 0;
+        _suppressedStallLogs = 0;
         _worstFrameMilliseconds = observation.FrameMilliseconds;
         _worstTps = observation.TpsValid ? observation.AchievedTps : double.PositiveInfinity;
         _worstFps = observation.AverageFps;

--- a/Content.CMU/Server/Diagnostics/Performance/ICMUServerPerformanceDiagnostics.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/ICMUServerPerformanceDiagnostics.cs
@@ -7,6 +7,9 @@ public interface ICMUServerPerformanceDiagnostics
     void Initialize();
     void Update();
     void ObservePhase(ModUpdateLevel level);
+    void EndFrameCallbacks();
+    void RequestSyncReport(long syncIncidentId);
+    string GetCorrelationContext();
     void Shutdown();
     string GetStatus();
     bool CaptureManualReport();

--- a/Content.CMU/Server/Diagnostics/Performance/README.md
+++ b/Content.CMU/Server/Diagnostics/Performance/README.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-CMU's automatic server performance diagnostics turn a future FPS/TPS collapse, high allocation burst, ECS growth event, or network flood into a bounded incident report in the `cmu.server-performance` sawmill.
+CMU's automatic server performance diagnostics focus on gameplay stalls and client synchronization failures, with bounded incident reports in the `cmu.server-performance` sawmill.
 
-The monitor runs from the server's frame-post loop rather than a simulation `EntitySystem.Update`. It therefore continues to observe frame completion while simulation is paused. A hard frame is checked every completed server frame; the broader rates are sampled on a configurable interval.
+The monitor runs at `InputPostEngine`, before catch-up simulation ticks. The previous frame has been finalized by then, so its profile can be read before catch-up work overwrites it. This hook also runs while simulation is paused. A hard frame is checked every completed server frame; broader rates are sampled on a configurable interval.
 
 It never automatically invokes `serverperf deep` or retains per-entity details. The hot path consists of scalar reads, fixed-time scalar windows, event counters keyed only by prototype/component/map identifiers, and the engine's fixed profiler ring.
 
@@ -15,11 +15,13 @@ It never automatically invokes `serverperf deep` or retains per-entity details. 
 - A real frame of 250 ms opens an incident immediately; 1,000 ms is critical.
 - TPS or average FPS below 80% of target for three seconds opens an incident.
 - Recovery requires all triggers to remain healthy for ten seconds; low-TPS/FPS signals must first reach 95% of target.
-- Abnormal ECS net growth/churn, network throughput, and main-thread allocation can independently open an incident.
+- Network throughput and main-thread allocation can independently open an incident. ECS growth/churn stays in scalar telemetry but does not open incidents by default; opt in with `churn_incidents = true`. Detailed ECS rankings remain available in manual reports.
 - The flight-recorder profiler is enabled during startup so the completed frames before a trigger are still in its ring.
 - Disabling the monitor unhooks its ECS event handlers and disables the profiler only when the monitor still owns that enablement; an administrator-owned profiler is left alone.
 - Detailed reports have a two-minute cooldown. Incident opening/updates/recovery are never hidden by that cooldown.
-- Critical stalls can force a fresh detailed report during an existing incident, at most once every 30 seconds, so a later severe stall is not lost behind an earlier churn report.
+- Gameplay stalls (250 ms, after the first 30 round seconds) and critical lifecycle stalls can force a fresh detailed report during an existing incident, at most once every 30 seconds. New client sync incidents have a separate 30-second capture allowance even when TPS is healthy.
+- `scope=gameplay`, `paused`, `round-start`, `post-round`, `startup`, or `lobby-or-loading` separates gameplay from lifecycle work. `stall` rows identify individual frames (at most one row per second); incident close includes all observed stall counts, summed stalled-frame wall time, and suppressed row counts. Incident duration includes recovery and is not frozen time.
+- The server profiler defaults to at least 65,536 events and 512 indices. Explicit config values and larger existing buffers are preserved. Startup logs show effective capacities.
 - Error counts and representative existing errors are attached to detailed reports and summarized every 30 seconds when nonzero. At most 32 sources are retained and four samples are emitted, each capped at 2,048 characters. These identify coincident failures, not proof of CPU/GC attribution.
 - Healthy churn baselines refresh every five minutes and at startup/round boundaries.
 
@@ -48,6 +50,10 @@ The principal records are:
 | `incident-close` | Duration, prior reasons, worst TPS/FPS/frame/allocation, and suppressed detail count. |
 | `detail-begin` / `detail-end` | Bounds one profiler/ECS/network attribution report. |
 | `profile-frame` | Selected slow, allocation-heavy, or tick-bearing frame and its main-thread allocation. |
+| `profile-coverage` | Available/partial/overwritten history, effective capacities, unindexed events, and event-budget truncation. |
+| `profile-unavailable` | Actual reason and appropriate action, rather than a generic enable-profiler hint. |
+| `profile-retry` | One follow-up capture after an unavailable current frame has been finalized; bypasses the normal cooldown. |
+| `stall` | Frame wall time, scope, latest input-to-input phase maximum and tick, including whether that phase contains idle time. |
 | `profile-sample` | Ranked system/engine timing and allocation aggregate. |
 | `profile-counter` | Integer profiler counters, including frame GC collection deltas when present. |
 | `ecs-churn` | Top prototype/component net growth or map creation since the healthy baseline. |
@@ -57,6 +63,29 @@ The principal records are:
 | `phase-window` | Wall time between module callbacks, with the worst tick: simulation/timers/tasks, post-tick work and state sending, engine frame work, and frame tail/wait/input. The last category includes idle time and is not a CPU measurement. Windows accumulate since the previous detailed report. |
 
 Every incident line has a stable `incidentId`. Group all rows with the same ID before drawing conclusions.
+Client synchronization captures also carry `syncIncidentId`, linking to `cmu.client_state` reports. Profiler
+`index` is the unique ring index; use retained tick numbers for correlation, since the engine frame counter
+can remain constant on the server. GC generation counters are always included when retained, even when zero;
+collection counts do not measure pause duration.
+
+## Missing or partial profiles
+
+The engine publishes a frame index only after its frame-post callbacks return. The older reporter ran inside
+those callbacks: a busy unfinished frame could overwrite all preceding frames, leaving nothing readable.
+Moving capture before catch-up fixes that ordering. Slow input work can still cause the same situation, so
+an empty capture is retried once after the frame completes.
+
+A frame can also overwrite its own start. The reader now preserves the retained tail, full frame timing and
+allocation totals, and completed scopes. `partial=true` means system rankings cover only retained events;
+they cannot be treated as a complete attribution of that frame. Parsing remains capped by `profile_max_events`.
+
+- `disabled`: enable `prof.enabled` before reproduction.
+- `no-completed-frames`: startup/enablement has not yet produced an indexed frame; inspect the follow-up retry.
+- `history-overwritten`: increase `prof.buffer_size` and inspect `unindexedEvents` and the retry.
+- `invalid-frame-data`: inspect the profiler frame/index data.
+
+The old logs did not record buffer capacities or rejected-frame counts, so they cannot establish exactly
+which loss mechanism occurred in every old incident. A larger buffer cannot recover previously overwritten events.
 
 ## Interpreting an incident
 
@@ -74,6 +103,9 @@ Use `phase-window` to distinguish a long simulation tick from a long post-tick/s
 profiler has no finer PVS scope. `post-tick-and-state-send` includes content post-tick callbacks and game-state
 generation/serialization/sending; it does not separate those substeps or identify GC pauses. Pair it with
 `error-source` and external runtime metrics before attributing a stall to a particular method.
+`content-frame-callbacks` now separates content service updates from `frame-tail-wait-and-input`.
+`phase-window` spans reports; its maxima can belong to different ticks. The `stall` row instead uses the
+latest input-to-input window, which includes the next frame's input work and does not exactly equal `frameMs`.
 
 ## Admin commands
 
@@ -107,6 +139,7 @@ All automatic-monitor CVars are server-only and archived. In the table, the firs
 | CVar | Default | Effect |
 | --- | ---: | --- |
 | `cmu.server_performance.enabled` | `true` | Master switch. |
+| `churn_incidents` | `false` | Enable standalone ECS growth/churn incidents and automatic ECS rankings. |
 | `log_enabled` | `true` | Write diagnostic logs; does not control metrics or collection. |
 | `sample_interval` | `1` s | Full observation cadence; hard stalls are still checked every frame. |
 | `warmup` | `30` s | Suppresses rate/growth triggers after startup or a new round. Hard stalls/allocation/network remain active. |
@@ -138,6 +171,8 @@ Example server configuration:
 ```toml
 [cmu.server_performance]
 enabled = true
+log_enabled = true
+churn_incidents = false
 sample_interval = 1
 heartbeat_interval = 60
 stall_ms = 250
@@ -148,11 +183,20 @@ allocation_mib_per_frame = 32
 detail_cooldown = 120
 
 [prof]
-# The automatic monitor enables recording, but ring sizes must be configured before profiler construction.
+# These explicit values also replace any smaller saved settings on an existing deployment.
 enabled = true
 buffer_size = 65536
 index_size = 512
+
+[cmu.diagnostics]
+client_state_enabled = true
+client_state_health_enabled = true
 ```
+
+The correct logging key is `cmu.server_performance.log_enabled`; the old
+`log.cmu.server_performance.log_enabled` key is invalid. These content changes must be deployed to both
+server and clients for application-progress reports. Runtime metrics below still need external scraping;
+the diagnostic logger does not claim to measure GC pauses or retained heap itself.
 
 Increasing profiler rings preserves more pre-trigger history but consumes more fixed memory and makes a report scan larger. The automatic parser still caps frames and events.
 

--- a/Content.CMU/Server/Diagnostics/README.md
+++ b/Content.CMU/Server/Diagnostics/README.md
@@ -1,12 +1,21 @@
 # Client state recovery reports
 
-The `cmu.client_state` sawmill adds server-side context to the engine's existing full-state-request logs.
+The `cmu.client_state` sawmill correlates full-state requests, receipt ACKs, client-reported state application,
+and nearby server performance incidents.
 It is enabled by default; disable it at runtime with `cvar cmu.diagnostics.client_state_enabled false`.
 
 - `full-state-request`: player account ID/name, requested/server/last received ACK ticks, repeat counts,
   ping, attached and missing entity IDs/prototypes/lifecycle/parent/map/grid, and time since round cleanup.
+  Tick-zero requests are labeled `initial-or-manual`; nonzero requests are labeled `recovery`.
 - `state-request-summary`: 30-second request totals, affected connected players, repeated requests,
   ACK progress, affected disconnections, suppressed detail count, and up to eight player/tick samples.
+  Samples prioritize clients making the most recovery requests and include ACK lag/age and application telemetry.
+- `sync-incident-open`: three nonzero requests in a reporting window, or a client report showing no application
+  progress for at least ten seconds and five seconds of tick lag during an unpaused round. Each has a stable
+  `syncIncidentId` and requests a bounded performance capture even if server TPS is healthy.
+- `sync-incident-close`: requests stopped and recent client telemetry reports application progress, or requests
+  stopped for a minute and receipt ACKs advanced without fresh application evidence. The outcome explicitly
+  distinguishes these cases; receipt progress alone is not confirmed application recovery.
 - `recent-server-error`: up to four errors from the preceding minute, with their original timestamps,
   categories and existing exception/inner-exception stack traces. These are correlation evidence, not
   proof that the server error caused the client failure. Each retained error is emitted at most once.
@@ -17,11 +26,24 @@ Search by account ID, requested tick and cleanup tick, then inspect the original
 reported timestamps. Repeated requests at the same tick across many users point to a shared incident;
 one request can also be a manual reset and is not proof of a bug.
 
-ACKs acknowledge receipt/queuing **before** the client applies the state. `clientAppliedState=unknown`
-is deliberate: this observer cannot prove recovery, detect every client freeze, or obtain the client's
-exception stack. Keep the affected client's `client.stdout.log` for that part of the trace.
+ACKs acknowledge receipt/queuing **before** the client applies the state. Updated clients send a small scalar
+report every five seconds based on the engine's `GameStateApplied` callback, buffer counts and average FPS.
+`clientAppliedState=client-reported` is explicitly untrusted diagnostic evidence, never gameplay authority.
+`clientAppliedAgeSeconds` is the age at client sampling; `healthReportAgeSeconds` is the server-side age of
+that sample. Stale telemetry is not current health. `clientAppliedState=unknown` means no accepted sample is
+available. A fully hung/disconnected client cannot send reports; this does not collect client exception
+stacks or prove rendering succeeded. Preserve the affected client's `client.stdout.log` as well.
+`clientAvgFps=-1` means frame-timing samples are unavailable; application-progress evidence is still retained.
 
-The observer does not send messages, request resets, alter PVS, capture fresh stack traces, scan entity
-trees or run client code. It reads a few entity fields only for emitted details. Details are limited to
-eight globally per 30 seconds and one per player per 30 seconds; summaries include suppressed requests.
+Use `perfIncidentId`, `lastStallTick`, `lastStallMs`, `lastStallAgeSeconds`, `serverTps`, `serverTpsValid` and
+`perfSampleAgeSeconds` to correlate client symptoms with server stalls. Performance `detail-begin` records
+with `source=client-sync` carry the corresponding `syncIncidentId`.
+
+The observer never requests resets, alters PVS, captures fresh stack traces or scans entity trees. Client
+health transport is controlled by the replicated `cmu.diagnostics.client_state_health_enabled` CVar, enabled
+by default. The server rejects nonfinite/out-of-range values and accepts at most one sample per connection
+every two seconds. Healthy reports are retained as scalar context rather than logged individually.
+It reads a few entity fields only for emitted details. All client detail rows share a limit of
+eight globally per 30 seconds. Full-state-request details additionally have a limit of one per player
+per 30 seconds; summaries include suppressed requests.
 Recent error text is capped at 8,192 characters per entry, with full text remaining in the original server log.

--- a/Content.CMU/Shared/CCVar/CMUCCVars.Diagnostics.cs
+++ b/Content.CMU/Shared/CCVar/CMUCCVars.Diagnostics.cs
@@ -4,6 +4,10 @@ namespace Content.Shared.CCVar;
 
 public sealed partial class CCVars
 {
+    /// <summary>Send a small client-reported state-application sample every five seconds.</summary>
+    public static readonly CVarDef<bool> CMUClientStateHealthEnabled =
+        CVarDef.Create("cmu.diagnostics.client_state_health_enabled", true, CVar.SERVER | CVar.REPLICATED | CVar.ARCHIVE);
+
     /// <summary>
     /// Records bounded server-side context when clients request replacement game states.
     /// Does not collect client logs or change state delivery.

--- a/Content.CMU/Shared/Diagnostics/CMUClientStateHealthEvent.cs
+++ b/Content.CMU/Shared/Diagnostics/CMUClientStateHealthEvent.cs
@@ -1,0 +1,17 @@
+using Robust.Shared.GameObjects;
+using Robust.Shared.Serialization;
+using Robust.Shared.Timing;
+
+namespace Content.Shared.CMU14.Diagnostics;
+
+/// <summary>Small, untrusted diagnostic sample. Never used to control state delivery or gameplay.</summary>
+[Serializable, NetSerializable]
+public sealed class CMUClientStateHealthEvent : EntityEventArgs
+{
+    public GameTick AppliedTick;
+    public double AppliedAgeSeconds;
+    public int BufferedStates;
+    public int TargetBuffer;
+    /// <summary>Average FPS, or -1 when frame timing samples are unavailable.</summary>
+    public double AverageFps;
+}

--- a/Content.CMU/Shared/Power/SharedRMCPowerSystem.Membership.cs
+++ b/Content.CMU/Shared/Power/SharedRMCPowerSystem.Membership.cs
@@ -1,0 +1,23 @@
+namespace Content.Shared._RMC14.Power;
+
+public abstract partial class SharedRMCPowerSystem
+{
+    private void RemoveCMUReceiverFromArea(Entity<RMCPowerReceiverComponent> ent)
+    {
+        var previousArea = ent.Comp.Area;
+        var previousLoad = ent.Comp.LastLoad;
+        ent.Comp.Area = null;
+        ent.Comp.LastLoad = 0;
+
+        // Termination and component removal can both run. Only the first removal releases load.
+        // Use the registered area even if the receiver has already moved to another area/nullspace.
+        if (previousArea is not { } areaUid
+            || TerminatingOrDeleted(areaUid)
+            || !_areaPowerQuery.TryComp(areaUid, out var area)
+            || !GetAreaReceivers((areaUid, area), ent.Comp.Channel).Remove(ent))
+            return;
+
+        area.Load[(int) ent.Comp.Channel] -= previousLoad;
+        Dirty(areaUid, area);
+    }
+}

--- a/Content.CMU/Shared/Power/SharedRMCPowerSystem.State.cs
+++ b/Content.CMU/Shared/Power/SharedRMCPowerSystem.State.cs
@@ -1,0 +1,60 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._RMC14.Power;
+
+public abstract partial class SharedRMCPowerSystem
+{
+    private void InitializeCMUAreaPowerState()
+    {
+        SubscribeLocalEvent<RMCAreaPowerComponent, ComponentGetState>(OnCMUAreaPowerGetState);
+        SubscribeLocalEvent<RMCAreaPowerComponent, ComponentHandleState>(OnCMUAreaPowerHandleState);
+    }
+
+    private void OnCMUAreaPowerGetState(Entity<RMCAreaPowerComponent> ent, ref ComponentGetState args)
+    {
+        // PVS workers may capture the same area for several clients. Filter new snapshots only;
+        // lifecycle cleanup owns mutation of the gameplay collections on the simulation thread.
+        args.State = new CMUAreaPowerComponentState
+        {
+            Apcs = GetCMULivePowerMembers(ent.Comp.Apcs),
+            EquipmentReceivers = GetCMULivePowerMembers(ent.Comp.EquipmentReceivers),
+            LightingReceivers = GetCMULivePowerMembers(ent.Comp.LightingReceivers),
+            EnvironmentReceivers = GetCMULivePowerMembers(ent.Comp.EnvironmentReceivers),
+            Load = (int[]) ent.Comp.Load.Clone(),
+        };
+    }
+
+    private HashSet<NetEntity> GetCMULivePowerMembers(HashSet<EntityUid> members)
+    {
+        var result = new HashSet<NetEntity>();
+        foreach (var member in members)
+        {
+            if (TryGetNetEntity(member, out var net) && net != NetEntity.Invalid)
+                result.Add(net.Value);
+        }
+        return result;
+    }
+
+    private void OnCMUAreaPowerHandleState(Entity<RMCAreaPowerComponent> ent, ref ComponentHandleState args)
+    {
+        if (args.Current is not CMUAreaPowerComponentState state)
+            return;
+
+        EnsureEntitySet<RMCAreaPowerComponent>(state.Apcs, ent, ent.Comp.Apcs);
+        EnsureEntitySet<RMCAreaPowerComponent>(state.EquipmentReceivers, ent, ent.Comp.EquipmentReceivers);
+        EnsureEntitySet<RMCAreaPowerComponent>(state.LightingReceivers, ent, ent.Comp.LightingReceivers);
+        EnsureEntitySet<RMCAreaPowerComponent>(state.EnvironmentReceivers, ent, ent.Comp.EnvironmentReceivers);
+        ent.Comp.Load = (int[]) state.Load.Clone();
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class CMUAreaPowerComponentState : ComponentState
+{
+    public HashSet<NetEntity> Apcs { get; init; } = new();
+    public HashSet<NetEntity> EquipmentReceivers { get; init; } = new();
+    public HashSet<NetEntity> LightingReceivers { get; init; } = new();
+    public HashSet<NetEntity> EnvironmentReceivers { get; init; } = new();
+    public int[] Load { get; init; } = [];
+}

--- a/Content.IntegrationTests/_CMU14/Diagnostics/AreaPowerStateRegressionTest.cs
+++ b/Content.IntegrationTests/_CMU14/Diagnostics/AreaPowerStateRegressionTest.cs
@@ -1,0 +1,205 @@
+using Content.Shared._RMC14.Areas;
+using Content.Shared._RMC14.Power;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Maths;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.CMU14.Diagnostics;
+
+[TestFixture]
+public sealed class AreaPowerStateRegressionTest
+{
+    private static readonly string[] MemberFields =
+    [
+        nameof(RMCAreaPowerComponent.Apcs), nameof(RMCAreaPowerComponent.EquipmentReceivers),
+        nameof(RMCAreaPowerComponent.LightingReceivers), nameof(RMCAreaPowerComponent.EnvironmentReceivers),
+    ];
+
+    [Test]
+    public async Task RemovingDetachedReceiverReplicatesReleasedLoad()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true, Dirty = true });
+        var map = await pair.CreateTestMap();
+        EntityUid receiver = default;
+        NetEntity areaNet = default;
+        await pair.Server.WaitPost(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var grid = entities.EnsureComponent<AreaGridComponent>(map.Grid.Owner);
+            entities.System<AreaSystem>().ReplaceArea(grid, Vector2i.Zero, "RMCAreaSpace");
+            receiver = entities.SpawnEntity(null, new EntityCoordinates(map.Grid.Owner, Vector2i.Zero));
+            var component = entities.AddComponent<RMCPowerReceiverComponent>(receiver);
+            SetField(component, nameof(component.Mode), RMCPowerMode.Idle);
+            SetField(component, nameof(component.IdleLoad), 17);
+        });
+        await pair.RunTicksSync(2);
+        await pair.Server.WaitPost(() =>
+        {
+            var entities = pair.Server.EntMan;
+            areaNet = entities.GetNetEntity(entities.GetComponent<RMCPowerReceiverComponent>(receiver).Area!.Value);
+        });
+        await pair.RunUntilSynced();
+        await pair.Client.WaitAssertion(() =>
+        {
+            var entities = pair.Client.EntMan;
+            var area = entities.GetComponent<RMCAreaPowerComponent>(entities.GetEntity(areaNet));
+            Assert.That(area.Load[(int) RMCPowerChannel.Equipment], Is.GreaterThan(0));
+        });
+        await pair.Server.WaitPost(() =>
+        {
+            var entities = pair.Server.EntMan;
+            entities.System<SharedTransformSystem>().DetachEntity(receiver);
+            entities.DeleteEntity(receiver);
+        });
+        await pair.RunUntilSynced();
+        await pair.Client.WaitAssertion(() =>
+        {
+            var entities = pair.Client.EntMan;
+            var area = entities.GetComponent<RMCAreaPowerComponent>(entities.GetEntity(areaNet));
+            Assert.That(area.Load[(int) RMCPowerChannel.Equipment], Is.Zero);
+            Assert.That(area.EquipmentReceivers, Is.Empty);
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task AreaStateStillReachesClientAfterMemberDeletion()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true, Dirty = true });
+        var map = await pair.CreateTestMap();
+        EntityUid owner = default;
+        EntityUid deleted = default;
+        NetEntity ownerNet = default;
+        NetEntity liveNet = default;
+        NetEntity deletedNet = default;
+        await pair.Server.WaitPost(() =>
+        {
+            var entities = pair.Server.EntMan;
+            owner = entities.SpawnEntity(null, map.GridCoords);
+            var live = entities.SpawnEntity(null, map.GridCoords);
+            deleted = entities.SpawnEntity(null, map.GridCoords);
+            ownerNet = entities.GetNetEntity(owner);
+            liveNet = entities.GetNetEntity(live);
+            deletedNet = entities.GetNetEntity(deleted);
+            var component = entities.AddComponent<RMCAreaPowerComponent>(owner);
+            foreach (var field in MemberFields)
+                SetField(component, field, new HashSet<EntityUid> { live, deleted });
+            SetField(component, nameof(component.Load), new[] { 17, 29, 41 });
+            entities.Dirty(owner, component);
+        });
+
+        async Task AssertClientMembers(bool afterDeletion)
+        {
+            await pair.RunUntilSynced();
+            await pair.Client.WaitAssertion(() =>
+            {
+                var entities = pair.Client.EntMan;
+                var component = entities.GetComponent<RMCAreaPowerComponent>(entities.GetEntity(ownerNet));
+                var live = entities.GetEntity(liveNet);
+                var expected = afterDeletion ? new[] { live } : new[] { live, entities.GetEntity(deletedNet) };
+                foreach (var field in MemberFields)
+                    Assert.That(typeof(RMCAreaPowerComponent).GetField(field)!.GetValue(component), Is.EquivalentTo(expected));
+                Assert.That(component.Load, Is.EqualTo(new[] { 17, 29, 41 }));
+            });
+        }
+
+        await AssertClientMembers(false);
+        await pair.Server.WaitPost(() =>
+        {
+            var entities = pair.Server.EntMan;
+            entities.DeleteEntity(deleted);
+            entities.Dirty(owner, entities.GetComponent<RMCAreaPowerComponent>(owner));
+        });
+        await AssertClientMembers(true);
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task AreaStateKeepsLiveMembersWhenAnOldMemberWasDeleted()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false, Dirty = true });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var owner = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var live = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var deleted = entities.SpawnEntity(null, MapCoordinates.Nullspace);
+            var liveNet = entities.GetNetEntity(live);
+            var deletedNet = entities.GetNetEntity(deleted);
+            var component = entities.AddComponent<RMCAreaPowerComponent>(owner);
+            foreach (var field in MemberFields)
+                SetField(component, field, new HashSet<EntityUid> { live, deleted });
+            SetField(component, nameof(component.Load), new[] { 17, 29, 41 });
+
+            var original = entities.GetComponentState(entities.EventBus, component, null, GameTick.Zero)!;
+            foreach (var field in MemberFields)
+                Assert.That(ReadState(original, field), Is.EquivalentTo(new[] { liveNet, deletedNet }));
+
+            entities.DeleteEntity(deleted);
+            var state = entities.GetComponentState(entities.EventBus, component, null, GameTick.Zero)!;
+            foreach (var field in MemberFields)
+            {
+                Assert.That(ReadState(state, field), Is.EquivalentTo(new[] { liveNet }));
+                Assert.That(ReadState(original, field), Is.EquivalentTo(new[] { liveNet, deletedNet }),
+                    "Building a new state must not mutate a previously captured state.");
+                Assert.That((HashSet<EntityUid>) typeof(RMCAreaPowerComponent).GetField(field)!.GetValue(component)!,
+                    Does.Contain(deleted), "State serialization must not mutate gameplay collections on PVS worker threads.");
+            }
+            Assert.That(ReadState(state, nameof(component.Load)), Is.EqualTo(new[] { 17, 29, 41 }));
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task ReceiverRemovalUsesRegisteredAreaAndReleasesLoad(
+        [Values] RMCPowerChannel channel, [Values(false, true)] bool detachFirst)
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false, Dirty = true });
+        var map = await pair.CreateTestMap();
+        EntityUid receiver = default;
+        await pair.Server.WaitPost(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var grid = entities.EnsureComponent<AreaGridComponent>(map.Grid.Owner);
+            entities.System<AreaSystem>().ReplaceArea(grid, Vector2i.Zero, "RMCAreaSpace");
+            receiver = entities.SpawnEntity(null, new EntityCoordinates(map.Grid.Owner, Vector2i.Zero));
+            var component = entities.AddComponent<RMCPowerReceiverComponent>(receiver);
+            SetField(component, nameof(component.Channel), channel);
+            SetField(component, nameof(component.Mode), RMCPowerMode.Idle);
+            SetField(component, nameof(component.IdleLoad), 17);
+        });
+        await pair.RunTicksSync(2);
+        await pair.Server.WaitAssertion(() =>
+        {
+            var entities = pair.Server.EntMan;
+            var component = entities.GetComponent<RMCPowerReceiverComponent>(receiver);
+            Assert.That(component.Area, Is.Not.Null, "The real power update must register this receiver first.");
+            var area = entities.GetComponent<RMCAreaPowerComponent>(component.Area!.Value);
+            Assert.That(area.Load[(int) channel], Is.GreaterThan(0));
+            if (detachFirst)
+                entities.System<SharedTransformSystem>().DetachEntity(receiver);
+            entities.DeleteEntity(receiver);
+            var field = channel switch
+            {
+                RMCPowerChannel.Equipment => nameof(area.EquipmentReceivers),
+                RMCPowerChannel.Lighting => nameof(area.LightingReceivers),
+                _ => nameof(area.EnvironmentReceivers),
+            };
+            Assert.Multiple(() =>
+            {
+                Assert.That((HashSet<EntityUid>) typeof(RMCAreaPowerComponent).GetField(field)!.GetValue(area)!,
+                    Does.Not.Contain(receiver), "Deletion must remove the registered member even after detaching it.");
+                Assert.That(area.Load[(int) channel], Is.Zero, "Termination and component removal must release its load exactly once.");
+            });
+            entities.GetComponentState(entities.EventBus, area, null, GameTick.Zero);
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    private static object ReadState(object state, string field) =>
+        state.GetType().GetField(field)?.GetValue(state) ?? state.GetType().GetProperty(field)!.GetValue(state);
+
+    private static void SetField<T>(T component, string field, object value) =>
+        typeof(T).GetField(field)!.SetValue(component, value);
+}

--- a/Content.IntegrationTests/_CMU14/Diagnostics/ClientStateDiagnosticsTest.cs
+++ b/Content.IntegrationTests/_CMU14/Diagnostics/ClientStateDiagnosticsTest.cs
@@ -1,7 +1,9 @@
 using System.Collections.Concurrent;
 using System.Linq;
 using Content.Server.CMU14.Diagnostics;
+using Content.Client.CMU14.Diagnostics;
 using Content.Shared.CCVar;
+using Content.Shared.CMU14.Diagnostics;
 using Content.Shared.GameTicking;
 using Robust.Client.GameStates;
 using Robust.Server.GameStates;
@@ -16,6 +18,99 @@ namespace Content.IntegrationTests.CMU14.Diagnostics;
 [TestFixture]
 public sealed class ClientStateDiagnosticsTest
 {
+    [Test]
+    public async Task ActualClientApplicationProgressReachesServerWithoutChangingStateDelivery()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true, Dirty = true });
+        await pair.RunUntilSynced();
+        var capture = new Capture();
+        ISawmill logger = null;
+        await pair.Server.WaitPost(() =>
+        {
+            var config = pair.Server.ResolveDependency<IConfigurationManager>();
+            config.SetCVar(CCVars.CMUClientStateDiagnosticsEnabled, false);
+            config.SetCVar(CCVars.CMUClientStateDiagnosticsEnabled, true);
+            logger = pair.Server.ResolveDependency<ILogManager>().GetSawmill(CMUClientStateDiagnosticsSystem.SawmillName);
+            logger.AddHandler(capture);
+        });
+        try
+        {
+            await pair.Client.WaitPost(() => pair.Client.EntMan.System<CMUClientStateHealthSystem>().ReportHealth());
+            await pair.RunTicksSync(5);
+            await pair.Client.WaitPost(() => pair.Client.ResolveDependency<IClientGameStateManager>().RequestFullState());
+            await pair.RunTicksSync(5);
+            await pair.RunUntilSynced();
+            await pair.Server.WaitAssertion(() =>
+            {
+                var request = capture.Messages.Single(message => message.StartsWith("full-state-request "));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(request, Does.Contain("clientAppliedState=client-reported "));
+                    Assert.That(request, Does.Not.Contain("clientAppliedTick=0 "));
+                    Assert.That(request, Does.Contain("healthReportAgeSeconds="));
+                    Assert.That(request, Does.Contain("perfIncidentId="));
+                });
+            });
+        }
+        finally
+        {
+            await pair.Server.WaitPost(() => logger.RemoveHandler(capture));
+        }
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task InvalidAndFloodedHealthReportsDoNotReplaceAcceptedEvidence()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = true, Dirty = true });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var server = pair.Server;
+            var config = server.ResolveDependency<IConfigurationManager>();
+            config.SetCVar(CCVars.CMUClientStateDiagnosticsEnabled, false);
+            config.SetCVar(CCVars.CMUClientStateDiagnosticsEnabled, true);
+            var system = server.EntMan.System<CMUClientStateDiagnosticsSystem>();
+            var states = server.ResolveDependency<IServerGameStateManager>();
+            var tick = server.ResolveDependency<IGameTiming>().CurTick;
+            var capture = new Capture();
+            var logger = server.ResolveDependency<ILogManager>().GetSawmill(CMUClientStateDiagnosticsSystem.SawmillName);
+            logger.AddHandler(capture);
+            try
+            {
+                system.ObserveHealth(pair.Player!, new CMUClientStateHealthEvent { AppliedTick = tick + 100 });
+                system.ObserveHealth(pair.Player!, new CMUClientStateHealthEvent { AppliedTick = tick, AverageFps = double.NaN });
+                for (var i = 0; i < 10; i++)
+                    states.ClientRequestFull?.Invoke(pair.Player!, GameTick.Zero, null);
+                Assert.That(capture.Messages.Single(), Does.Contain("clientAppliedState=unknown"));
+                config.SetCVar(CCVars.CMUClientStateDiagnosticsEnabled, false);
+                config.SetCVar(CCVars.CMUClientStateDiagnosticsEnabled, true);
+                capture.Messages.Clear();
+
+                system.ObserveHealth(pair.Player!, new CMUClientStateHealthEvent
+                {
+                    AppliedTick = tick - 2, AppliedAgeSeconds = 0.25, BufferedStates = 4, AverageFps = 60,
+                });
+                system.ObserveHealth(pair.Player!, new CMUClientStateHealthEvent
+                {
+                    AppliedTick = tick - 1, BufferedStates = 999, AverageFps = 60,
+                });
+                states.ClientRequestFull?.Invoke(pair.Player!, tick, null);
+                var request = capture.Messages.Single();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(request, Does.Contain($"clientAppliedTick={tick - 2} "));
+                    Assert.That(request, Does.Contain("bufferedStates=4 "));
+                    Assert.That(request, Does.Not.Contain("bufferedStates=999 "));
+                });
+            }
+            finally
+            {
+                logger.RemoveHandler(capture);
+            }
+        });
+        await pair.CleanReturnAsync();
+    }
+
     [Test]
     public async Task RealClientRequestIsObservedWithoutPreventingStateDelivery()
     {
@@ -39,6 +134,8 @@ public sealed class ClientStateDiagnosticsTest
             await server.WaitAssertion(() =>
             {
                 Assert.That(capture.Messages.Count(message => message.StartsWith("full-state-request ")), Is.EqualTo(1));
+
+                Assert.That(capture.Messages.Count(message => message.StartsWith("sync-incident-open ")), Is.Zero);
             });
         }
         finally
@@ -134,6 +231,7 @@ public sealed class ClientStateDiagnosticsTest
                     states.ClientRequestFull?.Invoke(session, tick, null);
 
                 Assert.That(capture.Messages.Count(message => message.StartsWith("full-state-request ")), Is.EqualTo(1));
+                Assert.That(capture.Messages.Count(message => message.StartsWith("sync-incident-open ")), Is.EqualTo(1));
 
                 // ACK progress is observed independently of PVS's forced-full-state bookkeeping.
                 // Neither that bookkeeping nor an ACK proves that the client applied the state.
@@ -144,6 +242,8 @@ public sealed class ClientStateDiagnosticsTest
                 Assert.Multiple(() =>
                 {
                     Assert.That(summary, Does.Contain("requests=21 "));
+                    Assert.That(summary, Does.Contain("recoveryRequests=21 "));
+                    Assert.That(summary, Does.Contain("activeSyncClients=1 "));
                     Assert.That(summary, Does.Contain("affectedConnectedClients=1 "));
                     Assert.That(summary, Does.Contain("ackAdvancedAfterLastRequestClients=1 "));
                     Assert.That(summary, Does.Contain("suppressedDetails=20 "));

--- a/Content.IntegrationTests/_CMU14/Diagnostics/ServerProfilerCaptureTest.cs
+++ b/Content.IntegrationTests/_CMU14/Diagnostics/ServerProfilerCaptureTest.cs
@@ -1,0 +1,91 @@
+using Content.Server.CMU14.Diagnostics.Performance;
+using Robust.Shared;
+using Robust.Shared.Configuration;
+using Robust.Shared.Profiling;
+
+namespace Content.IntegrationTests.CMU14.Diagnostics;
+
+[TestFixture]
+public sealed class ServerProfilerCaptureTest
+{
+    [Test]
+    public async Task BusyUnfinishedFrameExplainsLossAndRetainsItsTailAfterCompletion()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Dirty = true });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var config = pair.Server.ResolveDependency<IConfigurationManager>();
+            var profiler = pair.Server.ResolveDependency<ProfManager>();
+            var previousBuffer = profiler.Buffer;
+            var previousEnabled = profiler.IsEnabled;
+            try
+            {
+                profiler.Buffer = new ProfBuffer { LogBuffer = new ProfLog[256], IndexBuffer = new ProfIndex[8] };
+                config.SetCVar(CVars.ProfEnabled, false);
+                Assert.That(Capture().Coverage.Status, Is.EqualTo("disabled"));
+                config.SetCVar(CVars.ProfEnabled, true);
+                Assert.That(Capture().Coverage.Status, Is.EqualTo("no-completed-frames"));
+
+                var first = profiler.WriteValue("Start Frame", 1L);
+                profiler.WriteValue("Tick", 100L);
+                profiler.WriteValue("Tick count", 1);
+                EndFrame(first);
+                var completed = Capture();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(completed.Coverage.Status, Is.EqualTo("available"));
+                    Assert.That(completed.Frames.Single().FirstTick, Is.EqualTo(100));
+                    Assert.That(completed.Frames.Single().Partial, Is.False);
+                });
+
+                // This reproduces capture from FramePostEngine: the current frame has overwritten the
+                // previous frame, but has not yet published its own index.
+                var busy = profiler.WriteValue("Start Frame", 2L);
+                for (var i = 0; i < 300; i++)
+                    profiler.WriteValue("busy", i);
+                var unfinished = Capture();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(unfinished.Frames, Is.Empty);
+                    Assert.That(unfinished.Coverage.Status, Is.EqualTo("history-overwritten"));
+                    Assert.That(unfinished.Coverage.OverwrittenFrames, Is.EqualTo(1));
+                    Assert.That(unfinished.Coverage.UnindexedEvents, Is.GreaterThan(256));
+                });
+
+                profiler.WriteValue("Tick", 101L);
+                profiler.WriteValue("Tick count", 1);
+                profiler.WriteValue("Gen 2 Count", 1);
+                EndFrame(busy);
+                var partial = Capture();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(partial.Coverage.Status, Is.EqualTo("partial-history"));
+                    Assert.That(partial.Frames.Single().Partial, Is.True);
+                    Assert.That(partial.Frames.Single().TimeSeconds, Is.EqualTo(2));
+                    Assert.That(partial.Frames.Single().AllocatedBytes, Is.EqualTo(4096));
+                    Assert.That(partial.Frames.Single().LastTick, Is.EqualTo(101));
+                    Assert.That(partial.Counters.Single(row => row.Name == "Gen 2 Count").Total, Is.EqualTo(1));
+                    Assert.That(partial.EventsRead, Is.LessThanOrEqualTo(128));
+                    Assert.That(partial.Truncated, Is.True);
+                });
+            }
+            finally
+            {
+                profiler.Buffer = previousBuffer;
+                config.SetCVar(CVars.ProfEnabled, previousEnabled);
+            }
+
+            CMUPerformanceProfileReport Capture() => CMUPerformanceProfilerReader.Capture(profiler, new HashSet<string>(), 8, 128);
+            void EndFrame(long start)
+            {
+                profiler.WriteGroupEnd(start, "Frame", new ProfValue
+                {
+                    Type = ProfValueType.TimeAllocSample,
+                    TimeAllocSample = new TimeAndAllocSample { Time = 2, Alloc = 4096 },
+                });
+                profiler.MarkIndex(start, ProfIndexType.Frame);
+            }
+        });
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/_CMU14/Diagnostics/SurvivorPartySpawnRegressionTest.cs
+++ b/Content.IntegrationTests/_CMU14/Diagnostics/SurvivorPartySpawnRegressionTest.cs
@@ -1,0 +1,35 @@
+using Content.Shared.CMU14.Threats;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.CMU14.Diagnostics;
+
+[TestFixture]
+public sealed class SurvivorPartySpawnRegressionTest
+{
+    [TestCase("CLFSurvsSpawnSmall")]
+    [TestCase("CLFSurvsSpawnMedium")]
+    [TestCase("CLFSurvsSpawnBig")]
+    public async Task SurvivorPartyMembersAreSpawnableEntities(string partyId)
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Connected = false, Dirty = true });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var prototypes = pair.Server.ResolveDependency<IPrototypeManager>();
+            var party = prototypes.Index<PartySpawnPrototype>(partyId);
+            foreach (var members in new[] { party.LeadersToSpawn, party.GruntsToSpawn })
+            {
+                foreach (var id in members.Keys)
+                {
+                    Assert.That(prototypes.TryIndex<EntityPrototype>(id, out var prototype), Is.True,
+                        $"{partyId} must name entity prototypes, not job prototypes: {id}");
+                    Assert.That(prototype.Abstract, Is.False);
+                    var entity = pair.Server.EntMan.SpawnEntity(id, MapCoordinates.Nullspace);
+                    Assert.That(pair.Server.EntMan.GetComponent<MetaDataComponent>(entity).EntityPrototype!.ID, Is.EqualTo(id));
+                }
+            }
+        });
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.Server/Entry/EntryPoint.cs
+++ b/Content.Server/Entry/EntryPoint.cs
@@ -180,6 +180,13 @@ namespace Content.Server.Entry
 
             switch (level)
             {
+                // CMU14 Begin: capture the indexed frame before catch-up simulation overwrites it.
+                case ModUpdateLevel.InputPostEngine:
+                    // The previous frame is now indexed, and catch-up ticks have not overwritten it yet.
+                    _performanceDiagnostics.Update();
+                    break;
+                // CMU14 End
+
                 case ModUpdateLevel.PostEngine:
                 {
                     _euiManager.SendUpdates();
@@ -192,7 +199,7 @@ namespace Content.Server.Entry
                     _playTimeTracking.Update();
                     _watchlistWebhookManager.Update();
                     _connection.Update();
-                    _performanceDiagnostics.Update();
+                    _performanceDiagnostics.EndFrameCallbacks(); // CMU14: close the measured content frame interval.
                     break;
             }
         }

--- a/Content.Server/_RMC14/Power/RMCPowerSystem.cs
+++ b/Content.Server/_RMC14/Power/RMCPowerSystem.cs
@@ -94,6 +94,7 @@ public sealed partial class RMCPowerSystem : SharedRMCPowerSystem
 
     protected override void OnReceiverMapInit(Entity<RMCPowerReceiverComponent> ent, ref MapInitEvent args)
     {
+        base.OnReceiverMapInit(ent, ref args); // CMU14: newly initialized receivers still need area registration.
         if (!TryComp(ent, out ApcPowerReceiverComponent? receiver))
             return;
 

--- a/Content.Shared/CCVar/CCVars.CMU.PerformanceDiagnostics.cs
+++ b/Content.Shared/CCVar/CCVars.CMU.PerformanceDiagnostics.cs
@@ -4,6 +4,12 @@ namespace Content.Shared.CCVar;
 
 public sealed partial class CCVars
 {
+    // CMU14 Begin: keep gameplay stalls separate from routine entity growth.
+    /// <summary>Open incidents for entity/component growth and churn, even when gameplay timing is healthy.</summary>
+    public static readonly CVarDef<bool> CMUServerPerformanceChurnIncidents =
+        CVarDef.Create("cmu.server_performance.churn_incidents", false, CVar.SERVERONLY | CVar.ARCHIVE);
+    // CMU14 End
+
     /// <summary>
     ///     Enables automatic CMU server performance incident detection and reporting.
     /// </summary>

--- a/Content.Shared/_RMC14/Power/RMCAreaPowerComponent.cs
+++ b/Content.Shared/_RMC14/Power/RMCAreaPowerComponent.cs
@@ -1,23 +1,26 @@
-﻿using Robust.Shared.GameStates;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared._RMC14.Power;
 
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+// CMU14 AreaPowerState Begin: serialize retained live members through the owning power system.
+// [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
+[RegisterComponent, NetworkedComponent]
 [Access(typeof(SharedRMCPowerSystem))]
 public sealed partial class RMCAreaPowerComponent : Component
 {
-    [DataField, AutoNetworkedField]
+    [DataField]
     public HashSet<EntityUid> Apcs = new();
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public HashSet<EntityUid> EquipmentReceivers = new();
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public HashSet<EntityUid> LightingReceivers = new();
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public HashSet<EntityUid> EnvironmentReceivers = new();
 
-    [DataField, AutoNetworkedField]
+    [DataField]
     public int[] Load = new int[Enum.GetValues<RMCPowerChannel>().Length];
 }
+// CMU14 End

--- a/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
+++ b/Content.Shared/_RMC14/Power/SharedRMCPowerSystem.cs
@@ -79,6 +79,8 @@ public abstract partial class SharedRMCPowerSystem : EntitySystem
         _areaQuery = GetEntityQuery<AreaComponent>();
         _powerReceiverQuery = GetEntityQuery<RMCPowerReceiverComponent>();
 
+        InitializeCMUAreaPowerState(); // CMU14: handle stale members without mutating collections during PVS.
+
         SubscribeLocalEvent<RMCApcComponent, ComponentStartup>(OnApcStartup);
         SubscribeLocalEvent<RMCApcComponent, MapInitEvent>(OnApcUpdate);
         SubscribeLocalEvent<RMCApcComponent, EntParentChangedMessage>(OnApcUpdate);
@@ -362,16 +364,9 @@ public abstract partial class SharedRMCPowerSystem : EntitySystem
         ToUpdate.Add(ent);
     }
 
+    // CMU14 method: spatial lookup is no longer reliable after detach or during deletion.
     private void OnReceiverRemove<T>(Entity<RMCPowerReceiverComponent> ent, ref T args)
-    {
-        if (!TryGetPowerArea(ent, out var area) ||
-            TerminatingOrDeleted(area))
-        {
-            return;
-        }
-
-        GetAreaReceivers(area, ent.Comp.Channel).Remove(ent);
-    }
+        => RemoveCMUReceiverFromArea(ent);
 
     private void OnFusionReactorMapInit(Entity<RMCFusionReactorComponent> ent, ref MapInitEvent args)
     {
@@ -1200,12 +1195,10 @@ public abstract partial class SharedRMCPowerSystem : EntitySystem
 
                 if (_powerReceiverQuery.TryComp(update, out var receiver))
                 {
-                    if (_areaPowerQuery.TryComp(receiver.Area, out var oldArea))
-                    {
-                        GetAreaReceivers((receiver.Area.Value, oldArea), receiver.Channel).Remove(update);
-                        oldArea.Load[(int) receiver.Channel] -= receiver.LastLoad;
-                        Dirty(update, receiver);
-                    }
+                    // CMU14 Begin: update old membership/load once and notify clients of the old area.
+                    RemoveCMUReceiverFromArea((update, receiver));
+                    Dirty(update, receiver);
+                    // CMU14 End
                 }
 
                 if (!TryGetPowerArea(update, out var area))

--- a/Content.Tests/Server/_CMU14/Diagnostics/Performance/CMUPerformancePhaseTrackerTest.cs
+++ b/Content.Tests/Server/_CMU14/Diagnostics/Performance/CMUPerformancePhaseTrackerTest.cs
@@ -17,6 +17,7 @@ public sealed class CMUPerformancePhaseTrackerTest
         phases.Mark(ModUpdateLevel.PostEngine, TimeSpan.FromMilliseconds(10), 100);
         phases.Mark(ModUpdateLevel.FramePreEngine, TimeSpan.FromMilliseconds(12010), 100);
         phases.Mark(ModUpdateLevel.FramePostEngine, TimeSpan.FromMilliseconds(12011), 100);
+        phases.EndFrameCallbacks(TimeSpan.FromMilliseconds(12021), 100);
         phases.Mark(ModUpdateLevel.InputPostEngine, TimeSpan.FromMilliseconds(13011), 101);
         var rows = phases.Drain();
         Assert.Multiple(() =>
@@ -24,11 +25,35 @@ public sealed class CMUPerformancePhaseTrackerTest
             Assert.That(rows.Single(row => row.Name == "timers-tasks-and-simulation").MaxMs, Is.EqualTo(10));
             Assert.That(rows.Single(row => row.Name == "post-tick-and-state-send").MaxMs, Is.EqualTo(12000));
             Assert.That(rows.Single(row => row.Name == "post-tick-and-state-send").WorstTick, Is.EqualTo(100));
-            Assert.That(rows.Single(row => row.Name == "frame-tail-wait-and-input").MaxMs, Is.EqualTo(1000));
+            Assert.That(rows.Single(row => row.Name == "content-frame-callbacks").MaxMs, Is.EqualTo(10));
+            Assert.That(rows.Single(row => row.Name == "frame-tail-wait-and-input").MaxMs, Is.EqualTo(990));
+            Assert.That(phases.LastFrameWorst.Name, Is.EqualTo("post-tick-and-state-send"));
+            Assert.That(phases.LastFrameWorst.MaxMs, Is.EqualTo(12000));
             Assert.That(phases.Drain(), Is.Empty);
         });
         phases.Clear();
         phases.Mark(ModUpdateLevel.PreEngine, TimeSpan.FromSeconds(20), 200);
         Assert.That(phases.Drain(), Is.Empty, "Reset must not attribute downtime to a running tick.");
+    }
+
+    [Test]
+    public void LatestFrameDoesNotInheritAnEarlierLoadingStall()
+    {
+        var phases = new CMUPerformancePhaseTracker();
+        phases.Mark(ModUpdateLevel.PreEngine, TimeSpan.Zero, 100);
+        phases.Mark(ModUpdateLevel.PostEngine, TimeSpan.FromSeconds(10), 100);
+        phases.Mark(ModUpdateLevel.InputPostEngine, TimeSpan.FromSeconds(10.01), 101);
+        phases.Mark(ModUpdateLevel.PreEngine, TimeSpan.FromSeconds(10.02), 101);
+        phases.Mark(ModUpdateLevel.PostEngine, TimeSpan.FromSeconds(10.03), 101);
+        phases.Mark(ModUpdateLevel.FramePreEngine, TimeSpan.FromSeconds(10.53), 101);
+        phases.Mark(ModUpdateLevel.InputPostEngine, TimeSpan.FromSeconds(10.54), 102);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(phases.LastFrameWorst.Name, Is.EqualTo("post-tick-and-state-send"));
+            Assert.That(phases.LastFrameWorst.MaxMs, Is.EqualTo(500).Within(0.001));
+            Assert.That(phases.LastFrameWorst.WorstTick, Is.EqualTo(101));
+            Assert.That(phases.Drain().Single(row => row.Name == "timers-tasks-and-simulation").MaxMs, Is.EqualTo(10000));
+        });
     }
 }


### PR DESCRIPTION
## About the PR
Fix area-power state errors and missing CLF survivor spawns found in the September 10 server logs, and improve the diagnostics used to investigate gameplay stalls and client synchronization failures.

## Why / Balance
A removed receiver could remain in its area's member set, causing repeated MetaData resolution errors and invalid entity references during state serialization. Removing a receiver also left its recorded power load behind. Small CLF survivor parties attempted to spawn a job prototype, so their fighters were missing. Intended spawn counts and balance are unchanged.

## Technical details
- Register newly initialized power receivers through the shared startup handler. Remove membership using the recorded area, release load exactly once, clear cached membership, and dirty the old area so clients receive the change.
- Capture area-power state as separate snapshots containing live members only. Serialization never mutates gameplay collections on PVS worker threads; client state application preserves all four member sets and channel loads.
- Correct the small CLF survivor party to use its fighter entity prototype.
- Capture profiler data before catch-up simulation, preserve partial history, retry unavailable captures, and report actual coverage/failure reasons. Increase default ring capacities while preserving explicit configuration.
- Distinguish gameplay stalls from lifecycle work and routine churn. Correlate bounded synchronization incidents with client-reported applied states, state buffers, FPS, receipt ACKs, and server stall ticks. Client reports are diagnostic evidence only.

## Test plan
- Reproduced the original area-state resolution error and invalid network entity in an integration test before the fix.
- Reproduced stale receiver membership and unreleased load across all three power channels before the fix.
- Reproduced the invalid small-party spawn; medium and large variants already passed.
- Passed 19 focused integration checks covering area member deletion, actual client state/load delivery, receiver startup/cleanup, survivor spawning, profiler retention, health-report validation/rate limits, and client sandbox loading.
- Passed 19 focused performance unit tests. Shared, server, client, and integration projects compiled successfully through these runs.
- Ran the full YAML linter: it reports 29 errors in other content, including missing squad prototypes/maps, legacy action fields, and static prototype-kind validation. Every reported YAML file is unchanged from the base commit; the changed CLF party passes actual spawn tests. This PR does not claim a clean full-repository linter run.
- GitHub CI passed compilation, client/server packaging, Content.Tests, RMC integration tests (301 passed), schema/source/RSI validation, and PR checks. The CMU shard reports the same single failing test as the latest tested master commit `1a3ebb561b9` (164 passed). Twelve completed failing integration shards have exactly the same failing test names as that baseline; inspected spawn/delete and storage failures also have matching causes. The YAML linter has the same static prototype-kind failures. Broader root/map/debug jobs were still running at merge preparation. New `Content.IntegrationTests.CMU14.Diagnostics` tests were verified with the explicit local filter; the existing CMU shard filters the legacy `_CMU14` namespace.
- After deployment, use `cmuperf status` to check profiler capacities and logging, and inspect `stall`, `profile-coverage`, and `sync-incident-open` records during a reproduction.

## Media
Not required for these fixes and diagnostic changes.

## Requirements
- [x] I have read and am following the contributing guidelines.
- [x] I have tested this pull request and written instructions on how to test it.
- [x] My tests assert behavior that can break: no locked-in values or mirrored implementation.
- [x] Every change outside the CMU zones carries a CMU14 tag; new files and prototypes are in CMU zones.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a brief detail of the major changes in the changelog below.
- [x] The submitted changes can be distributed under the repository's applicable licenses.

## Breaking changes
Deploy matching server and client builds: area-power state serialization changes and client application-progress reports use updated shared network types. Existing explicit profiler settings still override the new defaults; deployment settings are documented in `Content.CMU/Server/Diagnostics/Performance/README.md`.

**Changelog**
:cl:
- fix: Fixed stale area-power references and power loads after equipment is removed or moved.
- fix: Fixed missing fighters in small CLF survivor groups.
- admin: Improved gameplay stall and client synchronization diagnostics.
