### PR TITLE
Increase dropship fabricator gain in RMCCCVars.cs

### DIFF
--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -159,7 +159,7 @@ public sealed partial class RMCCVars : CVars
         CVarDef.Create("rmc.dropship_fabricator_starting_points", 10000, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> RMCDropshipFabricatorGainEverySeconds =
-        CVarDef.Create("rmc.dropship_fabricator_gain_every_seconds", 0.5f, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.dropship_fabricator_gain_every_seconds", 0.5f, CVar.REPLICATED | CVar.SERVER); // CMU14: increase dropship fabricator point generation
 
     public static readonly CVarDef<bool> RMCDropshipCASDebug =
         CVarDef.Create("rmc.dropship_cas_debug", false, CVar.REPLICATED | CVar.SERVER);

--- a/Content.Shared/_RMC14/CCVar/RMCCVars.cs
+++ b/Content.Shared/_RMC14/CCVar/RMCCVars.cs
@@ -159,7 +159,7 @@ public sealed partial class RMCCVars : CVars
         CVarDef.Create("rmc.dropship_fabricator_starting_points", 10000, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<float> RMCDropshipFabricatorGainEverySeconds =
-        CVarDef.Create("rmc.dropship_fabricator_gain_every_seconds", 3.33333f, CVar.REPLICATED | CVar.SERVER);
+        CVarDef.Create("rmc.dropship_fabricator_gain_every_seconds", 0.5f, CVar.REPLICATED | CVar.SERVER);
 
     public static readonly CVarDef<bool> RMCDropshipCASDebug =
         CVarDef.Create("rmc.dropship_cas_debug", false, CVar.REPLICATED | CVar.SERVER);


### PR DESCRIPTION
## About the PR

Updated the dropship fabricator to generate 2 points per second.

## Why / Balance

Current dropship budget depletes too quickly

## Technical details

Changed `RMCDropshipFabricatorGainEverySeconds` from `3.33333f` to `0.5f`.

## Requirements

- [x] I have read and am following the contributing guidelines.
- [X] I have tested this pull request and written instructions on how to test it.
- [X] My tests assert behavior that can break: no locked-in values or mirrored implementation.
- [X] Every change outside the CMU zones carries a CMU14 tag; new files and prototypes are in CMU zones.
- [X] I have added media to this PR or it does not require an in-game showcase.
- [X] I have included a brief detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them.

**Changelog**

:cl:

- tweak: Increased dropship fabricator point generation to 2 points per second.