### PR TITLE
Reduce gameplay spawn spikes and improve stall attribution

### DIFF
--- a/Content.CMU/Server/Diagnostics/Performance/CMUPerformanceProfilerReader.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUPerformanceProfilerReader.cs
@@ -39,7 +39,12 @@ internal sealed record CMUPerformanceProfileReport(
     IReadOnlyList<CMUPerformanceProfileCounter> Counters,
     int EventsRead,
     bool Truncated,
-    CMUPerformanceProfileCoverage Coverage);
+    CMUPerformanceProfileCoverage Coverage)
+{
+    public IReadOnlyList<CMUPerformanceFrameSamples> FrameSamples { get; init; } = [];
+}
+
+internal sealed record CMUPerformanceFrameSamples(long IndexOffset, IReadOnlyList<CMUPerformanceProfileSample> Samples);
 
 internal readonly record struct CMUPerformanceProfileCoverage(
     string Status,
@@ -163,11 +168,13 @@ internal static class CMUPerformanceProfilerReader
         var indices = selectedOffsets.ToList();
         var frames = new List<CMUPerformanceProfileFrame>(indices.Count);
         var samples = new Dictionary<string, SampleAccumulator>(StringComparer.Ordinal);
+        var frameSamples = new List<CMUPerformanceFrameSamples>(indices.Count);
         var counters = new Dictionary<string, CounterAccumulator>(StringComparer.Ordinal);
         int eventsRead = 0;
 
         foreach (long offset in indices)
         {
+            var localSamples = new Dictionary<string, SampleAccumulator>(StringComparer.Ordinal);
             ref ProfIndex index = ref buffer.Index(offset);
             TimeAndAllocSample frameTiming = GetFrameTiming(buffer, index);
             long start = Math.Max(index.StartPos, validLogStart);
@@ -194,13 +201,13 @@ internal static class CMUPerformanceProfilerReader
                             firstTick ??= log.Value.Value.Int64;
                             lastTick = log.Value.Value.Int64;
                         }
-                        AddValue(profiler, entitySystemNames, samples, counters, log.Value);
+                        AddValue(profiler, entitySystemNames, localSamples, counters, log.Value);
                         break;
                     case ProfLogType.GroupEnd:
                         AddSample(
                             profiler,
                             entitySystemNames,
-                            samples,
+                            localSamples,
                             "group",
                             log.GroupEnd.StringId,
                             log.GroupEnd.Value);
@@ -211,6 +218,15 @@ internal static class CMUPerformanceProfilerReader
             frames.Add(new(offset, partial ? null : TryGetFrameNumber(profiler, buffer, index),
                 frameTiming.Time, frameTiming.Alloc, GetTickCount(profiler, buffer, index, start),
                 partial, firstTick, lastTick));
+            var rows = localSamples.Values.Select(sample => sample.ToRow()).ToArray();
+            frameSamples.Add(new(offset, rows));
+            foreach (var (key, local) in localSamples)
+            {
+                if (!samples.TryGetValue(key, out var total))
+                    samples.Add(key, local);
+                else
+                    total.Merge(local);
+            }
         }
 
         return new(
@@ -219,7 +235,7 @@ internal static class CMUPerformanceProfilerReader
             counters.Values.Select(counter => counter.ToRow()).ToArray(),
             eventsRead,
             truncated,
-            coverage);
+            coverage) { FrameSamples = frameSamples };
     }
 
     internal static IReadOnlyList<long> SelectFrameOffsets(
@@ -399,6 +415,15 @@ internal static class CMUPerformanceProfilerReader
         private double _maxSeconds;
         private long _totalAllocatedBytes;
         private long _maxAllocatedBytes;
+
+        public void Merge(SampleAccumulator other)
+        {
+            _count += other._count;
+            _totalSeconds += other._totalSeconds;
+            _maxSeconds = Math.Max(_maxSeconds, other._maxSeconds);
+            _totalAllocatedBytes += other._totalAllocatedBytes;
+            _maxAllocatedBytes = Math.Max(_maxAllocatedBytes, other._maxAllocatedBytes);
+        }
 
         public void Add(TimeAndAllocSample sample)
         {

--- a/Content.CMU/Server/Diagnostics/Performance/CMUPerformanceSpikeCapture.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUPerformanceSpikeCapture.cs
@@ -1,0 +1,33 @@
+namespace Content.Server.CMU14.Diagnostics.Performance;
+
+/// <summary>Bounds detail work without hiding new spikes behind unrelated incident cooldowns.</summary>
+internal sealed class CMUPerformanceSpikeCapture
+{
+    private TimeSpan? _lastCapture;
+    private double _milliseconds;
+    private long _bytes;
+
+    public bool ShouldCapture(TimeSpan now, double milliseconds, long bytes, double stallThreshold, double allocationThreshold)
+    {
+        if (!(stallThreshold > 0 && milliseconds >= stallThreshold) &&
+            !(allocationThreshold > 0 && bytes >= allocationThreshold))
+            return false;
+
+        if (_lastCapture is not { } last || now - last >= TimeSpan.FromSeconds(10))
+            return true;
+
+        // A substantially worse spike gets its own capture, but never more than once per second.
+        return now - last >= TimeSpan.FromSeconds(1) &&
+               (stallThreshold > 0 && milliseconds >= Math.Max(stallThreshold, _milliseconds * 2) ||
+                allocationThreshold > 0 && bytes >= Math.Max(allocationThreshold, _bytes * 2d));
+    }
+
+    public void Record(TimeSpan now, double milliseconds, long bytes)
+    {
+        _lastCapture = now;
+        _milliseconds = milliseconds;
+        _bytes = bytes;
+    }
+
+    public void Clear() => _lastCapture = null;
+}

--- a/Content.CMU/Server/Diagnostics/Performance/CMUServerPerformanceDiagnosticsManager.Operations.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUServerPerformanceDiagnosticsManager.Operations.cs
@@ -1,0 +1,79 @@
+using Stopwatch = System.Diagnostics.Stopwatch;
+
+namespace Content.Server.CMU14.Diagnostics.Performance;
+
+public sealed partial class CMUServerPerformanceDiagnosticsManager
+{
+    private readonly Queue<SlowOperation> _operations = new();
+    private TimeSpan _lastRuntimeSample;
+    private TimeSpan _lastGcPause;
+    private double _runtimeWindowMs;
+    private double _gcPauseMs;
+
+    public CMUPerformanceOperationScope MeasureOperation(string name, string? prototype = null) =>
+        _enabled ? new(this, name, prototype, _timing.CurTick.Value) : default;
+
+    internal void CompleteOperation(string name, string? prototype, uint tick, double milliseconds, long bytes)
+    {
+        if (milliseconds < 10 && bytes < 1024 * 1024)
+            return;
+        if (_operations.Count == 32)
+            _operations.Dequeue();
+        _operations.Enqueue(new(name, prototype, tick, _timing.RealTime, milliseconds, bytes));
+    }
+
+    private void ObserveRuntime(TimeSpan now)
+    {
+        var pause = GC.GetTotalPauseDuration();
+        _runtimeWindowMs = _lastRuntimeSample == default ? 0 : (now - _lastRuntimeSample).TotalMilliseconds;
+        _gcPauseMs = _lastRuntimeSample == default ? 0 : Math.Max(0, (pause - _lastGcPause).TotalMilliseconds);
+        _lastRuntimeSample = now;
+        _lastGcPause = pause;
+    }
+
+    private void LogOperations()
+    {
+        // Manual reports can reuse an older scalar observation. Age operations at emission time.
+        var now = _timing.RealTime;
+        while (_operations.TryDequeue(out var operation))
+        {
+            if (now - operation.Completed > TimeSpan.FromSeconds(2))
+                continue;
+            _sawmill.Warning(Invariant(
+                $"[CMU-PERF] operation incidentId={_activeIncidentId} name={SanitizeName(operation.Name)} ",
+                $"prototype={SanitizeName(operation.Prototype ?? "none")} tick={operation.Tick} ",
+                $"timeMs={operation.Milliseconds:F3} allocatedBytes={operation.Bytes} ",
+                $"ageMs={(now - operation.Completed).TotalMilliseconds:F3} inclusive=true source=content-scope"));
+        }
+    }
+
+    private readonly record struct SlowOperation(string Name, string? Prototype, uint Tick, TimeSpan Completed,
+        double Milliseconds, long Bytes);
+}
+
+/// <summary>Allocation-free content timing retained independently of the engine profiler ring.</summary>
+public readonly struct CMUPerformanceOperationScope : IDisposable
+{
+    private readonly CMUServerPerformanceDiagnosticsManager? _owner;
+    private readonly string _name;
+    private readonly string? _prototype;
+    private readonly uint _tick;
+    private readonly long _started;
+    private readonly long _allocated;
+
+    internal CMUPerformanceOperationScope(CMUServerPerformanceDiagnosticsManager owner, string name, string? prototype, uint tick)
+    {
+        _owner = owner;
+        _name = name;
+        _prototype = prototype;
+        _tick = tick;
+        _started = Stopwatch.GetTimestamp();
+        _allocated = GC.GetAllocatedBytesForCurrentThread();
+    }
+
+    public void Dispose()
+    {
+        _owner?.CompleteOperation(_name, _prototype, _tick, Stopwatch.GetElapsedTime(_started).TotalMilliseconds,
+            GC.GetAllocatedBytesForCurrentThread() - _allocated);
+    }
+}

--- a/Content.CMU/Server/Diagnostics/Performance/CMUServerPerformanceDiagnosticsManager.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/CMUServerPerformanceDiagnosticsManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using Content.Server.GameTicking;
 using Content.Shared.CCVar;
+using Content.Shared.GameTicking;
 using Robust.Server.DataMetrics;
 using Robust.Server.Player;
 using Robust.Shared;
@@ -37,6 +38,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
     private readonly CMUPerformanceChurnTracker _churn = new();
     private readonly CMUPerformanceErrorTracker _errors = new();
     private readonly CMUPerformancePhaseTracker _phases = new();
+    private readonly CMUPerformanceSpikeCapture _spikeCapture = new();
     private readonly CMUPerformanceRollingWindow _shortRates = new(ShortRateWindowSeconds);
     private readonly CMUPerformanceRollingWindow _churnRates = new(ChurnRateWindowSeconds);
 
@@ -80,7 +82,6 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
     private TimeSpan _incidentStartTime;
     private TimeSpan _errorWindowStart;
     private TimeSpan _nextErrorReportTime;
-    private TimeSpan _nextStallDetailTime;
 
     private double _worstFrameMilliseconds;
     private double _worstTps = double.PositiveInfinity;
@@ -194,6 +195,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             return;
 
         TimeSpan now = _timing.RealTime;
+        ObserveRuntime(now);
         RetryCompletedProfile();
         _metricLastCompletedTick = _timing.CurTick.Value;
         bool allocationBreach = ProbeProfiler(now);
@@ -210,7 +212,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             ResetEpoch("round-change");
         }
 
-        double stallThreshold = Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds));
+        double stallThreshold = GetStallThreshold();
         bool hardStall = stallThreshold > 0 &&
                          _timing.RealFrameTime.TotalMilliseconds >= stallThreshold;
         if (!hardStall && !allocationBreach && _pendingSyncIncidentId == 0 && now < _nextSampleTime)
