### PR TITLE
Revert localization changes in admin commands

### DIFF
--- a/Content.CMU/Server/Util/Admin/Console/NukeLightCommand.cs
+++ b/Content.CMU/Server/Util/Admin/Console/NukeLightCommand.cs
@@ -25,8 +25,9 @@ public sealed partial class NukeLightCommand : LocalizedEntityCommands
     private static readonly Color DefaultColor = Color.Orange;
 
     public override string Command => "nuke:lights";
-    public override string Description => Loc.GetString("cmu-cmd-nuke-lights-desc");
-    public override string Help => Loc.GetString("cmu-cmd-nuke-lights-help");
+    public override string Description => "Deletes lights in a radius around you, use 'help nuke:lights' for more info.";
+    public override string Help =>
+        "Usage: nuke:lights [radius=80] [energy=80] [duration=4] [x y mapId] [color=Orange]";
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
     {
@@ -41,16 +42,16 @@ public sealed partial class NukeLightCommand : LocalizedEntityCommands
         var duration = DefaultDuration;
         var color = DefaultColor;
 
-        if (!TryParseFloat(shell, args, 0, Loc.GetString("cmu-cmd-nuke-lights-hint-radius"), ref radius) ||
-            !TryParseFloat(shell, args, 1, Loc.GetString("cmu-cmd-nuke-lights-hint-energy"), ref energy) ||
-            !TryParseFloat(shell, args, 2, Loc.GetString("cmu-cmd-nuke-lights-hint-duration"), ref duration))
+        if (!TryParseFloat(shell, args, 0, "radius", ref radius) ||
+            !TryParseFloat(shell, args, 1, "energy", ref energy) ||
+            !TryParseFloat(shell, args, 2, "duration", ref duration))
         {
             return;
         }
 
         if (radius <= 0f || energy <= 0f || duration <= 0f)
         {
-            shell.WriteError(Loc.GetString("cmu-cmd-nuke-lights-positive"));
+            shell.WriteError("Radius, energy, and duration must be greater than zero.");
             return;
         }
 
@@ -67,19 +68,19 @@ public sealed partial class NukeLightCommand : LocalizedEntityCommands
         }
         else
         {
-            shell.WriteError(Loc.GetString("cmu-cmd-nuke-lights-no-attached"));
+            shell.WriteError("No attached entity. Provide x y mapId explicitly.");
             return;
         }
 
         if (args.Length == 7 && !Color.TryParse(args[6], out color))
         {
-            shell.WriteError(Loc.GetString("cmu-cmd-nuke-lights-color-error", ("color", args[6])));
+            shell.WriteError($"Failed to parse color '{args[6]}'. Use a name like Orange or a hex value like #ff8a00.");
             return;
         }
 
         if (!_map.MapExists(coords.MapId))
         {
-            shell.WriteError(Loc.GetString("cmu-cmd-nuke-lights-map-missing", ("mapId", coords.MapId)));
+            shell.WriteError($"Map {coords.MapId} does not exist.");
             return;
         }
 
@@ -95,24 +96,20 @@ public sealed partial class NukeLightCommand : LocalizedEntityCommands
 
         _pvs.AddGlobalOverride(uid);
 
-        shell.WriteLine(Loc.GetString("cmu-cmd-nuke-lights-spawned",
-            ("uid", uid),
-            ("position", coords.Position),
-            ("mapId", coords.MapId),
-            ("duration", duration.ToString("0.###", CultureInfo.InvariantCulture))));
+        shell.WriteLine($"Spawned global nuke light {uid} at {coords.Position} on map {coords.MapId} for {duration:0.###}s.");
     }
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
         return args.Length switch
         {
-            1 => CompletionResult.FromHint(Loc.GetString("cmu-cmd-nuke-lights-hint-radius")),
-            2 => CompletionResult.FromHint(Loc.GetString("cmu-cmd-nuke-lights-hint-energy")),
-            3 => CompletionResult.FromHint(Loc.GetString("cmu-cmd-nuke-lights-hint-duration")),
-            4 => CompletionResult.FromHint(Loc.GetString("cmu-cmd-nuke-lights-hint-x")),
-            5 => CompletionResult.FromHint(Loc.GetString("cmu-cmd-nuke-lights-hint-y")),
-            6 => CompletionResult.FromHint(Loc.GetString("cmu-cmd-nuke-lights-hint-map-id")),
-            7 => CompletionResult.FromHint(Loc.GetString("cmu-cmd-nuke-lights-hint-color")),
+            1 => CompletionResult.FromHint("radius"),
+            2 => CompletionResult.FromHint("energy"),
+            3 => CompletionResult.FromHint("duration"),
+            4 => CompletionResult.FromHint("x"),
+            5 => CompletionResult.FromHint("y"),
+            6 => CompletionResult.FromHint("mapId"),
+            7 => CompletionResult.FromHint("color"),
             _ => CompletionResult.Empty
         };
     }
@@ -125,7 +122,7 @@ public sealed partial class NukeLightCommand : LocalizedEntityCommands
         if (float.TryParse(args[index], NumberStyles.Float, CultureInfo.InvariantCulture, out value))
             return true;
 
-        shell.WriteError(Loc.GetString("cmu-cmd-nuke-lights-parse-value", ("name", name), ("value", args[index])));
+        shell.WriteError($"Failed to parse {name} '{args[index]}'.");
         return false;
     }
 
