### PR TITLE
Removes the Reaper caste as a Carrier evolution

### DIFF
--- a/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
+++ b/Resources/Prototypes/_RMC14/Entities/Mobs/Xeno/carrier.yml
@@ -174,9 +174,9 @@
     - ActionXenoDevolve
   - type: XenoParasiteThrower
   - type: XenoEvolution
-    max: 500
-    evolvesTo:
-    - CMXenoReaper
+ #   max: 500 # CMU14 - Needs a rework before re-enabling
+ #  evolvesTo:
+ #  - CMXenoReaper
     strains:
     - RMCXenoCarrierEggsac
   - type: RMCActionOrder


### PR DESCRIPTION
<!-- Guidelines: CONTRIBUTING.md at the repository root --> <!-- CMU14 -->

## About the PR
Removed Reaper as an evolution option from Carrier.

## Why / Balance
Reaper is pretty useless, and is borderline a throw pick as it takes up a T3 slot and does not contribute meaningfully to the hive. Its flesh resin mechanic relies on xenos already winning to get anything out of it. Its ability to build is overshadowed by its low plasma, so it can only get about 4-5 structures out before needing to recharge. The only good ability it has its mantle, which gives one xeno a shield, but that doesn't justify picking it.
Every other xeno does what reaper does, but better. It is meant to be a support caste, but does not do it very well. It is in dire need of a rework so I am disabling it until then.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [contributing guidelines](CONTRIBUTING.md).
- [X] I have tested this pull request and written instructions on how to test it.
- [X] My tests assert behavior that can break: no locked-in values or mirrored implementation ([CONVENTIONS.md](CONVENTIONS.md#tests)).
- [X] Every change outside the CMU zones carries a CMU14 tag; new files and prototypes are in CMU zones.
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have included a **brief** detail of the major changes for this PR in the changelog below.
- [X] By submitting this code and/or assets, I confirm that I either own them or have provided the correct necessary licenses to use and distribute them. I agree to be fully responsible for any legal claims or issues arising from the use of these materials.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Any of the below listed tags will function, for example admin changes may be listed for admins to see with admin:
Coding changes with no changes visible in-game may be listed for other contributors with code:
Changelog must have a singular :cl: symbol at the top, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
no cl