@@ -399,11 +401,11 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         if (thresholds.StallMilliseconds > 0 && observation.FrameMilliseconds >= thresholds.StallMilliseconds)
             RecordStall(observation);
         // A severe new stall must not disappear behind an earlier churn incident's two-minute cooldown.
-        double criticalMs = _config.GetCVar(CCVars.CMUServerPerformanceCriticalStallMilliseconds);
         bool gameplayStall = IsGameplay(observation) && thresholds.StallMilliseconds > 0 &&
                              observation.FrameMilliseconds >= thresholds.StallMilliseconds;
-        if ((gameplayStall || criticalMs > 0 && observation.FrameMilliseconds >= criticalMs) && now >= _nextStallDetailTime)
-            CaptureDetailedReport(observation, gameplayStall ? "gameplay-stall" : "critical-stall", bypassCooldown: false);
+        if (_lastDetailTime != now && _spikeCapture.ShouldCapture(now, observation.FrameMilliseconds,
+                observation.AllocatedBytes, thresholds.StallMilliseconds, thresholds.AllocationBytesPerFrame))
+            CaptureDetailedReport(observation, gameplayStall ? "gameplay-stall" : "allocation-or-stall", bypassCooldown: true);
         if (_pendingSyncIncidentId != 0)
         {
             _nextSyncDetailTime = now + TimeSpan.FromSeconds(30);
@@ -560,6 +562,10 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         }
 
         _nextStallLogTime = observation.RealTime + TimeSpan.FromSeconds(1);
+        LogOperations();
+        _sawmill.Warning(Invariant(
+            $"[CMU-PERF] runtime-window incidentId={_activeIncidentId} observedTick={observation.Tick} ",
+            $"windowMs={_runtimeWindowMs:F3} gcPauseMs={_gcPauseMs:F3} processWide=true"));
         var phase = _phases.LastFrameWorst;
         _sawmill.Warning(Invariant(
             $"[CMU-PERF] stall incidentId={_activeIncidentId} scope={Scope(observation)} round={observation.RoundId} ",
@@ -582,11 +588,13 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         string source,
         bool bypassCooldown)
     {
+        using var reportScope = _profiler.Group("CMU Diagnostics Report");
         _detailPending = false;
         _lastDetailTime = observation.RealTime;
-        double stallMs = _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds);
-        if (stallMs > 0 && observation.FrameMilliseconds >= stallMs)
-            _nextStallDetailTime = observation.RealTime + TimeSpan.FromSeconds(30);
+        LogOperations();
+        if (_spikeCapture.ShouldCapture(observation.RealTime, observation.FrameMilliseconds, observation.AllocatedBytes,
+                GetStallThreshold(), _config.GetCVar(CCVars.CMUServerPerformanceAllocationMiBPerFrame) * BytesPerMiB))
+            _spikeCapture.Record(observation.RealTime, observation.FrameMilliseconds, observation.AllocatedBytes);
         if (!bypassCooldown)
         {
             double cooldown = Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceDetailCooldown));
@@ -606,10 +614,11 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             systemNames,
             frames,
             maxEvents);
-        if (profile.Frames.Count == 0 && _profiler.IsEnabled)
+        if (_profiler.IsEnabled && (profile.Frames.Count == 0 || profile.Coverage.UnindexedEvents > 0))
         {
             // Input processing can itself be slow. Its current frame is not indexed until this
-            // callback returns, so make one retry next frame without waiting for the detail cooldown.
+            // callback returns. Older completed frames do not explain that work, so retry once
+            // next frame even when the first capture found usable older history.
             _retryProfileAfterIndex = _profiler.Buffer.IndexWriteOffset;
             _retryProfileIncidentId = _activeIncidentId;
             _retryProfileSyncIncidentId = _pendingSyncIncidentId;
@@ -739,6 +748,20 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
                 $"timeMs={frame.TimeSeconds * 1000:F3} allocatedBytes={frame.AllocatedBytes} ticks={frame.TickCount} ",
                 $"partial={frame.Partial} firstRetainedTick={frame.FirstTick?.ToString(CultureInfo.InvariantCulture) ?? "unknown"} ",
                 $"lastRetainedTick={frame.LastTick?.ToString(CultureInfo.InvariantCulture) ?? "unknown"}"));
+            var frameSamples = profile.FrameSamples.FirstOrDefault(row => row.IndexOffset == frame.IndexOffset);
+            if (frameSamples == null)
+                continue;
+            var selected = frameSamples.Samples.OrderByDescending(row => row.TotalSeconds).Take(5)
+                .Concat(frameSamples.Samples.OrderByDescending(row => row.TotalAllocatedBytes).Take(3))
+                .Concat(frameSamples.Samples.Where(row => row.Name.StartsWith("CMU ", StringComparison.Ordinal)).Take(5))
+                .Distinct();
+            foreach (var row in selected)
+            {
+                _sawmill.Warning(Invariant(
+                    $"[CMU-PERF] profile-frame-sample incidentId={_activeIncidentId} index={frame.IndexOffset} ",
+                    $"kind={row.Kind} name={SanitizeName(row.Name)} calls={row.Count} ",
+                    $"totalMs={row.TotalSeconds * 1000:F3} allocatedBytes={row.TotalAllocatedBytes} inclusive=true partial={frame.Partial}"));
+            }
         }
 
         LogProfileRows("system-time", profile.Samples
@@ -921,6 +944,9 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         _shortRates.Reset();
         _churnRates.Reset();
         _detector.Reset();
+        _spikeCapture.Clear();
+        _operations.Clear();
+        _lastRuntimeSample = default;
         _churnBaseline = _churn.Snapshot();
         _lastMessageBandwidth = new(_netManager.MessageBandwidthUsage);
         _haveNetworkStats = false;
@@ -1058,6 +1084,7 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
             $"capturePhase=input-post-engine churnIncidents={_config.GetCVar(CCVars.CMUServerPerformanceChurnIncidents)} ",
             $"sampleSeconds={Math.Max(0.1, _config.GetCVar(CCVars.CMUServerPerformanceSampleInterval)):F2} ",
             $"stallMs={Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds)):F1} ",
+            $"gameplayStallMs={Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceGameplayStallMilliseconds)):F1} ",
             $"criticalStallMs={Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceCriticalStallMilliseconds)):F1}"));
 
         bool runtimeMetrics = _config.GetCVar(CVars.MetricsRuntime);
@@ -1071,15 +1098,25 @@ public sealed partial class CMUServerPerformanceDiagnosticsManager : ICMUServerP
         {
             _sawmill.Warning(Invariant(
                 $"[CMU-PERF] runtime-metrics-disabled metrics={metrics} runtime={runtimeMetrics} ",
-                $"retainedHeapRssGcThreadPoolUnavailable=true action=enable-and-scrape-runtime-metrics"));
+                $"retainedHeapRssThreadPoolUnavailable=true gcPauseWindowAvailable=true action=enable-and-scrape-runtime-metrics"));
         }
+    }
+
+    private double GetStallThreshold()
+    {
+        double general = Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds));
+        double gameplay = Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceGameplayStallMilliseconds));
+        if (gameplay > 0 && !_timing.Paused && _ticker?.RunLevel == GameRunLevel.InRound &&
+            _ticker.RoundDuration().TotalSeconds >= 30)
+            return general > 0 ? Math.Min(general, gameplay) : gameplay;
+        return general;
     }
 
     private CMUPerformanceIncidentThresholds ReadThresholds()
     {
         bool churn = _config.GetCVar(CCVars.CMUServerPerformanceChurnIncidents);
         return new(
-            Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceStallMilliseconds)),
+            GetStallThreshold(),
             Math.Clamp(_config.GetCVar(CCVars.CMUServerPerformanceLowTpsRatio), 0, 1),
             Math.Clamp(_config.GetCVar(CCVars.CMUServerPerformanceLowFpsRatio), 0, 1),
             Math.Max(0, _config.GetCVar(CCVars.CMUServerPerformanceBreachDuration)),

--- a/Content.CMU/Server/Diagnostics/Performance/ICMUServerPerformanceDiagnostics.cs
+++ b/Content.CMU/Server/Diagnostics/Performance/ICMUServerPerformanceDiagnostics.cs
@@ -10,6 +10,7 @@ public interface ICMUServerPerformanceDiagnostics
     void EndFrameCallbacks();
     void RequestSyncReport(long syncIncidentId);
     string GetCorrelationContext();
+    CMUPerformanceOperationScope MeasureOperation(string name, string? prototype = null);
     void Shutdown();
     string GetStatus();
     bool CaptureManualReport();

--- a/Content.CMU/Server/Diagnostics/Performance/README.md
+++ b/Content.CMU/Server/Diagnostics/Performance/README.md
@@ -12,20 +12,28 @@ It never automatically invokes `serverperf deep` or retains per-entity details. 
 
 - Diagnostics and healthy one-minute heartbeats are enabled.
 - Log output is enabled by default (`cmu.server_performance.log_enabled = true`). An explicit saved false value still mutes it; `cmuperf status` and runtime configuration should be checked when deploying to an existing server.
-- A real frame of 250 ms opens an incident immediately; 1,000 ms is critical.
+- A real frame of 50 ms opens an incident during gameplay after the first 30 round seconds (`gameplay_stall_ms`). Other phases use 250 ms (`stall_ms`); 1,000 ms is critical. Set the gameplay threshold to zero to use the general threshold throughout.
 - TPS or average FPS below 80% of target for three seconds opens an incident.
 - Recovery requires all triggers to remain healthy for ten seconds; low-TPS/FPS signals must first reach 95% of target.
 - Network throughput and main-thread allocation can independently open an incident. ECS growth/churn stays in scalar telemetry but does not open incidents by default; opt in with `churn_incidents = true`. Detailed ECS rankings remain available in manual reports.
 - The flight-recorder profiler is enabled during startup so the completed frames before a trigger are still in its ring.
 - Disabling the monitor unhooks its ECS event handlers and disables the profiler only when the monitor still owns that enablement; an administrator-owned profiler is left alone.
 - Detailed reports have a two-minute cooldown. Incident opening/updates/recovery are never hidden by that cooldown.
