### PR TITLE
Increased passenger capacity of APCs

### DIFF
--- a/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
@@ -194,7 +194,7 @@
     interiorPath: /Maps/_RMC14/Vehicles/apc_transport_interior.yml
     enterDoAfter: 1.0
     exitDoAfter: 1.0
-    maxPassengers: 20 # CMU14 - increased capacity so APCs can take entire squads.
+    maxPassengers: 20 # CMU14: increased capacity so APCs can take entire squads.
     maxXenos: 3
     entryPoints:
     - offset: 1.5,0
@@ -243,7 +243,7 @@
     interiorPath: /Maps/_RMC14/Vehicles/apc_medical_interior.yml
     enterDoAfter: 1.0
     exitDoAfter: 1.0
-    maxPassengers: 15 # CMU14 - increased capacity so APCs can take entire squads.
+    maxPassengers: 15 # CMU14: increased capacity so APCs can take entire squads.
     maxXenos: 3
     entryPoints:
     - offset: 1.5,0
@@ -290,7 +290,7 @@
     interiorPath: /Maps/_RMC14/Vehicles/apc_command_interior.yml
     enterDoAfter: 1.0
     exitDoAfter: 1.0
-    maxPassengers: 15 # CMU14 - increased capacity so APCs can take entire squads.
+    maxPassengers: # CMU14: increased capacity so APCs can take entire squads.
     maxXenos: 3
     entryPoints:
     - offset: 1.5,0
@@ -415,7 +415,7 @@
     interiorPath: /Maps/_RMC14/Vehicles/spp_apc_interior.yml
     enterDoAfter: 1.0
     exitDoAfter: 1.0
-    maxPassengers: 20 # CMU14 - increased capacity so APCs can take entire squads.
+    maxPassengers: 20 # CMU14: increased capacity so APCs can take entire squads.
     maxXenos: 4
     entryPoints:
     - offset: -1.5,0

--- a/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
+++ b/Resources/Prototypes/_RMC14/Vehicles/APC/vehicles.yml
@@ -194,7 +194,7 @@
     interiorPath: /Maps/_RMC14/Vehicles/apc_transport_interior.yml
     enterDoAfter: 1.0
     exitDoAfter: 1.0
-    maxPassengers: 10
+    maxPassengers: 20 # CMU14 - increased capacity so APCs can take entire squads.
     maxXenos: 3
     entryPoints:
     - offset: 1.5,0
@@ -243,7 +243,7 @@
     interiorPath: /Maps/_RMC14/Vehicles/apc_medical_interior.yml
     enterDoAfter: 1.0
     exitDoAfter: 1.0
-    maxPassengers: 10
+    maxPassengers: 15 # CMU14 - increased capacity so APCs can take entire squads.
     maxXenos: 3
     entryPoints:
     - offset: 1.5,0
@@ -290,7 +290,7 @@
     interiorPath: /Maps/_RMC14/Vehicles/apc_command_interior.yml
     enterDoAfter: 1.0
     exitDoAfter: 1.0
-    maxPassengers: 10
+    maxPassengers: 15 # CMU14 - increased capacity so APCs can take entire squads.
     maxXenos: 3
     entryPoints:
     - offset: 1.5,0
@@ -415,7 +415,7 @@
     interiorPath: /Maps/_RMC14/Vehicles/spp_apc_interior.yml
     enterDoAfter: 1.0
     exitDoAfter: 1.0
-    maxPassengers: 14
+    maxPassengers: 20 # CMU14 - increased capacity so APCs can take entire squads.
     maxXenos: 4
     entryPoints:
     - offset: -1.5,0


### PR DESCRIPTION
<!-- Guidelines: CONTRIBUTING.md at the repository root --> <!-- CMU14 -->

## About the PR
<!-- What did you change? -->
Increased the maximum passengers for APCs. Previously, they did not fit entire squads, at
APC, Medical APC, Command APC: 10
UPP APC: 14

now, they should comfortably fit entire squads, at
Medical & Command APC: 14
APC, UPP APC: 20

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The idea of transporting squads around the map is really cool, but in practice it usually requires five or six guys to get out and walk. Visually, the APCs have plenty of space to fit this much people, but its just a arbitrary limit.
I can't see this causing any balance problems, as the more people you put in, the slower they can deploy.

## Technical details
<!-- Summary of code changes for easier review. -->

## Test plan
<!--
Describe how you tested the pull request, and how someone reviewing this PR can test it themselves.
-->
Manually spawned 20 riflemen and walked them into the vehicle, confirming that the 21st doesn't fit.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. Media may be used in progress reports with credit. -->
Below is what the new capacity looks like from the inside, to prove that they reasonably fit:
<img width="669" height="490" alt="image" src="https://github.com/user-attachments/assets/51d1ca6f-8088-4d3d-a528-dae8623dea6e" />
<img width="604" height="390" alt="image" src="https://github.com/user-attachments/assets/a0f17304-bf23-419a-8c71-53121d4b6d48" />
<img width="511" height="418" alt="image" src="https://github.com/user-attachments/assets/0506fcb2-3fe7-47b3-bf0f-06f1331b2594" />
<img width="591" height="438" alt="image" src="https://github.com/user-attachments/assets/0ad552aa-9a7b-4e13-bee1-b1988dd1de4b" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [contributing guidelines](CONTRIBUTING.md).
- [x] I have tested this pull request and written instructions on how to test it.
- [x] My tests assert behavior that can break: no locked-in values or mirrored implementation ([CONVENTIONS.md](CONVENTIONS.md#tests)).
- [x] Every change outside the CMU zones carries a CMU14 tag; new files and prototypes are in CMU zones.
- [x] I have added media to this PR or it does not require an ingame showcase.
- [x] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [x] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:Nox38
- tweak: increased the passenger capacity of all APCs.