@@ -136,13 +133,13 @@ public sealed partial class NukeLightCommand : LocalizedEntityCommands
         if (!float.TryParse(args[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var x) ||
             !float.TryParse(args[4], NumberStyles.Float, CultureInfo.InvariantCulture, out var y))
         {
-            shell.WriteError(Loc.GetString("cmu-cmd-nuke-lights-parse-coordinates", ("x", args[3]), ("y", args[4])));
+            shell.WriteError($"Failed to parse coordinates '{args[3]}' '{args[4]}'.");
             return false;
         }
 
         if (!int.TryParse(args[5], NumberStyles.Integer, CultureInfo.InvariantCulture, out var mapId))
         {
-            shell.WriteError(Loc.GetString("cmu-cmd-nuke-lights-parse-map-id", ("mapId", args[5])));
+            shell.WriteError($"Failed to parse map ID '{args[5]}'.");
             return false;
         }
 

--- a/Content.CMU/Server/ZLevels/Mapping/CMUInitializeZNetworkCommand.cs
+++ b/Content.CMU/Server/ZLevels/Mapping/CMUInitializeZNetworkCommand.cs
@@ -14,17 +14,18 @@ public sealed partial class CMUInitializeZNetworkCommand : LocalizedEntityComman
     [Dependency] private MapSystem _map = default!;
 
     public override string Command => "znetwork-initialize";
+    public override string Description => "Initialize all zNetwork maps. Warning! This will not add all components, that writed in gamemap prototype! So i think this command is useless, because all maps dont have lightning or even atmos :(";
 
     public override CompletionResult GetCompletion(IConsoleShell shell, string[] args)
     {
         var options = new List<CompletionOption>();
         var query = _entities.EntityQueryEnumerator<CMUZLevelsNetworkComponent, MetaDataComponent>();
-        while (query.MoveNext(out var uid, out _, out var meta))
+        while (query.MoveNext(out var uid, out var zLevelComp, out var meta))
         {
             options.Add(new CompletionOption(_entities.GetNetEntity(uid).ToString(), meta.EntityName));
         }
 
-        return CompletionResult.FromHintOptions(options, Loc.GetString("cmu-cmd-znetwork-entity-hint"));
+        return CompletionResult.FromHintOptions(options, "zNetwork net entity");
     }
 
     public override void Execute(IConsoleShell shell, string argStr, string[] args)
@@ -35,17 +36,19 @@ public sealed partial class CMUInitializeZNetworkCommand : LocalizedEntityComman
             return;
         }
 
+        // get the target
         EntityUid? target;
+
         if (!NetEntity.TryParse(args[0], out var targetNet) ||
             !_entities.TryGetEntity(targetNet, out target))
         {
-            shell.WriteError(Loc.GetString("cmu-cmd-znetwork-entity-missing", ("entity", args[0])));
+            shell.WriteError($"Unable to find entity {args[0]}");
             return;
         }
 
         if (!_entities.TryGetComponent<CMUZLevelsNetworkComponent>(target, out var levelComp))
         {
-            shell.WriteError(Loc.GetString("cmu-cmd-znetwork-component-missing", ("entity", args[0])));
+            shell.WriteError($"Target entity doesnt have CMUZLevelsNetworkComponent {args[0]}");
             return;
         }
 
@@ -53,28 +56,23 @@ public sealed partial class CMUInitializeZNetworkCommand : LocalizedEntityComman
         {
             if (!_entities.TryGetComponent<MapComponent>(mapUid, out var mapComp))
             {
-                shell.WriteError(Loc.GetString("cmu-cmd-znetwork-initialize-map-component-missing",
-                    ("map", mapUid.ToString())));
+                shell.WriteError($"Map entity {mapUid} doesnt have MapComponent.");
                 continue;
             }
 
             if (!_map.MapExists(mapComp.MapId))
             {
-                shell.WriteError(Loc.GetString("cmu-cmd-znetwork-initialize-map-missing",
-                    ("mapId", mapComp.MapId.ToString())));
+                shell.WriteError($"Map with ID {mapComp.MapId} does not exist.");
                 continue;
             }
 
             if (_map.IsInitialized(mapComp.MapId))
             {
-                shell.WriteLine(Loc.GetString("cmu-cmd-znetwork-initialize-already",
-                    ("mapId", mapComp.MapId.ToString())));
+                shell.WriteLine($"Map with ID {mapComp.MapId} is already initialized.");
                 continue;
             }
-
             _map.InitializeMap(mapComp.MapId);
-            shell.WriteLine(Loc.GetString("cmu-cmd-znetwork-initialize-success",
-                ("mapId", mapComp.MapId.ToString())));
+            shell.WriteLine($"Map with ID {mapComp.MapId} has been initialized.");
         }
     }
 }


### PR DESCRIPTION
Reverts the recent localization changes in:

- `Content.CMU/Server/Util/Admin/Console/NukeLightCommand.cs`
- `Content.CMU/Server/ZLevels/Mapping/CMUInitializeZNetworkCommand.cs`

The localized versions introduced compile errors involving `LocalizedCommands.Loc` usage from static methods and nullable localization arguments. This restores both files to their previous working implementations.