-- Gameplay stalls (250 ms, after the first 30 round seconds) and critical lifecycle stalls can force a fresh detailed report during an existing incident, at most once every 30 seconds. New client sync incidents have a separate 30-second capture allowance even when TPS is healthy.
+- Stalls and allocation spikes can force a fresh detailed report during an existing incident. They use a separate ten-second allowance; a spike twice as large can capture sooner, with a one-second minimum spacing. New client sync incidents have a separate 30-second capture allowance even when TPS is healthy.
 - `scope=gameplay`, `paused`, `round-start`, `post-round`, `startup`, or `lobby-or-loading` separates gameplay from lifecycle work. `stall` rows identify individual frames (at most one row per second); incident close includes all observed stall counts, summed stalled-frame wall time, and suppressed row counts. Incident duration includes recovery and is not frozen time.
-- The server profiler defaults to at least 65,536 events and 512 indices. Explicit config values and larger existing buffers are preserved. Startup logs show effective capacities.
+- The server profiler defaults to at least 65,536 events and 512 indices, and the capture budget defaults to 65,536 events. Explicit config values and larger existing buffers are preserved. Startup logs show effective capacities. An in-progress input frame gets one completion retry even if older completed frames were available.
 - Error counts and representative existing errors are attached to detailed reports and summarized every 30 seconds when nonzero. At most 32 sources are retained and four samples are emitted, each capped at 2,048 characters. These identify coincident failures, not proof of CPU/GC attribution.
 - Healthy churn baselines refresh every five minutes and at startup/round boundaries.
 
 ## Log records
+
+`profile-frame-sample` attributes work and allocations to a specific profiler frame `index`; use it before comparing the older aggregate `profile-sample` rows. Nested scope timings are inclusive and must not be summed. A partial frame can still have missing scopes, and its missing time must remain unattributed.
+
+`operation` records retain slow player-spawn, storage-fill and requisitions work independently of the profiler ring, including the job or storage prototype, start tick, elapsed time and main-thread allocations. At most 32 recent operations are retained; reports discard entries older than two seconds. These scopes cover synchronous work, including synchronous work entered from an async continuation, and do not identify every possible callback.
+
+`runtime-window` reports process-wide GC pause time since the previous diagnostics update. Its `windowMs` defines the interval; it is not a per-method or exact-profiler-frame measurement. This helps distinguish GC pauses from CPU work without guessing from allocation counts alone.
+
+Timed-action completion scopes use `CMU DoAfter <event type>` so expensive pickup, medical, construction or other callbacks can be separated. The scope includes synchronous awaited continuations. `CMU Diagnostics Report` identifies the reporter's own cost.
 
 Search the named sawmill or the stable prefix:
 
@@ -39,7 +47,7 @@ The principal records are:
 | Record | Meaning |
 | --- | --- |
 | `startup` | Effective startup state, profiler state, metrics state, and main thresholds. |
-| `runtime-metrics-disabled` | Content cannot see retained heap/RSS/GC/thread-pool counters; enable external metrics. |
+| `runtime-metrics-disabled` | Retained heap/RSS/thread-pool counters need external metrics; GC pause windows remain available. |
 | `tracking-reset` / `epoch-reset` | Bounded ECS counters and rate windows were safely re-anchored. |
 | `heartbeat` | Healthy/warmup scalar snapshot. Absence is externally alertable. |
 | `baseline-refresh` | New healthy prototype/component churn comparison point. |
@@ -55,6 +63,9 @@ The principal records are:
 | `profile-retry` | One follow-up capture after an unavailable current frame has been finalized; bypasses the normal cooldown. |
 | `stall` | Frame wall time, scope, latest input-to-input phase maximum and tick, including whether that phase contains idle time. |
 | `profile-sample` | Ranked system/engine timing and allocation aggregate. |
+| `profile-frame-sample` | Inclusive scope timing and allocation for a specific profiler frame index. |
+| `operation` | Recent slow synchronous spawn, storage-fill or requisitions operation, retained outside the profiler ring. |
+| `runtime-window` | Process-wide GC pause delta and the measured interval. |
 | `profile-counter` | Integer profiler counters, including frame GC collection deltas when present. |
 | `ecs-churn` | Top prototype/component net growth or map creation since the healthy baseline. |
 | `inbound-network-message` | Top decoded inbound message types during the latest sample interval. |
@@ -146,7 +157,8 @@ All automatic-monitor CVars are server-only and archived. In the table, the firs
 | `heartbeat_interval` | `60` s | Healthy log heartbeat; `0` disables it. |
 | `incident_update_interval` | `30` s | Sustained-incident update cadence. |
 | `baseline_interval` | `300` s | Healthy churn baseline cadence. |
-| `stall_ms` | `250` ms | Immediate hard-frame trigger; `0` disables it. |
+| `stall_ms` | `250` ms | General hard-frame trigger; `0` disables this threshold. |
+| `gameplay_stall_ms` | `50` ms | Lower frame threshold after 30 round seconds; `0` uses the general threshold. |
 | `critical_stall_ms` | `1000` ms | Critical severity threshold. |
 | `low_tps_ratio` | `0.80` | Sustained achieved-TPS trigger fraction. |
 | `low_fps_ratio` | `0.80` | Sustained average-FPS trigger fraction. |
@@ -162,7 +174,7 @@ All automatic-monitor CVars are server-only and archived. In the table, the firs
 | `allocation_mib_per_frame` | `32` | Profiled main-thread allocation trigger. |
 | `enable_profiler` | `true` | Enables the profiler during diagnostics startup if it is off. |
 | `profile_frames` | `8` | Maximum selected frames in a detail report, mixing slowest, highest-allocation, recent tick-bearing, and newest frames. |
-| `profile_max_events` | `20000` | Hard profiler parse bound. |
+| `profile_max_events` | `65536` | Hard profiler parse bound. |
 | `report_top` | `10` | Rows per detail category, clamped to 1–25. |
 | `detail_cooldown` | `120` s | Minimum spacing between automatic detail reports. |
 
@@ -176,6 +188,8 @@ churn_incidents = false
 sample_interval = 1
 heartbeat_interval = 60
 stall_ms = 250
+gameplay_stall_ms = 50
+profile_max_events = 65536
 critical_stall_ms = 1000
 low_tps_ratio = 0.80
 low_fps_ratio = 0.80
@@ -196,13 +210,13 @@ client_state_health_enabled = true
 The correct logging key is `cmu.server_performance.log_enabled`; the old
 `log.cmu.server_performance.log_enabled` key is invalid. These content changes must be deployed to both
 server and clients for application-progress reports. Runtime metrics below still need external scraping;
-the diagnostic logger does not claim to measure GC pauses or retained heap itself.
+the diagnostic logger measures process-wide GC pause windows but does not measure retained heap.
 
 Increasing profiler rings preserves more pre-trigger history but consumes more fixed memory and makes a report scan larger. The automatic parser still caps frames and events.
 
 ## Runtime and process telemetry
 
-The content sandbox does not allow direct calls to `GC`, `Process`, or `ThreadPool`. The automatic logs therefore cannot honestly report retained managed heap, process working set/private bytes, CPU, handles, thread count, or thread-pool starvation.
+The diagnostics manager under `Content.CMU/Server` is compiled into `Content.Server`, which runs without the client sandbox and can read GC pause and allocation counters. Server gameplay code calls its bounded operation scopes through the diagnostics interface. Client and shared code keep using the sandbox-compatible engine profiler. The automatic logs do not report retained managed heap, process working set/private bytes, CPU, handles, thread count, or thread-pool starvation.
 
 Use the existing engine metrics endpoint for that layer:
 

--- a/Content.CMU/Server/Requisitions/RequisitionsDeliveryComponent.cs
+++ b/Content.CMU/Server/Requisitions/RequisitionsDeliveryComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._RMC14.Requisitions;
+
+/// <summary>Private, off-map cargo being prepared for an elevator's current trip.</summary>
+[RegisterComponent]
+public sealed partial class RequisitionsDeliveryComponent : Component
+{
+    public readonly List<EntityUid> Roots = new();
+    public readonly Queue<EntProtoId> Remaining = new();
+    public EntityUid CurrentRoot;
+}

--- a/Content.CMU/Server/Requisitions/RequisitionsSystem.Delivery.cs
+++ b/Content.CMU/Server/Requisitions/RequisitionsSystem.Delivery.cs
@@ -1,0 +1,70 @@
+using Content.Server.Storage.Components;
+using Content.Shared._RMC14.Requisitions.Components;
+using Content.Shared.Storage;
+using Content.Shared.Storage.Components;
+using Robust.Shared.Map;
+using Stopwatch = System.Diagnostics.Stopwatch;
+
+namespace Content.Server._RMC14.Requisitions;
+
+public sealed partial class RequisitionsSystem
+{
+    // Shared across elevators in one update. The count cap also bounds very cheap spawns.
+    private int _deliverySteps;
+    private long _deliveryStarted;
+
+    private bool PrepareDelivery(Entity<RequisitionsElevatorComponent> elevator)
+    {
+        using var profile = _profiler.Group("CMU Requisitions Prepare");
+        using var operation = _performance.MeasureOperation("requisitions-prepare");
+        TryGiveRoundStartFreeCrate(elevator);
+        var delivery = EnsureComp<RequisitionsDeliveryComponent>(elevator);
+        while (delivery.Remaining.Count > 0 || delivery.Roots.Count < elevator.Comp.Orders.Count)
+        {
+            if (_deliverySteps >= 4 ||
+                _deliverySteps > 0 && Stopwatch.GetElapsedTime(_deliveryStarted).TotalMilliseconds >= 2)
+                return false;
+            if (_deliverySteps++ == 0)
+                _deliveryStarted = Stopwatch.GetTimestamp();
+
+            if (delivery.Remaining.TryDequeue(out var item))
+            {
+                var uid = Spawn(item, MapCoordinates.Nullspace);
+                if (!_entityStorage.Insert(uid, delivery.CurrentRoot))
+                {
+                    // Retain unexpected overflow and deliver it rather than leaking it in nullspace.
+                    // Crate capacity is validated by the catalog; a failure is a content error.
+                    _transform.SetParent(uid, delivery.CurrentRoot);
+                    Log.Error($"Shipment item {item} did not fit in {ToPrettyString(delivery.CurrentRoot)}.");
+                }
+                continue;
+            }
+
+            var order = elevator.Comp.Orders[delivery.Roots.Count];
+            var root = EntityManager.CreateEntityUninitialized(order.Crate, MapCoordinates.Nullspace);
+            delivery.Roots.Add(root); // Own the entity before initialization, including exceptional cleanup.
+            delivery.CurrentRoot = root;
+            if (HasComp<EntityStorageComponent>(root) && !HasComp<StorageComponent>(root))
+                AddComp<DeferredEntityStorageFillComponent>(root);
+            EntityManager.InitializeAndStartEntity(root, true);
+            if (TryComp<DeferredEntityStorageFillComponent>(root, out var fill))
+            {
+                foreach (var prototype in fill.Prototypes)
+                    delivery.Remaining.Enqueue(prototype);
+                RemComp<DeferredEntityStorageFillComponent>(root);
+            }
+            foreach (var prototype in order.Entities)
+                delivery.Remaining.Enqueue(prototype);
+        }
+        return true;
+    }
+
+    private void OnDeliveryShutdown(Entity<RequisitionsDeliveryComponent> ent, ref ComponentShutdown args)
+    {
+        foreach (var root in ent.Comp.Roots)
+        {
+            if (!TerminatingOrDeleted(root))
+                QueueDel(root);
+        }
+    }
+}

--- a/Content.CMU/Server/Storage/DeferredEntityStorageFillComponent.cs
+++ b/Content.CMU/Server/Storage/DeferredEntityStorageFillComponent.cs
@@ -1,0 +1,8 @@
+namespace Content.Server.Storage.Components;
+
+/// <summary>Lets a bounded shipment builder populate a crate after its map initialization.</summary>
+[RegisterComponent]
+public sealed partial class DeferredEntityStorageFillComponent : Component
+{
+    public readonly List<string> Prototypes = new();
+}

--- a/Content.CMU/Shared/Storage/SharedStorageSystem.Placement.cs
+++ b/Content.CMU/Shared/Storage/SharedStorageSystem.Placement.cs
@@ -1,0 +1,66 @@
+using Robust.Shared.Map;
+using Robust.Shared.Map.Enumerators;
+
+namespace Content.Shared.Storage.EntitySystems;
+
+public abstract partial class SharedStorageSystem
+{
+    /// <summary>
+    /// Builds a snapshot for one placement operation. Reusing the component's occupied
+    /// mask would incorrectly ignore overlapping items when moving an existing item,
+    /// and can miss changes to storage-specific item shapes.
+    /// </summary>
+    private Dictionary<Vector2i, ulong> BuildPlacementOccupancy(Entity<StorageComponent> storage, EntityUid ignored)
+    {
+        var occupied = new Dictionary<Vector2i, ulong>();
+        RemoveOccupied(storage.Comp.Grid, occupied);
+
+        foreach (var (uid, location) in storage.Comp.StoredItems)
+        {
+            if (uid == ignored || !_itemQuery.TryGetComponent(uid, out var item))
+                continue;
+
+            var shape = ItemSystem.GetAdjustedItemShape((storage.Owner, storage.Comp), (uid, item), location);
+            // Chunks outside the grid must remain absent (and therefore unavailable).
+            AddOccupied(shape, occupied, onlyExistingChunks: true);
+        }
+
+        return occupied;
+    }
+
+    private static bool FitsPlacementOccupancy(
+        Dictionary<Vector2i, ulong> occupied,
+        IReadOnlyList<Box2i> shape,
+        Vector2i position)
+    {
+        for (var i = 0; i < shape.Count; i++)
+        {
+            var box = shape[i].Translated(position);
+            var chunks = new ChunkIndicesEnumerator(box, StorageComponent.ChunkSize);
+            while (chunks.MoveNext(out var chunk))
+            {
+                var origin = chunk.Value * StorageComponent.ChunkSize;
+                if (!occupied.TryGetValue(origin, out var mask))
+                    return false;
+
+                var left = Math.Max(origin.X, box.Left);
+                var bottom = Math.Max(origin.Y, box.Bottom);
+                var right = Math.Min(origin.X + StorageComponent.ChunkSize - 1, box.Right);
+                var top = Math.Min(origin.Y + StorageComponent.ChunkSize - 1, box.Top);
+
+                for (var x = left; x <= right; x++)
+                {
+                    for (var y = bottom; y <= top; y++)
+                    {
+                        var relative = SharedMapSystem.GetChunkRelative(new Vector2i(x, y), StorageComponent.ChunkSize);
+                        var flag = SharedMapSystem.ToBitmask(relative, StorageComponent.ChunkSize);
+                        if ((mask & flag) != 0)
+                            return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/Content.IntegrationTests/_CMU14/Diagnostics/GameplaySpawnMeasurement.cs
+++ b/Content.IntegrationTests/_CMU14/Diagnostics/GameplaySpawnMeasurement.cs
@@ -1,0 +1,89 @@
+using System.Diagnostics;
+using Content.IntegrationTests.Fixtures;
+using Content.Server.Station.Systems;
+using Content.Server._RMC14.Requisitions;
+using Content.Shared._RMC14.Requisitions;
+using Content.Shared._RMC14.Requisitions.Components;
+using Content.Shared.Preferences;
+
+namespace Content.IntegrationTests.CMU14.Diagnostics;
+
+[TestFixture, Explicit("Controlled measurement of the gameplay spawn workloads seen in server incidents.")]
+public sealed class GameplaySpawnMeasurement : GameTest
+{
+    public override PoolSettings PoolSettings => new() { Connected = false, Dirty = true };
+
+    [Test]
+    public async Task MeasureGameplaySpawns()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var spawning = Server.System<StationSpawningSystem>();
+            Measure("physician", () => spawning.SpawnPlayerMob(map.GridCoords,
+                "AU14JobCivilianPhysician", HumanoidCharacterProfile.DefaultWithSpecies("Human"), null), 8);
+            Measure("flare-batch", () =>
+            {
+                for (var i = 0; i < 40; i++)
+                    SEntMan.SpawnEntity("CMPackFlare", map.GridCoords);
+            }, 8);
+        });
+    }
+
+    [Test]
+    public async Task MeasureDeliveryUpdates()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var system = Server.System<RequisitionsSystem>();
+            var timing = Server.ResolveDependency<Robust.Shared.Timing.IGameTiming>();
+            for (var iteration = 0; iteration < 8; iteration++)
+            {
+                var elevator = SEntMan.SpawnEntity("CMCargoElevator", map.GridCoords);
+                var component = SEntMan.GetComponent<RequisitionsElevatorComponent>(elevator);
+                component.RoundStartFreeCrateGiven = true;
+                component.Orders.Add(new RequisitionsEntry
+                {
+                    Crate = "CMUASRSShipmentCrate",
+                    Entities = Enumerable.Repeat<Robust.Shared.Prototypes.EntProtoId>("CMPackFlare", 40).ToList(),
+                });
+                component.Mode = RequisitionsElevatorMode.Raising;
+                component.Busy = true;
+                component.RaiseDelay = TimeSpan.Zero;
+                component.LowerDelay = TimeSpan.Zero;
+                component.ToggledAt = timing.CurTime - TimeSpan.FromSeconds(1);
+                var maxMs = 0d;
+                var totalMs = 0d;
+                var maxBytes = 0L;
+                var steps = 0;
+                while (component.Mode != RequisitionsElevatorMode.Raised && steps++ < 200)
+                {
+                    var allocated = GC.GetAllocatedBytesForCurrentThread();
+                    var start = Stopwatch.GetTimestamp();
+                    system.Update(0f);
+                    var ms = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+                    maxBytes = Math.Max(maxBytes, GC.GetAllocatedBytesForCurrentThread() - allocated);
+                    maxMs = Math.Max(maxMs, ms);
+                    totalMs += ms;
+                }
+                Assert.That(component.Mode, Is.EqualTo(RequisitionsElevatorMode.Raised));
+                TestContext.Progress.WriteLine($"workload=delivery iteration={iteration} steps={steps} maxMs={maxMs:F3} totalMs={totalMs:F3} maxBytes={maxBytes}");
+                SEntMan.DeleteEntity(elevator);
+            }
+        });
+    }
+
+    private static void Measure(string name, Action action, int repetitions)
+    {
+        for (var i = 0; i < repetitions; i++)
+        {
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            var start = Stopwatch.GetTimestamp();
+            action();
+            var elapsed = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+            var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+            TestContext.Out.WriteLine($"workload={name} iteration={i} milliseconds={elapsed:F3} allocatedBytes={allocated}");
+        }
+    }
+}

--- a/Content.IntegrationTests/_CMU14/Diagnostics/ServerProfilerCaptureTest.cs
+++ b/Content.IntegrationTests/_CMU14/Diagnostics/ServerProfilerCaptureTest.cs
@@ -2,12 +2,99 @@ using Content.Server.CMU14.Diagnostics.Performance;
 using Robust.Shared;
 using Robust.Shared.Configuration;
 using Robust.Shared.Profiling;
+using Robust.Shared.Log;
+using Serilog.Events;
 
 namespace Content.IntegrationTests.CMU14.Diagnostics;
 
 [TestFixture]
 public sealed class ServerProfilerCaptureTest
 {
+    [Test]
+    public async Task SlowOperationSurvivesOutsideProfilerHistory()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Dirty = true });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var diagnostics = pair.Server.ResolveDependency<ICMUServerPerformanceDiagnostics>();
+            var logger = pair.Server.ResolveDependency<ILogManager>().GetSawmill("cmu.server-performance");
+            var capture = new OperationCapture();
+            logger.AddHandler(capture);
+            try
+            {
+                using (diagnostics.MeasureOperation("regression-fill", "TestPrototype"))
+                    GC.KeepAlive(new byte[2 * 1024 * 1024]);
+                Assert.That(diagnostics.CaptureManualReport(), Is.True);
+                var operation = capture.Messages.Single(message => message.Contains("name=regression-fill "));
+                Assert.That(operation, Does.Contain("prototype=TestPrototype "));
+                Assert.That(operation, Does.Contain("source=content-scope"));
+                Assert.That(operation, Does.Contain("inclusive=true"));
+                Assert.That(operation, Does.Not.Contain("ageMs=-"),
+                    "A cached manual-report observation must not predate the operation's logging timestamp.");
+            }
+            finally
+            {
+                logger.RemoveHandler(capture);
+            }
+        });
+        await pair.CleanReturnAsync();
+    }
+
+    private sealed class OperationCapture : ILogHandler
+    {
+        public readonly List<string> Messages = new();
+        public void Log(string sawmillName, LogEvent message) => Messages.Add(message.RenderMessage());
+    }
+
+    [Test]
+    public async Task SlowInputRemainsAttributableWhenOlderCompletedFramesExist()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings { Dirty = true });
+        await pair.Server.WaitAssertion(() =>
+        {
+            var config = pair.Server.ResolveDependency<IConfigurationManager>();
+            var profiler = pair.Server.ResolveDependency<ProfManager>();
+            var previous = profiler.Buffer;
+            var enabled = profiler.IsEnabled;
+            try
+            {
+                profiler.Buffer = new ProfBuffer { LogBuffer = new ProfLog[1024], IndexBuffer = new ProfIndex[8] };
+                config.SetCVar(CVars.ProfEnabled, true);
+                var old = profiler.WriteValue("Start Frame", 1L);
+                End(old, "Frame", 0.01);
+                profiler.MarkIndex(old, ProfIndexType.Frame);
+                var current = profiler.WriteValue("Start Frame", 2L);
+                var input = profiler.WriteValue("Input start", 1L);
+                End(input, "CMU PlayerSpawn", 0.2);
+                var pending = Capture();
+                Assert.That(pending.Frames, Has.Count.EqualTo(1));
+                Assert.That(pending.Coverage.UnindexedEvents, Is.GreaterThan(0),
+                    "A successful older capture must not prevent a completion retry for slow input.");
+                End(current, "Frame", 0.21);
+                profiler.MarkIndex(current, ProfIndexType.Frame);
+                var completed = Capture();
+                Assert.That(completed.FrameSamples, Has.Count.EqualTo(2));
+                Assert.That(completed.FrameSamples.Single(row => row.IndexOffset == 0).Samples, Is.Empty);
+                var spawn = completed.FrameSamples.Single(row => row.IndexOffset == 1).Samples.Single();
+                Assert.That(spawn.Name, Is.EqualTo("CMU PlayerSpawn"));
+                Assert.That(spawn.TotalSeconds, Is.EqualTo(0.2).Within(0.000001));
+            }
+            finally
+            {
+                profiler.Buffer = previous;
+                config.SetCVar(CVars.ProfEnabled, enabled);
+            }
+
+            CMUPerformanceProfileReport Capture() => CMUPerformanceProfilerReader.Capture(profiler, new HashSet<string>(), 8, 1024);
+            void End(long start, string name, double seconds) => profiler.WriteGroupEnd(start, name, new ProfValue
+            {
+                Type = ProfValueType.TimeAllocSample,
+                TimeAllocSample = new TimeAndAllocSample { Time = (float) seconds, Alloc = 1024 },
+            });
+        });
+        await pair.CleanReturnAsync();
+    }
+
     [Test]
     public async Task BusyUnfinishedFrameExplainsLossAndRetainsItsTailAfterCompletion()
     {

--- a/Content.IntegrationTests/_CMU14/Requisitions/ASRSDeliveryBudgetTest.cs
+++ b/Content.IntegrationTests/_CMU14/Requisitions/ASRSDeliveryBudgetTest.cs
@@ -1,0 +1,114 @@
+using Stopwatch = System.Diagnostics.Stopwatch;
+using Content.IntegrationTests.Fixtures;
+using Content.Server._RMC14.Requisitions;
+using Content.Shared._RMC14.Requisitions;
+using Content.Shared._RMC14.Requisitions.Components;
+using Content.Shared.Containers.ItemSlots;
+using Content.Shared.Storage.Components;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.CMU14.Requisitions;
+
+[TestFixture]
+public sealed class ASRSDeliveryBudgetTest : GameTest
+{
+    public override PoolSettings PoolSettings => new() { Connected = false, Dirty = true };
+
+    [TestPrototypes]
+    private const string Prototypes = """
+        - type: entity
+          parent: CMUASRSShipmentCrate
+          id: CMUBudgetFlareCrate
+          components:
+          - type: StorageFill
+            contents:
+            - id: CMPackFlare
+              amount: 40
+        """;
+
+    [TestCase(false)]
+    [TestCase(true)]
+    public async Task BulkDeliverySpreadsSpawnsAndPublishesCompleteCrates(bool legacy)
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var elevator = SEntMan.SpawnEntity("CMCargoElevator", map.GridCoords);
+            var component = SEntMan.GetComponent<RequisitionsElevatorComponent>(elevator);
+            component.RoundStartFreeCrateGiven = true;
+            component.Orders.Add(new RequisitionsEntry
+            {
+                Crate = legacy ? "CMUBudgetFlareCrate" : "CMUASRSShipmentCrate",
+                Entities = legacy ? [] : Enumerable.Repeat<Robust.Shared.Prototypes.EntProtoId>("CMPackFlare", 40).ToList(),
+            });
+            component.Mode = RequisitionsElevatorMode.Raising;
+            component.NextMode = null;
+            component.Busy = true;
+            component.RaiseDelay = TimeSpan.Zero;
+            component.LowerDelay = TimeSpan.Zero;
+            component.ToggledAt = Server.ResolveDependency<IGameTiming>().CurTime - TimeSpan.FromSeconds(1);
+            var system = Server.System<RequisitionsSystem>();
+            system.Update(0f);
+            Assert.That(component.Mode, Is.EqualTo(RequisitionsElevatorMode.Raising),
+                "A forty-pack shipment must not be materialized in one gameplay tick.");
+            Assert.That(component.Orders, Has.Count.EqualTo(1));
+
+            var steps = 1;
+            var longest = 0d;
+            while (component.Mode != RequisitionsElevatorMode.Raised && steps++ < 200)
+            {
+                var start = Stopwatch.GetTimestamp();
+                system.Update(0f);
+                longest = Math.Max(longest, Stopwatch.GetElapsedTime(start).TotalMilliseconds);
+            }
+            TestContext.Progress.WriteLine($"Delivery legacy={legacy} updates={steps} longestAfterFirstMs={longest:F3}");
+            Assert.That(component.Mode, Is.EqualTo(RequisitionsElevatorMode.Raised));
+            Assert.That(component.Orders, Is.Empty);
+            var crates = SEntMan.EntityQueryEnumerator<MetaDataComponent, EntityStorageComponent, TransformComponent>();
+            var delivered = 0;
+            while (crates.MoveNext(out _, out var metadata, out var storage, out var transform))
+            {
+                if (metadata.EntityPrototype?.ID != (legacy ? "CMUBudgetFlareCrate" : "CMUASRSShipmentCrate"))
+                    continue;
+                Assert.That(transform.MapID, Is.EqualTo(map.MapId));
+                Assert.That(storage.Contents.ContainedEntities, Has.Count.EqualTo(40));
+                foreach (var pack in storage.Contents.ContainedEntities)
+                {
+                    var slots = SEntMan.GetComponent<ItemSlotsComponent>(pack);
+                    Assert.That(slots.Slots.Values.Count(slot => slot.ContainerSlot?.ContainedEntity != null), Is.EqualTo(8));
+                }
+                delivered++;
+            }
+            Assert.That(delivered, Is.EqualTo(1));
+        });
+    }
+    [Test]
+    public async Task RemovingElevatorCleansUpCargoPreparedOffMap()
+    {
+        var map = await Pair.CreateTestMap();
+        EntityUid[] roots = [];
+        await Server.WaitAssertion(() =>
+        {
+            var elevator = SEntMan.SpawnEntity("CMCargoElevator", map.GridCoords);
+            var component = SEntMan.GetComponent<RequisitionsElevatorComponent>(elevator);
+            component.RoundStartFreeCrateGiven = true;
+            component.Mode = RequisitionsElevatorMode.Preparing;
+            component.NextMode = RequisitionsElevatorMode.Raising;
+            component.RaiseDelay = TimeSpan.FromHours(1);
+            component.ToggledAt = Server.ResolveDependency<IGameTiming>().CurTime;
+            component.Orders.Add(new RequisitionsEntry { Crate = "CMUBudgetFlareCrate" });
+            Server.System<RequisitionsSystem>().Update(0f);
+            roots = SEntMan.GetComponent<RequisitionsDeliveryComponent>(elevator).Roots.ToArray();
+            Assert.That(roots, Has.Length.EqualTo(1));
+            Assert.That(SEntMan.GetComponent<TransformComponent>(roots[0]).MapID, Is.EqualTo(Robust.Shared.Map.MapId.Nullspace));
+            Assert.That(component.Mode, Is.EqualTo(RequisitionsElevatorMode.Preparing));
+            SEntMan.DeleteEntity(elevator);
+        });
+        await Server.WaitRunTicks(2);
+        await Server.WaitAssertion(() =>
+        {
+            foreach (var root in roots)
+                Assert.That(SEntMan.EntityExists(root), Is.False);
+        });
+    }
+}

--- a/Content.IntegrationTests/_CMU14/Requisitions/ASRSOrderDeliveryRegressionTest.cs
+++ b/Content.IntegrationTests/_CMU14/Requisitions/ASRSOrderDeliveryRegressionTest.cs
@@ -337,7 +337,9 @@ public sealed class ASRSOrderDeliveryRegressionTest : GameTest
         component.ToggleDelay = TimeSpan.FromHours(1);
         component.LowerDelay = TimeSpan.Zero;
         component.RaiseDelay = TimeSpan.Zero;
-        Server.System<RequisitionsSystem>().Update(0f);
+        for (var i = 0; i < 200 && component.Mode != RequisitionsElevatorMode.Raised; i++)
+            Server.System<RequisitionsSystem>().Update(0f);
+        Assert.That(component.Mode, Is.EqualTo(RequisitionsElevatorMode.Raised));
     }
 
     private void BeginLowerForSell(EntityUid elevator)

--- a/Content.IntegrationTests/_CMU14/Storage/StoragePlacementAllocationTest.cs
+++ b/Content.IntegrationTests/_CMU14/Storage/StoragePlacementAllocationTest.cs
@@ -1,0 +1,251 @@
+using Content.IntegrationTests.Fixtures;
+using Content.Shared.DoAfter;
+using Content.Shared.Storage.EntitySystems;
+using Content.Shared.Item;
+using Robust.Shared.Containers;
+
+namespace Content.IntegrationTests.CMU14.Storage;
+
+[TestFixture]
+public sealed class StoragePlacementAllocationTest : GameTest
+{
+    [TestPrototypes]
+    private const string Prototypes = """
+        - type: entity
+          id: CMUStoragePlacementPerfHost
+          components:
+          - type: Storage
+            maxItemSize: Huge
+            grid:
+            - 0,0,7,7
+
+        - type: entity
+          id: CMUStoragePlacementPerfItem
+          components:
+          - type: Item
+            size: Tiny
+            shape:
+            - 0,0,0,0
+
+        - type: entity
+          parent: CMUStoragePlacementPerfHost
+          id: CMUStoragePlacementSplitGrid
+          components:
+          - type: Storage
+            grid:
+            - -2,0,-1,0
+            - 1,0,1,0
+
+        - type: entity
+          parent: CMUStoragePlacementSplitGrid
+          id: CMUStoragePlacementFixedGrid
+          components:
+          - type: FixedItemSizeStorage
+            size: 1,1
+
+        - type: entity
+          parent: CMUStoragePlacementPerfItem
+          id: CMUStoragePlacementWideItem
+          components:
+          - type: Item
+            shape:
+            - 0,0,1,0
+        """;
+
+    [Test]
+    public async Task NearlyFullStorageDoesNotRebuildEveryStoredShapeForEveryCandidate()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var host = SEntMan.SpawnEntity("CMUStoragePlacementPerfHost", map.GridCoords);
+            var candidate = SEntMan.SpawnEntity("CMUStoragePlacementPerfItem", map.GridCoords);
+            var storage = SEntMan.GetComponent<StorageComponent>(host);
+            var containers = Server.System<SharedContainerSystem>();
+            var system = Server.System<SharedStorageSystem>();
+            try
+            {
+                for (var i = 0; i < 63; i++)
+                {
+                    var item = SEntMan.SpawnEntity("CMUStoragePlacementPerfItem", map.GridCoords);
+                    Assert.That(containers.Insert(item, storage.Container), Is.True);
+                }
+
+                Assert.That(system.TryGetAvailableGridSpace(host, candidate, out var expected), Is.True);
+                Assert.That(expected!.Value.Position, Is.EqualTo(new Vector2i(7, 7)));
+                for (var i = 0; i < 8; i++)
+                    system.TryGetAvailableGridSpace(host, candidate, out _);
+
+                var before = GC.GetAllocatedBytesForCurrentThread();
+                var found = 0;
+                for (var i = 0; i < 32; i++)
+                {
+                    if (system.TryGetAvailableGridSpace(host, candidate, out var location) && location == expected)
+                        found++;
+                }
+                var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+                TestContext.Out.WriteLine($"32 nearly-full placement searches allocated {allocated} bytes");
+                Assert.Multiple(() =>
+                {
+                    Assert.That(found, Is.EqualTo(32));
+                    Assert.That(allocated, Is.LessThan(1024 * 1024),
+                        "Placement must not allocate shapes again for each candidate cell and rotation.");
+                });
+
+                Assert.That(containers.Insert(candidate, storage.Container), Is.True);
+                Assert.That(system.TryGetAvailableGridSpace(host, candidate, out var ownLocation), Is.True,
+                    "An item already in storage must be allowed to reuse its own occupied cells.");
+                Assert.That(ownLocation, Is.EqualTo(expected));
+                var extra = SEntMan.SpawnEntity("CMUStoragePlacementPerfItem", map.GridCoords);
+                try
+                {
+                    Assert.That(system.TryGetAvailableGridSpace(host, extra, out _), Is.False);
+                }
+                finally
+                {
+                    SEntMan.DeleteEntity(extra);
+                }
+            }
+            finally
+            {
+                SEntMan.DeleteEntity(candidate);
+                SEntMan.DeleteEntity(host);
+            }
+        });
+    }
+
+    [Test]
+    public async Task AreaPickupIntoNearlyFullStorageKeepsAllocationsBounded()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var host = SEntMan.SpawnEntity("CMUStoragePlacementPerfHost", map.GridCoords);
+            var user = SEntMan.SpawnEntity("MobHuman", map.GridCoords);
+            var storage = SEntMan.GetComponent<StorageComponent>(host);
+            var containers = Server.System<SharedContainerSystem>();
+            var doAfters = Server.System<SharedDoAfterSystem>();
+            var pickups = new List<EntityUid>();
+            try
+            {
+                for (var i = 0; i < 53; i++)
+                {
+                    var item = SEntMan.SpawnEntity("CMUStoragePlacementPerfItem", map.GridCoords);
+                    Assert.That(containers.Insert(item, storage.Container), Is.True);
+                }
+
+                // Warm the actual completion handler before measuring a full ten-item pickup.
+                var warmItem = SEntMan.SpawnEntity("CMUStoragePlacementPerfItem", map.GridCoords);
+                pickups.Add(warmItem);
+                var warmEvent = new AreaPickupDoAfterEvent([SEntMan.GetNetEntity(warmItem)]);
+                Assert.That(doAfters.TryStartDoAfter(new DoAfterArgs(SEntMan, user, TimeSpan.Zero, warmEvent, host)), Is.True);
+                Assert.That(storage.Container.ContainedEntities.Count, Is.EqualTo(54));
+
+                var entities = new List<NetEntity>();
+                for (var i = 0; i < StorageComponent.AreaPickupLimit; i++)
+                {
+                    var item = SEntMan.SpawnEntity("CMUStoragePlacementPerfItem", map.GridCoords);
+                    pickups.Add(item);
+                    entities.Add(SEntMan.GetNetEntity(item));
+                }
+
+                var ev = new AreaPickupDoAfterEvent(entities);
+                var args = new DoAfterArgs(SEntMan, user, TimeSpan.Zero, ev, host);
+                var before = GC.GetAllocatedBytesForCurrentThread();
+                var started = doAfters.TryStartDoAfter(args);
+                var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+                TestContext.Out.WriteLine($"Ten-item area pickup allocated {allocated} bytes");
+                Assert.Multiple(() =>
+                {
+                    Assert.That(started, Is.True);
+                    Assert.That(ev.Handled, Is.True);
+                    Assert.That(storage.Container.ContainedEntities.Count, Is.EqualTo(64));
+                    Assert.That(allocated, Is.LessThan(4 * 1024 * 1024),
+                        "Completing a pickup must not rebuild stored shapes for each placement candidate.");
+                });
+            }
+            finally
+            {
+                foreach (var item in pickups)
+                    SEntMan.DeleteEntity(item);
+                SEntMan.DeleteEntity(user);
+                SEntMan.DeleteEntity(host);
+            }
+        });
+    }
+
+    [TestCase("CMUStoragePlacementSplitGrid", false)]
+    [TestCase("CMUStoragePlacementFixedGrid", true)]
+    public async Task PlacementPreservesHolesNegativeCoordinatesAndFixedSize(string prototype, bool fixedSize)
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var host = SEntMan.SpawnEntity(prototype, map.GridCoords);
+            var item = SEntMan.SpawnEntity("CMUStoragePlacementWideItem", map.GridCoords);
+            var system = Server.System<SharedStorageSystem>();
+            try
+            {
+                Assert.That(system.TryGetAvailableGridSpace(host, item, out var location), Is.True);
+                Assert.That(location!.Value.Position, Is.EqualTo(new Vector2i(-2, 0)));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(system.ItemFitsInGridLocation(item, host, new Vector2i(-1, 0), Angle.Zero), Is.EqualTo(fixedSize));
+                    Assert.That(system.ItemFitsInGridLocation(item, host, new Vector2i(0, 0), Angle.Zero), Is.False);
+                    Assert.That(system.ItemFitsInGridLocation(item, host, new Vector2i(1, 0), Angle.Zero), Is.EqualTo(fixedSize));
+                });
+
+                // A new query must observe shape changes without retaining a stale occupancy snapshot.
+                Server.System<SharedItemSystem>().SetShape(item, [new Box2i(0, 0, 0, 0)]);
+                Assert.That(system.ItemFitsInGridLocation(item, host, new Vector2i(1, 0), Angle.Zero), Is.True);
+            }
+            finally
+            {
+                SEntMan.DeleteEntity(item);
+                SEntMan.DeleteEntity(host);
+            }
+        });
+    }
+
+    [Test]
+    public async Task SavedPlacementFallsBackWhenBlockedAndMovingDoesNotIgnoreOtherItems()
+    {
+        var map = await Pair.CreateTestMap();
+        await Server.WaitAssertion(() =>
+        {
+            var host = SEntMan.SpawnEntity("CMUStoragePlacementPerfHost", map.GridCoords);
+            var first = SEntMan.SpawnEntity("CMUStoragePlacementPerfItem", map.GridCoords);
+            var second = SEntMan.SpawnEntity("CMUStoragePlacementPerfItem", map.GridCoords);
+            var system = Server.System<SharedStorageSystem>();
+            var containers = Server.System<SharedContainerSystem>();
+            var storage = SEntMan.GetComponent<StorageComponent>(host);
+            try
+            {
+                Assert.That(containers.Insert(first, storage.Container), Is.True);
+                var saved = new ItemStorageLocation(Angle.Zero, new Vector2i(6, 6));
+                Assert.That(system.TrySetItemStorageLocation(first, host, saved), Is.True);
+                system.SaveItemLocation(host, first);
+                Assert.That(containers.Remove(first, storage.Container), Is.True);
+                Assert.That(system.TryGetAvailableGridSpace(host, second, out var preferred), Is.True);
+                Assert.That(preferred, Is.EqualTo(saved));
+                Assert.That(containers.Insert(first, storage.Container), Is.True);
+                Assert.That(system.TryGetAvailableGridSpace(host, second, out var fallback), Is.True);
+                Assert.That(fallback!.Value.Position, Is.EqualTo(Vector2i.Zero));
+                Assert.That(containers.Insert(second, storage.Container), Is.True);
+                Assert.That(system.TrySetItemStorageLocation(first, host, fallback.Value), Is.False);
+
+                // Even with overlapping stored locations, ignoring the moving item must retain the other occupant.
+                storage.StoredItems[second] = saved;
+                Assert.That(system.ItemFitsInGridLocation(first, host, saved), Is.False);
+                Assert.That(system.TryGetAvailableGridSpace(host, first, out var free), Is.True);
+                Assert.That(free!.Value.Position, Is.EqualTo(Vector2i.Zero));
+            }
+            finally
+            {
+                SEntMan.DeleteEntity(first);
+                SEntMan.DeleteEntity(second);
+                SEntMan.DeleteEntity(host);
+            }
+        });
+    }
+}

--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -1,6 +1,7 @@
 using System.Collections.Frozen;
 using Content.Server.Access.Systems;
 using Content.Server.CMU14.Roles;
+using Content.Server.CMU14.Diagnostics.Performance; // CMU14
 using Content.Server.CMU14.Round;
 using Content.Server.Humanoid;
 using Content.Server.Jobs;
@@ -73,6 +74,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
     [Dependency] private MarkingManager _markingManager = default!;
     [Dependency] private ISharedAdminLogManager _adminLog = default!;
     [Dependency] private MindSystem _mindSystem = default!;
+    [Dependency] private ICMUServerPerformanceDiagnostics _performance = default!; // CMU14
 
     private static readonly PlatoonJobClass[] PlatoonJobClasses = Enum.GetValues<PlatoonJobClass>();
     private static readonly FrozenDictionary<PlatoonJobClass, string> PlatoonJobClassNames = PlatoonJobClasses.ToFrozenDictionary(v => v, v => v.ToString());
@@ -175,6 +177,7 @@ public sealed partial class StationSpawningSystem : SharedStationSpawningSystem
         EntityUid? entity = null)
     {
         // --- Platoon job override logic start ---
+        using var operation = _performance.MeasureOperation("player-spawn", job?.Id); // CMU14: retain slow spawn attribution.
         string? jobId = job?.ToString();
         var originalJob = job;
         _prototypeManager.Resolve(originalJob, out JobPrototype? originalPrototype);

--- a/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
+++ b/Content.Server/Storage/EntitySystems/StorageSystem.Fill.cs
@@ -1,5 +1,9 @@
 using System.Linq;
 using Content.Server.Spawners.Components;
+// CMU14 Begin: bounded delivery preparation and fill diagnostics.
+using Content.Server.CMU14.Diagnostics.Performance;
+using Content.Server.Storage.Components;
+// CMU14 End
 using Content.Shared._RMC14.Prototypes;
 using Content.Shared._RMC14.Storage;
 using Content.Shared.Item;
@@ -13,6 +17,7 @@ namespace Content.Server.Storage.EntitySystems;
 
 public sealed partial class StorageSystem
 {
+    [Dependency] private ICMUServerPerformanceDiagnostics _cmuPerformance = default!; // CMU14
     private void OnStorageFillMapInit(EntityUid uid, StorageFillComponent component, MapInitEvent args)
     {
         if (component.Contents.Count == 0)
@@ -34,6 +39,7 @@ public sealed partial class StorageSystem
 
     private void FillStorage(Entity<StorageFillComponent?, StorageComponent?> entity)
     {
+        using var operation = _cmuPerformance.MeasureOperation("storage-fill", MetaData(entity.Owner).EntityPrototype?.ID); // CMU14
         var (uid, component, storage) = entity;
 
         if (!Resolve(uid, ref component, ref storage))
@@ -96,6 +102,7 @@ public sealed partial class StorageSystem
 
     private void FillEntityStorage(Entity<StorageFillComponent?, EntityStorageComponent?> entity)
     {
+        using var operation = _cmuPerformance.MeasureOperation("entity-storage-fill", MetaData(entity.Owner).EntityPrototype?.ID); // CMU14
         var (uid, component, entityStorageComp) = entity;
 
         if (!Resolve(uid, ref component, ref entityStorageComp))
@@ -104,6 +111,13 @@ public sealed partial class StorageSystem
         var coordinates = Transform(uid).Coordinates;
 
         var spawnItems = EntitySpawnCollection.GetSpawns(component.Contents, Random);
+        // CMU14 Begin: preserve the fill roll while spreading shipment spawns over ticks.
+        if (TryComp<DeferredEntityStorageFillComponent>(uid, out var deferred))
+        {
+            deferred.Prototypes.AddRange(spawnItems);
+            return;
+        }
+        // CMU14 End
         foreach (var item in spawnItems)
         {
             // No, you are not allowed to fill a container with entity spawners.

--- a/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
+++ b/Content.Server/_RMC14/Requisitions/RequisitionsSystem.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using Content.Server.Administration.Logs;
 using Content.Server.CMU14.Round;
+using Content.Server.CMU14.Diagnostics.Performance; // CMU14
 using Content.Server.Cargo.Components;
 using Content.Server.Cargo.Systems;
 using Content.Shared.CMU14.Requisitions;
@@ -46,6 +47,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Dynamics;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Profiling; // CMU14
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 using static Content.Shared._RMC14.Requisitions.Components.RequisitionsElevatorMode;
@@ -71,6 +73,10 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
     [Dependency] private XenoSystem _xeno = default!;
     [Dependency] private IPrototypeManager _prototypeManager = default!;
     [Dependency] private PricingSystem _pricing = default!;
+    // CMU14 Begin: attribute shipment preparation and publication separately.
+    [Dependency] private ProfManager _profiler = default!;
+    [Dependency] private ICMUServerPerformanceDiagnostics _performance = default!;
+    // CMU14 End
 
     private static readonly EntProtoId AccountId = "RMCASRSAccount";
     private static readonly EntProtoId PaperRequisitionInvoice = "RMCPaperRequisitionInvoice";
@@ -92,6 +98,7 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
 
         _chasmQuery = GetEntityQuery<ChasmComponent>();
         _chasmFallingQuery = GetEntityQuery<ChasmFallingComponent>();
+        SubscribeLocalEvent<RequisitionsDeliveryComponent, ComponentShutdown>(OnDeliveryShutdown); // CMU14
         SubscribeLocalEvent<ColonyAtmComponent, EntInsertedIntoContainerMessage>(OnMoneyInserted);
 
         SubscribeLocalEvent<RequisitionsComputerComponent, MapInitEvent>(OnComputerMapInit);
@@ -503,25 +510,25 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
             Dirty(elevator);
     }
 
+    // CMU14 method: publish cargo prepared during travel instead of spawning the shipment in one tick.
     private void SpawnOrders(Entity<RequisitionsElevatorComponent> elevator)
     {
+        using var profile = _profiler.Group("CMU Requisitions Publish");
+        using var operation = _performance.MeasureOperation("requisitions-publish");
         var comp = elevator.Comp;
         if (comp.Mode == Raised)
         {
+            var delivery = Comp<RequisitionsDeliveryComponent>(elevator);
             var coordinates = _transform.GetMoverCoordinates(elevator);
             var xOffset = comp.Radius;
             var yOffset = comp.Radius;
             int remainingDeliveries = GetElevatorCapacity(elevator);
-            foreach (var order in comp.Orders)
+            for (var orderIndex = 0; orderIndex < comp.Orders.Count; orderIndex++)
             {
-                var crate = SpawnAtPosition(order.Crate, coordinates.Offset(new Vector2(xOffset, yOffset)));
+                var order = comp.Orders[orderIndex];
+                var crate = delivery.Roots[orderIndex];
+                _transform.SetCoordinates(crate, coordinates.Offset(new Vector2(xOffset, yOffset)));
                 remainingDeliveries--;
-
-                foreach (var prototype in order.Entities)
-                {
-                    var entity = Spawn(prototype, MapCoordinates.Nullspace);
-                    _entityStorage.Insert(entity, crate);
-                }
 
                 // If this order came from a department console, attach a department note
                 // instead of the generic invoice so it shows on the crate label.
@@ -546,6 +553,8 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
             }
 
             comp.Orders.Clear();
+            delivery.Roots.Clear();
+            RemComp<RequisitionsDeliveryComponent>(elevator);
 
             var query = EntityQueryEnumerator<RequisitionsCustomDeliveryComponent>();
 
@@ -655,6 +664,7 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
     public override void Update(float frameTime)
     {
         base.Update(frameTime);
+        _deliverySteps = 0; // CMU14: share the preparation budget across elevators this update.
 
         var time = _timing.CurTime;
         var updateUI = false;
@@ -1014,6 +1024,13 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
         if (elevator.ToggledAt == null)
             return false;
 
+        // CMU14 Begin: prepare cargo while the lift is travelling. If a delayed update skipped the trip,
+        // keep the lift closed until the bounded preparation has finished.
+        bool deliveryReady = true;
+        if (elevator.Mode == Raising || elevator.Mode == Preparing && elevator.NextMode == Raising)
+            deliveryReady = PrepareDelivery(ent);
+        // CMU14 End
+
         TryPlayAudio(ent);
 
         var delay = elevator.NextMode == Raising ? elevator.RaiseDelay : elevator.LowerDelay;
@@ -1053,6 +1070,10 @@ public sealed partial class RequisitionsSystem : SharedRequisitionsSystem
 
         if (time > elevator.ToggledAt + moveDelay)
         {
+            // CMU14 Begin: keep the platform closed until its shipment is complete.
+            if (elevator.Mode == Raising && !deliveryReady)
+                return false;
+            // CMU14 End
             elevator.Audio = null;
 
             var mode = elevator.Mode switch

--- a/Content.Shared/CCVar/CCVars.CMU.PerformanceDiagnostics.cs
+++ b/Content.Shared/CCVar/CCVars.CMU.PerformanceDiagnostics.cs
@@ -58,6 +58,12 @@ public sealed partial class CCVars
     public static readonly CVarDef<float> CMUServerPerformanceStallMilliseconds =
         CVarDef.Create("cmu.server_performance.stall_ms", 250f, CVar.SERVERONLY | CVar.ARCHIVE);
 
+    // CMU14 Begin: capture short gameplay stalls independently of loading stalls.
+    /// <summary>Lower stall threshold during active gameplay. Zero uses the general stall threshold.</summary>
+    public static readonly CVarDef<float> CMUServerPerformanceGameplayStallMilliseconds =
+        CVarDef.Create("cmu.server_performance.gameplay_stall_ms", 50f, CVar.SERVERONLY | CVar.ARCHIVE);
+    // CMU14 End
+
     /// <summary>
     ///     A single real frame at or above this duration is classified as critical.
     /// </summary>
@@ -153,7 +159,7 @@ public sealed partial class CCVars
     ///     Maximum profiler events parsed for one detailed incident report.
     /// </summary>
     public static readonly CVarDef<int> CMUServerPerformanceProfileMaxEvents =
-        CVarDef.Create("cmu.server_performance.profile_max_events", 20000, CVar.SERVERONLY | CVar.ARCHIVE);
+        CVarDef.Create("cmu.server_performance.profile_max_events", 65536, CVar.SERVERONLY | CVar.ARCHIVE); // CMU14: cover the default profiler ring.
 
     /// <summary>
     ///     Maximum entries emitted per category in detailed performance reports.

--- a/Content.Shared/DoAfter/SharedDoAfterSystem.cs
+++ b/Content.Shared/DoAfter/SharedDoAfterSystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Movement.Systems;
 using Content.Shared.Tag;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Profiling; // CMU14
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
 using Robust.Shared.Utility;
@@ -23,6 +24,10 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     [Dependency] private SharedTransformSystem _transform = default!;
     [Dependency] private SharedMoverController _mover = default!;
     [Dependency] private TagSystem _tag = default!;
+    // CMU14 Begin: cached timed-action profiler names.
+    [Dependency] private ProfManager _profiler = default!;
+    private readonly Dictionary<Type, string> _completionProfileNames = new();
+    // CMU14 End
 
     /// <summary>
     ///     We'll use an excess time so stuff like finishing effects can show.
@@ -105,6 +110,15 @@ public abstract partial class SharedDoAfterSystem : EntitySystem
     private void RaiseDoAfterEvents(DoAfter doAfter, DoAfterComponent component)
     {
         var ev = doAfter.Args.Event;
+        // CMU14 Begin: attribute expensive callbacks, including awaited continuations, to their timed action.
+        var eventType = ev.GetType();
+        if (!_completionProfileNames.TryGetValue(eventType, out var profileName))
+        {
+            profileName = $"CMU DoAfter {eventType.Name}";
+            _completionProfileNames.Add(eventType, profileName);
+        }
+        using var profile = _profiler.Group(profileName);
+        // CMU14 End
         ev.Handled = false;
         ev.Repeat = false;
         ev.DoAfter = doAfter;

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -1429,22 +1429,31 @@ public abstract partial class SharedStorageSystem : EntitySystem
             }
         }
 
+        // CMU14 Begin: compute storage occupancy and rotated shapes once per search, rather
+        // than rebuilding every stored item's shape for every candidate cell.
+        var occupied = BuildPlacementOccupancy((storageEnt.Owner, storageEnt.Comp), itemEnt.Owner);
+        var rotations = new List<(Angle Rotation, IReadOnlyList<Box2i> Shape)>();
+        for (var angle = startAngle; angle <= Angle.FromDegrees(360 - startAngle); angle += Math.PI / 2f)
+        {
+            rotations.Add((angle, ItemSystem.GetAdjustedItemShape(storageEnt, itemEnt, angle, Vector2i.Zero)));
+        }
+
         for (var y = storageBounding.Bottom; y <= storageBounding.Top; y++)
         {
             for (var x = storageBounding.Left; x <= storageBounding.Right; x++)
             {
-                for (var angle = startAngle; angle <= Angle.FromDegrees(360 - startAngle); angle += Math.PI / 2f)
+                foreach (var (angle, shape) in rotations)
                 {
-                    var location = new ItemStorageLocation(angle, (x, y));
-                    if (ItemFitsInGridLocation(itemEnt, storageEnt, location))
+                    if (FitsPlacementOccupancy(occupied, shape, (x, y)))
                     {
-                        storageLocation = location;
+                        storageLocation = new ItemStorageLocation(angle, (x, y));
                         return true;
                     }
                 }
             }
         }
 
+        // CMU14 End
         return false;
     }
 
@@ -1522,37 +1531,13 @@ public abstract partial class SharedStorageSystem : EntitySystem
     /// <summary>
     /// Checks if an item fits into a specific spot on a storage grid.
     /// </summary>
+    // CMU14 method: use the shared occupancy check for stored locations.
     public bool ItemFitsInGridLocation(
         Entity<ItemComponent?> itemEnt,
         Entity<StorageComponent?> storageEnt,
         ItemStorageLocation location)
     {
-        if (!Resolve(itemEnt, ref itemEnt.Comp) || !Resolve(storageEnt, ref storageEnt.Comp))
-            return false;
-
-        var position = location.Position;
-        var rotation = location.Rotation;
-        var gridBounds = storageEnt.Comp.Grid.GetBoundingBox();
-        if (!gridBounds.Contains(position))
-            return false;
-
-        var itemShape = ItemSystem.GetAdjustedItemShape(storageEnt, itemEnt, rotation, position);
-
-        foreach (var box in itemShape)
-        {
-            for (var offsetY = box.Bottom; offsetY <= box.Top; offsetY++)
-            {
-                for (var offsetX = box.Left; offsetX <= box.Right; offsetX++)
-                {
-                    var pos = (offsetX, offsetY);
-
-                    if (!IsGridSpaceEmpty(itemEnt, storageEnt, pos))
-                        return false;
-                }
-            }
-        }
-
-        return true;
+        return ItemFitsInGridLocation(itemEnt, storageEnt, location.Position, location.Rotation);
     }
 
     // private bool ItemFitsInGridLocation(
@@ -1611,6 +1596,7 @@ public abstract partial class SharedStorageSystem : EntitySystem
     /// <summary>
     /// Checks if an item fits into a specific spot on a storage grid.
     /// </summary>
+    // CMU14 method: build occupancy once instead of recomputing item shapes for each occupied cell.
     public bool ItemFitsInGridLocation(
         Entity<ItemComponent?> itemEnt,
         Entity<StorageComponent?> storageEnt,
@@ -1625,22 +1611,8 @@ public abstract partial class SharedStorageSystem : EntitySystem
             return false;
 
         var itemShape = ItemSystem.GetAdjustedItemShape(storageEnt, itemEnt, rotation, position);
-
-        foreach (var box in itemShape)
-        {
-            for (var offsetY = box.Bottom; offsetY <= box.Top; offsetY++)
-            {
-                for (var offsetX = box.Left; offsetX <= box.Right; offsetX++)
-                {
-                    var pos = (offsetX, offsetY);
-
-                    if (!IsGridSpaceEmpty(itemEnt, storageEnt, pos))
-                        return false;
-                }
-            }
-        }
-
-        return true;
+        var occupied = BuildPlacementOccupancy((storageEnt.Owner, storageEnt.Comp), itemEnt.Owner);
+        return FitsPlacementOccupancy(occupied, itemShape, Vector2i.Zero);
     }
 
     /// <summary>
@@ -1780,7 +1752,9 @@ public abstract partial class SharedStorageSystem : EntitySystem
         }
     }
 
-    private void AddOccupied(IReadOnlyList<Box2i> adjustedShape, Dictionary<Vector2i, ulong> occupied)
+    // CMU14 method: optionally constrain occupancy to the storage grid's existing chunks.
+    private void AddOccupied(IReadOnlyList<Box2i> adjustedShape, Dictionary<Vector2i, ulong> occupied,
+        bool onlyExistingChunks = false)
     {
         foreach (var box in adjustedShape)
         {
@@ -1792,7 +1766,8 @@ public abstract partial class SharedStorageSystem : EntitySystem
             while (chunkEnumerator.MoveNext(out var chunk))
             {
                 var chunkOrigin = chunk.Value * StorageComponent.ChunkSize;
-                var existing = occupied.GetOrNew(chunkOrigin);
+                if (!occupied.TryGetValue(chunkOrigin, out var existing) && onlyExistingChunks)
+                    continue;
 
                 // Box may not necessarily be in 1 chunk so clamp it.
                 var left = Math.Max(chunkOrigin.X, box.Left);

--- a/Content.Tests/Server/_CMU14/Diagnostics/Performance/CMUPerformanceSpikeCaptureTest.cs
+++ b/Content.Tests/Server/_CMU14/Diagnostics/Performance/CMUPerformanceSpikeCaptureTest.cs
@@ -1,0 +1,42 @@
+using System;
+using Content.Server.CMU14.Diagnostics.Performance;
+using NUnit.Framework;
+
+namespace Content.Tests.Server.CMU14.Diagnostics.Performance;
+
+[TestFixture]
+public sealed class CMUPerformanceSpikeCaptureTest
+{
+    private const double AllocationThreshold = 32 * 1024 * 1024;
+
+    [TestCase(155.07, 98348432)]
+    [TestCase(218.75, 102509384)]
+    public void LoggedGameplaySpikesAreCapturedIndependentlyOfIncidentAge(double ms, long bytes)
+    {
+        var gate = new CMUPerformanceSpikeCapture();
+        Assert.That(gate.ShouldCapture(TimeSpan.FromSeconds(73), ms, bytes, 50, AllocationThreshold), Is.True);
+        gate.Record(TimeSpan.FromSeconds(73), ms, bytes);
+        Assert.That(gate.ShouldCapture(TimeSpan.FromSeconds(74), ms, bytes, 50, AllocationThreshold), Is.False);
+        Assert.That(gate.ShouldCapture(TimeSpan.FromSeconds(83), ms, bytes, 50, AllocationThreshold), Is.True);
+    }
+
+    [Test]
+    public void WorseSpikeBypassesCooldownButReportsCannotRecurseImmediately()
+    {
+        var gate = new CMUPerformanceSpikeCapture();
+        gate.Record(TimeSpan.Zero, 50, 1024);
+        Assert.That(gate.ShouldCapture(TimeSpan.FromMilliseconds(500), 219, 100000000, 50, AllocationThreshold), Is.False);
+        Assert.That(gate.ShouldCapture(TimeSpan.FromSeconds(1), 219, 100000000, 50, AllocationThreshold), Is.True);
+        Assert.That(gate.ShouldCapture(TimeSpan.FromSeconds(11), 10, 1024, 50, AllocationThreshold), Is.False);
+    }
+
+    [Test]
+    public void AllocationSpikeDoesNotRequireMatchingFrameTiming()
+    {
+        var gate = new CMUPerformanceSpikeCapture();
+        Assert.That(gate.ShouldCapture(TimeSpan.Zero, 1, 100000000, 50, AllocationThreshold), Is.True);
+        gate.Record(TimeSpan.Zero, 1, 100000000);
+        gate.Clear();
+        Assert.That(gate.ShouldCapture(TimeSpan.Zero, 155, 100000000, 50, AllocationThreshold), Is.True);
+    }
+}


### PR DESCRIPTION
## About the PR

Reduce gameplay hitches caused by storage placement and bulk requisitions spawning, and capture short gameplay stalls that previously fell below the general threshold or behind an existing incident's detail cooldown.

## Why / Balance

Player equipment fills repeatedly rebuilt storage item shapes for every candidate cell. Large supply orders also spawned their entire contents in one update. These changes reduce allocation churn and spread shipment preparation across updates while preserving the delivered contents.

## Technical details

- Build a transient storage occupancy mask and rotated item shapes once per placement search, preserving grid holes, negative coordinates, saved placement fallback, fixed item sizes, and overlapping-item checks.
- Prepare requisitions cargo off-map during elevator travel, with a shared four-step / 2 ms budget checked between spawns. Defer legacy crate fills, publish completed cargo, and clean up unfinished cargo when the elevator is removed.
- Capture gameplay frames at 50 ms after the first 30 round seconds. Give new stalls/allocation spikes a bounded capture allowance independent of the normal incident cooldown.
- Add per-frame profiler rankings, recent spawn/storage/requisitions operation records, timed-action completion scopes, and process-wide GC pause windows. Retry unfinished input frames and increase the default event parse budget to 65,536.
- Keep new helper files in Content.CMU; no engine/submodule changes.

## Test plan

Validation passed on this PR's current-master checkout: Release builds of Shared, Client, Server and the test projects; 18 focused integration/sandbox tests; and 14 diagnostics unit tests (32 total).

```powershell
dotnet test Content.IntegrationTests/Content.IntegrationTests.csproj -c Release --filter 'FullyQualifiedName~ASRSDeliveryBudgetTest|FullyQualifiedName~ASRSOrderDeliveryRegressionTest|FullyQualifiedName~ServerProfilerCaptureTest|FullyQualifiedName~StoragePlacementAllocationTest|FullyQualifiedName~Tests.Utility.SandboxTest'
dotnet test Content.Tests/Content.Tests.csproj --no-build --no-restore -c Release --filter 'FullyQualifiedName~CMUPerformanceSpikeCaptureTest|FullyQualifiedName~CMUPerformanceProfilerSelectionTest|FullyQualifiedName~CMUPerformancePhaseTrackerTest|FullyQualifiedName~CMUPerformanceIncidentDetectorTest'
```

Focused fixtures cover storage placement and area pickup, legacy/itemized deliveries and cancellation cleanup, profiler history loss and frame attribution, and capture gating for the logged 155 ms and 219 ms stalls.

Controlled measurements: placement-search allocation fell 99.3%; warm physician spawn median fell from 112.7 ms to 54.8 ms. Seven warm 40-pack deliveries had a maximum individual update below 24 ms. A cold delivery still reached 104 ms: the budget cannot interrupt an individual spawn or GC pause, and historical unattributed stalls are not claimed eliminated.

For runtime verification, spawn equipped players, perform bulk storage pickup, deliver a large flare order, and correlate `stall`, `profile-frame-sample`, `operation`, and `runtime-window` rows in the server log.

## Media

No visual changes requiring a showcase.

## Requirements

- [x] I have read the contributing guidelines.
- [x] Tests cover behavior that can break, with reproduction instructions above.
- [x] Changes outside CMU zones carry CMU14 markers; new files are in CMU zones.
- [x] No in-game media is required.
- [x] Changelog entries are included below.

## Breaking changes

No gameplay protocol changes. Existing saved diagnostic CVar values remain authoritative; the new `cmu.server_performance.gameplay_stall_ms` defaults to 50, and the default `profile_max_events` increases to 65,536.

## Changelog

:cl:
- fix: Reduced hitches when filling storage and preparing large supply deliveries.
- admin: Improved capture and attribution of short gameplay stalls.
